### PR TITLE
[BUG]: lock boardSettings button with subboard merge

### DIFF
--- a/frontend/src/pages/boards/[boardId].tsx
+++ b/frontend/src/pages/boards/[boardId].tsx
@@ -123,11 +123,15 @@ const Board: NextPage<Props> = ({ boardId, mainBoardId }) => {
 
 	// Show board settings button if current user is allowed to edit
 	const showBoardSettings =
-		isStakeholderOrAdmin ||
-		(board?.isSubBoard && isResponsible) ||
-		isOwner ||
-		session?.isSAdmin;
+		(isStakeholderOrAdmin ||
+			(board?.isSubBoard && isResponsible) ||
+			isOwner ||
+			session?.isSAdmin) &&
+		board?.submitedAt === null;
 
+	console.log(board);
+	console.log(board?.submitedAt);
+	console.log(board?.submitedAt === null);
 	// Show Alert message if any sub-board wansn't merged
 	const showMessageHaveSubBoardsMerged =
 		!board?.isSubBoard &&
@@ -142,14 +146,14 @@ const Board: NextPage<Props> = ({ boardId, mainBoardId }) => {
 		<>
 			<BoardHeader />
 			<Container direction="column">
-				<Flex justify="between" align="center" css={{ py: '$32', width: '100%' }} gap={40}>
+				<Flex align="center" css={{ py: '$32', width: '100%' }} gap={40} justify="between">
 					{showButtonToMerge ? <AlertMergeIntoMain boardId={boardId} /> : null}
 
 					{showMessageHaveSubBoardsMerged ? (
 						<AlertBox
 							css={{ flex: 1 }}
-							type="info"
 							title="No sub-team has merged into this main board yet."
+							type="info"
 						/>
 					) : null}
 
@@ -159,13 +163,13 @@ const Board: NextPage<Props> = ({ boardId, mainBoardId }) => {
 
 					{showMessageIfMerged ? (
 						<AlertGoToMainBoard
-							submitedAt={board.submitedAt as Date}
 							mainBoardId={mainBoardId}
+							submitedAt={board.submitedAt as Date}
 						/>
 					) : null}
 				</Flex>
 
-				<DragDropArea userId={userId} board={board} socketId={socketId} />
+				<DragDropArea board={board} socketId={socketId} userId={userId} />
 			</Container>
 		</>
 	) : (

--- a/frontend/src/pages/boards/[boardId].tsx
+++ b/frontend/src/pages/boards/[boardId].tsx
@@ -129,9 +129,6 @@ const Board: NextPage<Props> = ({ boardId, mainBoardId }) => {
 			session?.isSAdmin) &&
 		board?.submitedAt === null;
 
-	console.log(board);
-	console.log(board?.submitedAt);
-	console.log(board?.submitedAt === null);
 	// Show Alert message if any sub-board wansn't merged
 	const showMessageHaveSubBoardsMerged =
 		!board?.isSubBoard &&


### PR DESCRIPTION
Fixes #389 

## Screenshots (if visual changes)
![imagem](https://user-images.githubusercontent.com/104831678/182598185-46d4746c-1f64-41fc-9506-f483f5d4cee8.png)


## Proposed Changes

  - when the board is already merged don't show the button



This pull request closes #389 