### PR TITLE
[BUG]: Lazy loading indicator in the dashboard

### DIFF
--- a/frontend/src/components/Dashboard/RecentRetros/ListOfCards.tsx
+++ b/frontend/src/components/Dashboard/RecentRetros/ListOfCards.tsx
@@ -4,7 +4,7 @@ import { InfiniteData, UseInfiniteQueryResult } from 'react-query';
 import { styled } from 'styles/stitches/stitches.config';
 
 import CardBody from 'components/CardBoard/CardBody/CardBody';
-import LoadingPage from 'components/loadings/LoadingPage';
+import { DotsLoading } from 'components/loadings/DotsLoading';
 import Flex from 'components/Primitives/Flex';
 import Text from 'components/Primitives/Text';
 import BoardType from 'types/board/board';
@@ -97,7 +97,11 @@ const ListOfCards = React.memo<ListOfCardsProp>(({ data, userId, fetchBoards, is
 				);
 			})}
 
-			{isLoading && <LoadingPage />}
+			{isLoading && (
+				<Flex justify="center">
+					<DotsLoading />
+				</Flex>
+			)}
 		</Flex>
 	);
 });

--- a/frontend/src/components/loadings/LoadingPage/styles.tsx
+++ b/frontend/src/components/loadings/LoadingPage/styles.tsx
@@ -8,6 +8,7 @@ const Overlay = styled('div', Flex, {
 	right: 0,
 	bottom: 0,
 	left: 0,
+	zIndex: 10,
 
 	width: '100%',
 	height: '100vh',


### PR DESCRIPTION
Fixes #358

## Screenshots (if visual changes)

![Screenshot 2022-07-25 at 10 36 46](https://user-images.githubusercontent.com/68588265/180746819-021bb820-877c-4ca7-8c58-a2d6e63f7935.png)

## Proposed Changes

  - Change the pageLoading component for the dotsLoading component
  - Giving z-index to pageLoading to fix the overlap bug
 

This pull request closes #358