### PR TITLE
[FIX]: SSO icons margin

### DIFF
--- a/frontend/src/components/auth/LoginForm/styles.tsx
+++ b/frontend/src/components/auth/LoginForm/styles.tsx
@@ -31,7 +31,7 @@ const OrSeparator = styled('div', {
 	width: '100%',
 
 	mt: '$26',
-	mb: '$34',
+	mb: '$32',
 
 	hr: {
 		flexGrow: 1,


### PR DESCRIPTION
Fixes #245

## Screenshots (if visual changes)

![Screenshot 2022-06-23 at 11 46 21](https://user-images.githubusercontent.com/68588265/175281689-5974ad83-9d9d-4177-965b-e61d70f3d35b.png)

## Proposed Changes

  - Spacing between separator and sso icons

This pull request closes #245