### PR TITLE
[FIX]: Resize of the scrolling window in the boards page

### DIFF
--- a/frontend/src/components/Boards/MyBoards/styles.tsx
+++ b/frontend/src/components/Boards/MyBoards/styles.tsx
@@ -4,7 +4,7 @@ import Flex from 'components/Primitives/Flex';
 
 const ScrollableContent = styled(Flex, {
 	mt: '$24',
-	height: 'calc(100vh - 300px)',
+	height: 'calc(100vh - 200px)',
 	overflowY: 'auto',
 	pr: '$10',
 	pb: '$10'


### PR DESCRIPTION
Fixes #280

## Screenshots (

![Screenshot 2022-06-29 at 14 58 58](https://user-images.githubusercontent.com/107922758/176457007-9835e920-b49c-491e-9695-0c0a803b5a1f.png)

## Proposed Changes

  -Resize the  size of the scrolling window in the Boards Page

This pull request closes #280