### PR TITLE
[FIX]: Avatar color

### DIFF
--- a/frontend/src/components/Board/Card/CardFooter.tsx
+++ b/frontend/src/components/Board/Card/CardFooter.tsx
@@ -13,7 +13,6 @@ import { BoardUser } from 'types/board/board.user';
 import CardType from 'types/card/card';
 import { CardItemType } from 'types/card/cardItem';
 import CommentType from 'types/comment/comment';
-import useAvatarColor from '../../../hooks/useAvatarColor';
 
 interface FooterProps {
 	boardId: string;
@@ -121,19 +120,16 @@ const CardFooter = React.memo<FooterProps>(
 			});
 		};
 
-		const GetAvatarColor = (id: string | undefined) => {
-			return useAvatarColor(id, id === userId);
-		};
-
 		return (
 			<Flex align="center" justify={!anonymous ? 'between' : 'end'} gap="6">
 				{!anonymous && !teamName && (
 					<Flex gap="4" align="center">
 						<Avatar
 							size={20}
-							colors={GetAvatarColor(createdBy?._id)}
 							fallbackText={`${createdBy?.firstName[0]}${createdBy?.lastName[0]}`}
 							isBoardPage
+							id={createdBy?._id}
+							isDefaultColor={createdBy?._id === userId}
 						/>
 						<Text size="xs">
 							{createdBy?.firstName} {createdBy?.lastName}

--- a/frontend/src/components/Board/Card/CardFooter.tsx
+++ b/frontend/src/components/Board/Card/CardFooter.tsx
@@ -13,7 +13,7 @@ import { BoardUser } from 'types/board/board.user';
 import CardType from 'types/card/card';
 import { CardItemType } from 'types/card/cardItem';
 import CommentType from 'types/comment/comment';
-import { getRandomColor } from 'utils/initialNames';
+import useAvatarColor from '../../../hooks/useAvatarColor';
 
 interface FooterProps {
 	boardId: string;
@@ -121,9 +121,9 @@ const CardFooter = React.memo<FooterProps>(
 			});
 		};
 
-		const color = useMemo(() => {
-			return getRandomColor();
-		}, []);
+		const GetAvatarColor = (id: string | undefined) => {
+			return useAvatarColor(id, id === userId);
+		};
 
 		return (
 			<Flex align="center" justify={!anonymous ? 'between' : 'end'} gap="6">
@@ -131,7 +131,7 @@ const CardFooter = React.memo<FooterProps>(
 					<Flex gap="4" align="center">
 						<Avatar
 							size={20}
-							colors={color}
+							colors={GetAvatarColor(createdBy?._id)}
 							fallbackText={`${createdBy?.firstName[0]}${createdBy?.lastName[0]}`}
 							isBoardPage
 						/>

--- a/frontend/src/components/CardBoard/CardAvatars.tsx
+++ b/frontend/src/components/CardBoard/CardAvatars.tsx
@@ -72,8 +72,10 @@ const CardAvatars = React.memo<CardAvatarProps>(
 			[]
 		);
 
-		const GetAvatarColor = (value: User | string) =>
-			useAvatarColor(typeof value === 'string' ? value : value._id);
+		const GetAvatarColor = (value: User | string) => {
+			const id = typeof value === 'string' ? value : value._id;
+			return useAvatarColor(id, id === userId);
+		};
 
 		const renderAvatar = useCallback((value: User | string, avatarColor, idx) => {
 			if (typeof value === 'string') {

--- a/frontend/src/components/CardBoard/CardAvatars.tsx
+++ b/frontend/src/components/CardBoard/CardAvatars.tsx
@@ -6,7 +6,6 @@ import Tooltip from 'components/Primitives/Tooltip';
 import { User } from 'types/user/user';
 import { BoardUserRoles } from 'utils/enums/board.user.roles';
 import { TeamUserRoles } from 'utils/enums/team.user.roles';
-import useAvatarColor from '../../hooks/useAvatarColor';
 
 type ListUsersType = {
 	user: User | string;
@@ -72,58 +71,62 @@ const CardAvatars = React.memo<CardAvatarProps>(
 			[]
 		);
 
-		const GetAvatarColor = (value: User | string) => {
-			const id = typeof value === 'string' ? value : value._id;
-			return useAvatarColor(id, id === userId);
-		};
-
-		const renderAvatar = useCallback((value: User | string, avatarColor, idx) => {
-			if (typeof value === 'string') {
-				return (
-					<Avatar
-						key={`${value}-${idx}-${Math.random()}`}
-						css={{ position: 'relative', ml: idx > 0 ? '-7px' : 0 }}
-						size={32}
-						colors={avatarColor}
-						fallbackText={value}
-					/>
-				);
-			}
-			const initials = `${value.firstName[0]}${value.lastName[0]}`;
-			return (
-				<Tooltip
-					key={`${value}-${idx}-${Math.random()}`}
-					content={`${value.firstName} ${value.lastName}`}
-				>
-					<div>
+		const renderAvatar = useCallback(
+			(value: User | string, avatarColor, idx) => {
+				if (typeof value === 'string') {
+					return (
 						<Avatar
+							key={`${value}-${idx}-${Math.random()}`}
 							css={{ position: 'relative', ml: idx > 0 ? '-7px' : 0 }}
-							size={32}
 							colors={avatarColor}
-							fallbackText={initials}
+							size={32}
+							fallbackText={value}
+							id={value}
+							isDefaultColor={value === userId}
 						/>
-					</div>
-				</Tooltip>
-			);
-		}, []);
+					);
+				}
+				const initials = `${value.firstName[0]}${value.lastName[0]}`;
+				return (
+					<Tooltip
+						key={`${value}-${idx}-${Math.random()}`}
+						content={`${value.firstName} ${value.lastName}`}
+					>
+						<div>
+							<Avatar
+								key={`${value}-${idx}-${Math.random()}`}
+								css={{ position: 'relative', ml: idx > 0 ? '-7px' : 0 }}
+								colors={avatarColor}
+								size={32}
+								fallbackText={initials}
+								id={value._id}
+								isDefaultColor={value._id === userId}
+							/>
+						</div>
+					</Tooltip>
+				);
+			},
+			[userId]
+		);
 
 		return (
 			<Flex align="center" css={{ height: 'fit-content', overflow: 'hidden' }}>
 				{haveError
-					? ['-', '-', '-'].map((value, index) =>
-							renderAvatar(
+					? ['-', '-', '-'].map((value, index) => {
+							return renderAvatar(
 								value,
-								stakeholders ? stakeholdersColors : GetAvatarColor(value),
+								stakeholders ? stakeholdersColors : undefined,
 								index
-							)
-					  )
+							);
+					  })
 					: (data.slice(0, !myBoards ? 3 : 1) as User[]).map(
-							(user: User, index: number) =>
-								renderAvatar(
+							(user: User, index: number) => {
+								return renderAvatar(
 									getInitials(user, index),
-									stakeholders ? stakeholdersColors : GetAvatarColor(user),
+									stakeholders ? stakeholdersColors : undefined,
 									index
-								)
+								);
+							}
 					  )}
 			</Flex>
 		);

--- a/frontend/src/components/Primitives/Avatar.tsx
+++ b/frontend/src/components/Primitives/Avatar.tsx
@@ -2,6 +2,7 @@ import * as AvatarPrimitive from '@radix-ui/react-avatar';
 
 import { styled } from 'styles/stitches/stitches.config';
 
+import useAvatarColor from 'hooks/useAvatarColor';
 import Flex from './Flex';
 
 const AvatarRoot = styled(AvatarPrimitive.Root, Flex, {
@@ -32,11 +33,25 @@ type AvatarType = {
 	src?: string;
 	size?: number;
 	isBoardPage?: boolean;
+	id?: string;
+	isDefaultColor: boolean;
 };
 
 type AvatarProps = AvatarType & React.ComponentProps<typeof AvatarRoot>;
 
-const Avatar: React.FC<AvatarProps> = ({ src, size, colors, fallbackText, css, isBoardPage }) => {
+const Avatar: React.FC<AvatarProps> = ({
+	src,
+	size,
+	colors,
+	fallbackText,
+	css,
+	isBoardPage,
+	id,
+	isDefaultColor
+}) => {
+	const avatarColor = useAvatarColor(id, isDefaultColor);
+	if (colors === undefined) colors = avatarColor;
+
 	return (
 		<AvatarRoot
 			css={{

--- a/frontend/src/components/Primitives/Avatar.tsx
+++ b/frontend/src/components/Primitives/Avatar.tsx
@@ -41,8 +41,8 @@ const Avatar: React.FC<AvatarProps> = ({ src, size, colors, fallbackText, css, i
 		<AvatarRoot
 			css={{
 				size,
-				backgroundColor: colors.bg,
-				border: colors.border ? '1px solid $primary200' : undefined,
+				backgroundColor: colors?.bg,
+				border: colors?.border ? '1px solid $primary200' : undefined,
 				...css,
 				filter: 'drop-shadow(0px 1px 4px rgba(18, 25, 34, 0.05))'
 			}}
@@ -54,7 +54,7 @@ const Avatar: React.FC<AvatarProps> = ({ src, size, colors, fallbackText, css, i
 					lineHeight: !isBoardPage ? '$16' : '$12',
 					fontWeight: !isBoardPage ? '$medium' : '$regular',
 					fontFamily: 'DM Sans',
-					color: colors.fontColor,
+					color: colors?.fontColor,
 					'& span': ''
 				}}
 			>

--- a/frontend/src/hooks/useAvatarColor.tsx
+++ b/frontend/src/hooks/useAvatarColor.tsx
@@ -7,8 +7,13 @@ type AvatarColor = {
 	fontColor: string;
 };
 
-const useAvatarColor = (userId: string): AvatarColor => {
+const useAvatarColor = (userId: string, isDefaultColor: boolean): AvatarColor => {
 	const [color, setColor] = useState<AvatarColor | undefined>(undefined);
+
+	// The userIcon sprite is filled with #F3FD58 color that correspond to secondaryBase
+	const getDefaultColor = useCallback(() => {
+		return { bg: `$secondaryBase`, fontColor: `$secondaryDarkest` };
+	}, []);
 
 	const getRandomColor = useCallback(() => {
 		const keys = Object.keys(bubbleColors);
@@ -27,11 +32,11 @@ const useAvatarColor = (userId: string): AvatarColor => {
 				fontColor: user.fontColor
 			});
 		} else {
-			const newColor = getRandomColor();
+			const newColor = isDefaultColor ? getDefaultColor : getRandomColor();
 			localStorage.setItem(localStorageKey, JSON.stringify(newColor));
 			setColor(newColor);
 		}
-	}, [userId, getRandomColor]);
+	}, [userId, isDefaultColor, getRandomColor, getDefaultColor]);
 
 	return color as AvatarColor;
 };

--- a/frontend/src/hooks/useAvatarColor.tsx
+++ b/frontend/src/hooks/useAvatarColor.tsx
@@ -1,13 +1,13 @@
 import { useCallback, useEffect, useState } from 'react';
 
-import { bubbleColors } from 'styles/stitches/partials/colors/bubble.colors';
+import { getRandomColor } from 'utils/initialNames';
 
 type AvatarColor = {
 	bg: string;
 	fontColor: string;
 };
 
-const useAvatarColor = (userId: string, isDefaultColor: boolean): AvatarColor => {
+const useAvatarColor = (userId: string | undefined, isDefaultColor: boolean): AvatarColor => {
 	const [color, setColor] = useState<AvatarColor | undefined>(undefined);
 
 	// The userIcon sprite is filled with #F3FD58 color that correspond to secondaryBase
@@ -15,17 +15,11 @@ const useAvatarColor = (userId: string, isDefaultColor: boolean): AvatarColor =>
 		return { bg: `$secondaryBase`, fontColor: `$secondaryDarkest` };
 	}, []);
 
-	const getRandomColor = useCallback(() => {
-		const keys = Object.keys(bubbleColors);
-		const value = Math.floor(Math.random() * keys.length);
-		return { bg: `$${keys[value]}`, fontColor: `$${bubbleColors[keys[value]]}` };
-	}, []);
-
 	useEffect(() => {
 		const localStorageKey = `user_color_${userId}`;
 		const userStorage = localStorage.getItem(localStorageKey);
 
-		if (userStorage) {
+		if (userStorage !== null && userStorage !== 'undefined') {
 			const user = JSON.parse(userStorage);
 			setColor({
 				bg: user.bg,
@@ -36,7 +30,7 @@ const useAvatarColor = (userId: string, isDefaultColor: boolean): AvatarColor =>
 			localStorage.setItem(localStorageKey, JSON.stringify(newColor));
 			setColor(newColor);
 		}
-	}, [userId, isDefaultColor, getRandomColor, getDefaultColor]);
+	}, [userId, isDefaultColor, getDefaultColor]);
 
 	return color as AvatarColor;
 };

--- a/frontend/src/hooks/useAvatarColor.tsx
+++ b/frontend/src/hooks/useAvatarColor.tsx
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { bubbleColors } from 'styles/stitches/partials/colors/bubble.colors';
+
+type AvatarColor = {
+	bg: string;
+	fontColor: string;
+};
+
+const useAvatarColor = (userId: string): AvatarColor => {
+	const [color, setColor] = useState<AvatarColor | undefined>(undefined);
+
+	const getRandomColor = useCallback(() => {
+		const keys = Object.keys(bubbleColors);
+		const value = Math.floor(Math.random() * keys.length);
+		return { bg: `$${keys[value]}`, fontColor: `$${bubbleColors[keys[value]]}` };
+	}, []);
+
+	useEffect(() => {
+		const localStorageKey = `user_color_${userId}`;
+		const userStorage = localStorage.getItem(localStorageKey);
+
+		if (userStorage) {
+			const user = JSON.parse(userStorage);
+			setColor({
+				bg: user.bg,
+				fontColor: user.fontColor
+			});
+		} else {
+			const newColor = getRandomColor();
+			localStorage.setItem(localStorageKey, JSON.stringify(newColor));
+			setColor(newColor);
+		}
+	}, [userId, getRandomColor]);
+
+	return color as AvatarColor;
+};
+
+export default useAvatarColor;


### PR DESCRIPTION
Fixes #260 

## Screenshots (if visual changes)
- Dashboard page: First load
<img width="1003" alt="Screenshot 2022-06-29 at 10 27 37" src="https://user-images.githubusercontent.com/67462841/176402960-84eea649-edab-4d59-ae5f-e15c3a7b4fb5.png">

- Dashboard page: second load
<img width="1003" alt="Screenshot 2022-06-29 at 10 28 43" src="https://user-images.githubusercontent.com/67462841/176403043-fe3fad5a-c323-4833-8a67-c7c013859d50.png">

- Boards page: First load
<img width="1003" alt="Screenshot 2022-06-29 at 10 30 29" src="https://user-images.githubusercontent.com/67462841/176403485-f468809f-3415-43e6-bc03-16a8b44529f9.png">

- Boards page: Second load
<img width="1003" alt="Screenshot 2022-06-29 at 10 31 04" src="https://user-images.githubusercontent.com/67462841/176403530-91c193c3-a6a5-4b2d-bf12-b24c0836dda0.png">

Proposed Changes
  - Colors of each user are being saved to Local Storage
  - Show the same colors every time the page is loaded

This pull request closes #260 