### PR TITLE
[BUG] Editing a comment to empty crashes the website

### DIFF
--- a/frontend/src/components/Board/AddCardOrComment.tsx
+++ b/frontend/src/components/Board/AddCardOrComment.tsx
@@ -135,7 +135,7 @@ const AddCard = React.memo<AddCardProps>(
 			const updateCommentDto: UpdateCommentDto = {
 				cardId,
 				cardItemId,
-				text,
+				text: text.trim(),
 				boardId,
 				socketId,
 				isCardGroup: !cardItemId,

--- a/frontend/src/components/Board/AddCardOrComment.tsx
+++ b/frontend/src/components/Board/AddCardOrComment.tsx
@@ -132,6 +132,7 @@ const AddCard = React.memo<AddCardProps>(
 
 		const handleUpdateComment = (text: string) => {
 			if (!cardId || !cancelUpdate || !commentId) return;
+			if (text.trim().length === 0) return;
 			const updateCommentDto: UpdateCommentDto = {
 				cardId,
 				cardItemId,


### PR DESCRIPTION
Fixes #411 


## Proposed Changes

  - user cannot edit a comment for an empty comment


This pull request closes #411