### PR TITLE
 [BUG] Editing a comment to empty crashes the website

### DIFF
--- a/frontend/src/components/Board/AddCardOrComment.tsx
+++ b/frontend/src/components/Board/AddCardOrComment.tsx
@@ -135,7 +135,7 @@ const AddCard = React.memo<AddCardProps>(
 			const updateCommentDto: UpdateCommentDto = {
 				cardId,
 				cardItemId,
-				text,
+				text: text.trim(),
 				boardId,
 				socketId,
 				isCardGroup: !cardItemId,


### PR DESCRIPTION
Relates to #411

## Screenshots (if visual changes)
![imagem](https://user-images.githubusercontent.com/104831678/186377714-de5e1aa9-3865-4853-a412-0d87cb999bf0.png)


## Proposed Changes

  -if we try to change a comment to an empty space it gives an error but it doesn't break the site


This pull request closes #411