### PR TITLE
[FIX]: Only show the board settings for the user that created the board

### DIFF
--- a/frontend/src/pages/boards/[boardId].tsx
+++ b/frontend/src/pages/boards/[boardId].tsx
@@ -71,6 +71,7 @@ const Board: React.FC<BoardProps> = ({ boardId, mainBoardId }) => {
 	});
 	const { data } = fetchBoard;
 	const board = data?.board;
+	const boardOwner = board?.createdBy === userId;
 
 	const [newBoard, setNewBoard] = useRecoilState(newBoardState);
 
@@ -241,7 +242,7 @@ const Board: React.FC<BoardProps> = ({ boardId, mainBoardId }) => {
 								/>
 							)}
 
-							{!board.submitedByUser && !board.submitedAt && (
+							{boardOwner && !board.submitedByUser && !board.submitedAt && (
 								<BoardSettings
 									isOpen={isOpen}
 									setIsOpen={setIsOpen}


### PR DESCRIPTION
Fixes #338 

## Screenshots (if visual changes)
![imagem](https://user-images.githubusercontent.com/104831678/179718835-c2312735-0ff6-49d4-bb91-6581dbea35cf.png)

![imagem](https://user-images.githubusercontent.com/104831678/179718868-628eb2ff-d5d1-439c-8c23-2ecaac4bd909.png)


## Proposed Changes
  - Only show the button if the user created the board


This pull request closes #338 