### PR TITLE
[BUG]: Editing a card title to empty crashes the website

### DIFF
--- a/frontend/src/components/Board/AddCardOrComment.tsx
+++ b/frontend/src/components/Board/AddCardOrComment.tsx
@@ -75,6 +75,7 @@ const AddCard = React.memo<AddCardProps>(
 		});
 
 		const handleAddCard = (text: string) => {
+			if (text.trim().length === 0) return;
 			const newCard: CardToAdd = {
 				items: [
 					{
@@ -102,6 +103,7 @@ const AddCard = React.memo<AddCardProps>(
 
 		const handleUpdateCard = (text: string) => {
 			if (!cardId || !cancelUpdate) return;
+			if (text.trim().length === 0) return;
 			const cardUpdated: UpdateCardDto = {
 				cardId,
 				cardItemId: cardItemId ?? '',
@@ -117,6 +119,7 @@ const AddCard = React.memo<AddCardProps>(
 
 		const handleAddComment = (text: string) => {
 			if (!cardId || !cancelUpdate) return;
+			if (text.trim().length === 0) return;
 			const commentDto: AddCommentDto = {
 				cardId,
 				cardItemId,


### PR DESCRIPTION
Fixes #421

## Proposed Changes

  -the user cannot put empty cards or empty comments



This pull request closes #421