### PR TITLE
[BUG] Comment icon remains in clicked state 

### DIFF
--- a/frontend/src/components/Board/Card/CardFooter.tsx
+++ b/frontend/src/components/Board/Card/CardFooter.tsx
@@ -210,15 +210,7 @@ const CardFooter = React.memo<FooterProps>(
 							}}
 						>
 							<StyledButtonIcon onClick={setOpenComments}>
-								<Icon
-									name={
-										!!comments?.find(
-											(comment) => comment.createdBy._id === userId
-										) || !!isCommentsOpened
-											? 'comment-filled'
-											: 'comment'
-									}
-								/>
+								<Icon name={isCommentsOpened ? 'comment-filled' : 'comment'} />
 							</StyledButtonIcon>
 							<Text
 								css={{ visibility: comments.length > 0 ? 'visible' : 'hidden' }}


### PR DESCRIPTION
Relates to #428

## Screenshots (if visual changes)
<img width="280" alt="imagem" src="https://user-images.githubusercontent.com/104831678/187710400-92aede96-eacf-41e7-b266-c500c9ceef8c.png">


## Proposed Changes

  - just fill the icon when the comments are open


Mention people who discussed this issue previously
@f-morgado 


This pull request closes #428