### PR TITLE
[FIX]: Create Board: Slack checkbox uncheck when change between tabs

### DIFF
--- a/frontend/src/components/CreateBoard/SubTeamsTab/MainBoardCard.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/MainBoardCard.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { SetterOrUpdater, useRecoilValue } from 'recoil';
+import { SetterOrUpdater, useRecoilState, useRecoilValue } from 'recoil';
 
 import { styled } from 'styles/stitches/stitches.config';
 
@@ -12,7 +12,11 @@ import Separator from 'components/Primitives/Separator';
 import Text from 'components/Primitives/Text';
 import Tooltip from 'components/Primitives/Tooltip';
 import useCreateBoard from 'hooks/useCreateBoard';
-import { CreateBoardData, createBoardError } from 'store/createBoard/atoms/create-board.atom';
+import {
+	CreateBoardData,
+	createBoardError,
+	slackGroup
+} from 'store/createBoard/atoms/create-board.atom';
 import { BoardToAdd } from 'types/board/board';
 import { Team } from 'types/team/team';
 import { BoardUserRoles } from 'utils/enums/board.user.roles';
@@ -56,6 +60,7 @@ const MainBoardCard = React.memo(({ team, stakeholders }: MainBoardCardInterface
 	/**
 	 * Recoil Atoms
 	 */
+	const [createSlackGroup, setCreateSlackGroup] = useRecoilState(slackGroup);
 	const haveError = useRecoilValue(createBoardError);
 
 	const {
@@ -194,7 +199,14 @@ const MainBoardCard = React.memo(({ team, stakeholders }: MainBoardCardInterface
 				</Flex>
 			</MainContainer>
 			<SubBoardList dividedBoards={board.dividedBoards} setBoard={setCreateBoardData} />
-			<Checkbox id="slack" label="Create Slack group for each sub-team" size="16" />
+			<Box onClick={() => setCreateSlackGroup(!createSlackGroup)}>
+				<Checkbox
+					checked={createSlackGroup}
+					id="slack"
+					label="Create Slack group for each sub-team"
+					size="16"
+				/>
+			</Box>
 		</Flex>
 	);
 });

--- a/frontend/src/store/createBoard/atoms/create-board.atom.tsx
+++ b/frontend/src/store/createBoard/atoms/create-board.atom.tsx
@@ -14,6 +14,11 @@ export const createBoardState = atom({
 	default: false
 });
 
+export const slackGroup = atom({
+	key: 'slackGroup',
+	default: false
+});
+
 export interface CreateBoardData {
 	count: {
 		teamsCount: number;


### PR DESCRIPTION
Fixes #283

## Proposed Changes

  - Add and atom state to manage the checkbox state
  - Wrap the checkbox in event click to be in sync with the atom state
  

This pull request closes #283