### PR TITLE
[BUG]: users permissions to delete boards

### DIFF
--- a/backend/src/modules/azure/controller/azure.controller.ts
+++ b/backend/src/modules/azure/controller/azure.controller.ts
@@ -77,7 +77,6 @@ export default class AzureController {
 	@HttpCode(200)
 	@Post('/')
 	loginOrRegistetruerAzureToken(@Body() azureToken: AzureToken) {
-		console.log('AZURE', azureToken);
 		return this.authAzureApp.registerOrLogin(azureToken.token);
 	}
 

--- a/backend/src/modules/boards/services/delete.board.service.ts
+++ b/backend/src/modules/boards/services/delete.board.service.ts
@@ -8,6 +8,7 @@ import isEmpty from 'libs/utils/isEmpty';
 import { GetTeamServiceInterface } from 'modules/teams/interfaces/services/get.team.service.interface';
 import * as Teams from 'modules/teams/interfaces/types';
 import { TeamUserDocument } from 'modules/teams/schemas/team.user.schema';
+import { UserDocument } from 'modules/users/schemas/user.schema';
 
 import { DeleteBoardService } from '../interfaces/services/delete.board.service.interface';
 import Board, { BoardDocument } from '../schemas/board.schema';
@@ -34,6 +35,26 @@ export default class DeleteBoardServiceImpl implements DeleteBoardService {
 		return teamUser;
 	}
 
+	private async isUserSAdmin(
+		userId: string,
+		quantidadeUsers: LeanDocument<TeamUserDocument>[]
+	): Promise<boolean> {
+		const myUser = quantidadeUsers.find(
+			(user) => String((user.user as UserDocument)?._id) === String(userId)
+		);
+		const isUserSAdmin = (myUser?.user as UserDocument).isSAdmin;
+		return isUserSAdmin;
+	}
+
+	private async getUsersOfTeam(teamId: string): Promise<LeanDocument<TeamUserDocument>[]> {
+		const users = await this.getTeamService.getUsersOfTeam(teamId);
+		if (!users) {
+			throw new NotFoundException('User not found list of users!');
+		}
+
+		return users;
+	}
+
 	async deleteSubBoards(dividedBoards: Board[] | ObjectId[], boardSession: ClientSession) {
 		const { deletedCount } = await this.boardModel
 			.deleteMany({ _id: { $in: dividedBoards } }, { session: boardSession })
@@ -54,8 +75,6 @@ export default class DeleteBoardServiceImpl implements DeleteBoardService {
 	}
 
 	async deleteBoard(boardId: string, userId: string, boardSession: ClientSession) {
-		// console.log('deleteBoard', boardId, userId);
-
 		const result = await this.boardModel.findOneAndRemove(
 			{
 				_id: boardId
@@ -69,32 +88,32 @@ export default class DeleteBoardServiceImpl implements DeleteBoardService {
 
 	async delete(boardId: string, userId: string) {
 		const boardSession = await this.boardModel.db.startSession();
-		// console.log('boardModel', this.boardModel);
-		// const boardTest = await this.boardModel.findOne({
-		// 	_id: boardId
-		// });
-		// console.log('boardTest', boardTest);
 		const board = await this.boardModel.findById(boardId).exec();
 		if (!board) {
 			throw new NotFoundException('Board not found!');
 		}
 		const { team, createdBy } = board;
 		const teamUser = await this.getTeamUser(userId, String(team));
-		console.log('teamuser', teamUser.role);
+		const users = await this.getUsersOfTeam(String(team));
+
+		const userIsSAdmin = await this.isUserSAdmin(userId, users);
+		console.log('userIsAdmin', userIsSAdmin);
+
 		const isAdminOrStakeholder = [TeamRoles.STAKEHOLDER, TeamRoles.ADMIN].includes(
 			teamUser.role as TeamRoles
 		);
-		console.log(isAdminOrStakeholder);
 
 		// Validate if the logged user are the owner
 		const isOwner = String(userId) === String(createdBy);
 
-		console.log('isOwner', isOwner);
+		if (!(isOwner || isAdminOrStakeholder || userIsSAdmin)) {
+			console.log('  NAO PODES ALTERAR');
+			throw Error(DELETE_FAILED);
+		}
 
 		const boardUserSession = await this.boardUserModel.db.startSession();
 		boardSession.startTransaction();
 		boardUserSession.startTransaction();
-
 		try {
 			const { _id, dividedBoards } = await this.deleteBoard(boardId, userId, boardSession);
 

--- a/backend/src/modules/boards/services/delete.board.service.ts
+++ b/backend/src/modules/boards/services/delete.board.service.ts
@@ -17,7 +17,8 @@ import BoardUser, { BoardUserDocument } from '../schemas/board.user.schema';
 @Injectable()
 export default class DeleteBoardServiceImpl implements DeleteBoardService {
 	constructor(
-		@InjectModel(Board.name) private boardModel: Model<BoardDocument>,
+		@InjectModel(Board.name)
+		private boardModel: Model<BoardDocument>,
 		@Inject(Teams.TYPES.services.GetTeamService)
 		private getTeamService: GetTeamServiceInterface,
 		@InjectModel(BoardUser.name)
@@ -37,9 +38,9 @@ export default class DeleteBoardServiceImpl implements DeleteBoardService {
 
 	private async isUserSAdmin(
 		userId: string,
-		quantidadeUsers: LeanDocument<TeamUserDocument>[]
+		teamUsers: LeanDocument<TeamUserDocument>[]
 	): Promise<boolean> {
-		const myUser = quantidadeUsers.find(
+		const myUser = teamUsers.find(
 			(user) => String((user.user as UserDocument)?._id) === String(userId)
 		);
 		const isUserSAdmin = (myUser?.user as UserDocument).isSAdmin;

--- a/backend/src/modules/boards/services/delete.board.service.ts
+++ b/backend/src/modules/boards/services/delete.board.service.ts
@@ -43,8 +43,7 @@ export default class DeleteBoardServiceImpl implements DeleteBoardService {
 			(user) => String((user.user as UserDocument)?._id) === String(userId)
 		);
 		const isUserSAdmin = (myUser?.user as UserDocument).isSAdmin;
-
-		return Boolean(isUserSAdmin);
+		return isUserSAdmin;
 	}
 
 	private async getUsersOfTeam(teamId: string): Promise<LeanDocument<TeamUserDocument>[]> {
@@ -106,17 +105,7 @@ export default class DeleteBoardServiceImpl implements DeleteBoardService {
 		// Validate if the logged user are the owner
 		const isOwner = String(userId) === String(createdBy);
 
-		console.log(
-			'isOwner',
-			isOwner,
-			'isAdminOrStakeholder',
-			isAdminOrStakeholder,
-			'userIsSAdmin',
-			userIsSAdmin
-		);
-		console.log(isOwner || isAdminOrStakeholder || userIsSAdmin);
 		if (isOwner || isAdminOrStakeholder || userIsSAdmin) {
-			console.log('PODES ALTERAR');
 			const boardUserSession = await this.boardUserModel.db.startSession();
 			boardSession.startTransaction();
 			boardUserSession.startTransaction();

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -88,7 +88,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 			.find({ team: teamId })
 			.populate({
 				path: 'user',
-				select: '_id firstName lastName email'
+				select: '_id firstName lastName email isSAdmin'
 			})
 			.lean()
 			.exec();

--- a/frontend/src/components/CardBoard/CardBody/CardBody.tsx
+++ b/frontend/src/components/CardBoard/CardBody/CardBody.tsx
@@ -106,13 +106,20 @@ const CardBody = React.memo<CardBodyProps>(
 			return !!users.find((user) => user.user._id === userId);
 		}, [users, userId]);
 
-		const userIsAdmin = useMemo(() => {
-			if (isSAdmin) return true;
-			if (team) {
-				return !!team.users.find((user) => user.role === 'admin');
+		const userIsAdminOrStakeholder = useMemo(() => {
+			if (isSAdmin) {
+				return true;
+			}
+			const myUser = team.users.find((user) => String(user.user._id) === String(userId));
+			const myUserIsOwner = board.createdBy._id === userId;
+			if (
+				team &&
+				(myUser?.role === 'admin' || myUser?.role === 'stakeholder' || myUserIsOwner)
+			) {
+				return true;
 			}
 			return !!users.find((user) => user.role === 'owner');
-		}, [isSAdmin, team, users]);
+		}, [isSAdmin, team, board.createdBy._id, userId, users]);
 
 		const handleOpenSubBoards = (e: ClickEvent<HTMLDivElement, MouseEvent>) => {
 			e.preventDefault();
@@ -225,7 +232,8 @@ const CardBody = React.memo<CardBodyProps>(
 							isDashboard={isDashboard}
 							isSubBoard={isSubBoard}
 							userId={userId}
-							userIsAdmin={userIsAdmin}
+							userIsAdminOrStakeholder={userIsAdminOrStakeholder}
+							userIsParticipating={userIsParticipating}
 							userSAdmin={isSAdmin}
 						/>
 					</InnerContainer>

--- a/frontend/src/components/CardBoard/CardBody/CardEnd.tsx
+++ b/frontend/src/components/CardBoard/CardBody/CardEnd.tsx
@@ -13,13 +13,22 @@ type CardEndProps = {
 	isDashboard: boolean;
 	isSubBoard: boolean | undefined;
 	index: number | undefined;
-	userIsAdmin: boolean;
+	userIsAdminOrStakeholder: boolean;
 	userId: string;
 	userSAdmin?: boolean;
+	userIsParticipating: boolean;
 };
 
 const CardEnd: React.FC<CardEndProps> = React.memo(
-	({ board, isDashboard, isSubBoard, index, userIsAdmin, userId, userSAdmin = undefined }) => {
+	({
+		board,
+		isDashboard,
+		isSubBoard,
+		index,
+		userIsAdminOrStakeholder,
+		userId,
+		userSAdmin = undefined
+	}) => {
 		CardEnd.defaultProps = {
 			userSAdmin: undefined
 		};
@@ -82,7 +91,7 @@ const CardEnd: React.FC<CardEndProps> = React.memo(
 						</Flex>
 					)}
 					<CountCards columns={columns} />
-					{(userIsAdmin || userSAdmin) && !isSubBoard && (
+					{(userIsAdminOrStakeholder || userSAdmin) && !isSubBoard && (
 						<Flex align="center" css={{ ml: '$24' }} gap="24">
 							<Separator
 								orientation="vertical"


### PR DESCRIPTION

Relates to #407


## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/99803749/185142050-4c028397-b82b-4a08-bb86-1f3841bde266.png)
![image](https://user-images.githubusercontent.com/99803749/185143818-b2d9ed4e-beaa-4ea6-a0ed-3c78c4143e6a.png)
![image](https://user-images.githubusercontent.com/99803749/185142577-af78beff-beaa-469c-a252-e62579aa951e.png)


## Proposed Changes

  - User who has just been created and is a member can't delete existing boards
  - Users with Stakeholder, admin, SuperAdmin have permissions to delete boards
  - Users who created boards also have permission to delete their own boards

Mention people who discussed this issue previously
@CatiaBarroco-xgeeks @dsousa12 @miguel-felix1 



This pull request closes #407 