### PR TITLE
[FEATURE]:disable button when card is empty 

### DIFF
--- a/frontend/src/components/Board/AddCardOrComment.tsx
+++ b/frontend/src/components/Board/AddCardOrComment.tsx
@@ -74,6 +74,9 @@ const AddCard = React.memo<AddCardProps>(
 			resolver: joiResolver(SchemaAddCommentForm)
 		});
 
+		const watchCardTextInput = methods.watch();
+		const disabledButton = watchCardTextInput.text?.trim().length === 0;
+
 		const handleAddCard = (text: string) => {
 			const newCard: CardToAdd = {
 				items: [
@@ -227,6 +230,7 @@ const AddCard = React.memo<AddCardProps>(
 						</ActionButton>
 						<ActionButton
 							css={{ width: '$48', height: '$36' }}
+							disabled={disabledButton}
 							size="sm"
 							type="submit"
 							variant="primary"


### PR DESCRIPTION
Relates to #423

## Screenshots (if visual changes)
![imagem](https://user-images.githubusercontent.com/104831678/186607975-88e454cf-d8d3-4c78-b98b-6c8cc666fbba.png)
![imagem](https://user-images.githubusercontent.com/104831678/186608014-6c6bfba0-07e6-463e-aab8-07f2079c9448.png)
![imagem](https://user-images.githubusercontent.com/104831678/186608083-128f4391-1802-4720-bef9-23d65ee68c96.png)


## Proposed Changes

  - when the user has the textarea empty the button is disabled
  - when the user types something the button is ready to submit



Mention people who discussed this issue previously
@mourabraz 

This pull request closes #432