### PR TITLE
fix: check user email or unique name in AD

### DIFF
--- a/backend/src/modules/azure/services/auth.azure.service.ts
+++ b/backend/src/modules/azure/services/auth.azure.service.ts
@@ -49,10 +49,13 @@ export default class AuthAzureServiceImpl implements AuthAzureService {
     const lastName =
       family_name ?? splitedName[splitedName.length - 1] ?? 'last';
 
-    const userExists = await this.checkUserExistsInActiveDirectory(email);
+    const emailOrUniqueName = email ?? unique_name;
+
+    const userExists = await this.checkUserExistsInActiveDirectory(
+      emailOrUniqueName,
+    );
     if (!userExists) return null;
 
-    const emailOrUniqueName = email ?? unique_name;
     const user = await this.getUserService.getByEmail(emailOrUniqueName);
     if (user) return signIn(user, this.getTokenService, 'azure');
 


### PR DESCRIPTION
<!--
#265 
-->

Fixes #265 

## Proposed Changes

  - Send the unique name or the email to check if the user exists in ad

<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #265