### PR TITLE
343/feature communication between create board and slack service

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -45,3 +45,6 @@ lerna-debug.log*
 .env.staging
 
 .vscode
+
+# Log file for slack
+slackLog.txt

--- a/backend/src/modules/boards/boards.module.ts
+++ b/backend/src/modules/boards/boards.module.ts
@@ -4,6 +4,7 @@ import {
 	mongooseBoardModule,
 	mongooseBoardUserModule
 } from 'infrastructure/database/mongoose.module';
+import { CommunicationModule } from 'modules/communication/communication.module';
 import { SchedulesModule } from 'modules/schedules/schedules.module';
 import TeamsModule from 'modules/teams/teams.module';
 import UsersModule from 'modules/users/users.module';
@@ -25,6 +26,7 @@ import BoardsController from './controller/boards.controller';
 		UsersModule,
 		TeamsModule,
 		SchedulesModule,
+		CommunicationModule,
 		mongooseBoardModule,
 		mongooseBoardUserModule
 	],

--- a/backend/src/modules/boards/dto/board.dto.ts
+++ b/backend/src/modules/boards/dto/board.dto.ts
@@ -100,4 +100,9 @@ export default class BoardDto {
 	@IsNotEmpty()
 	@IsBoolean()
 	isSubBoard?: boolean;
+
+	@ApiPropertyOptional({ default: false })
+	@IsOptional()
+	@IsBoolean()
+	createSlackCommunication?: boolean;
 }

--- a/backend/src/modules/boards/dto/board.dto.ts
+++ b/backend/src/modules/boards/dto/board.dto.ts
@@ -104,5 +104,5 @@ export default class BoardDto {
 	@ApiPropertyOptional({ default: false })
 	@IsOptional()
 	@IsBoolean()
-	createSlackCommunication?: boolean;
+	slackEnable?: boolean;
 }

--- a/backend/src/modules/boards/services/create.board.service.ts
+++ b/backend/src/modules/boards/services/create.board.service.ts
@@ -133,6 +133,10 @@ export default class CreateBoardServiceImpl implements CreateBoardService {
 			this.createFirstCronJob(addCronJobDto);
 		}
 
+		// if (boardData.createSlackCommunication) {
+		// 	console.log('create slack communication');
+		// }
+
 		return newBoard;
 	}
 

--- a/backend/src/modules/boards/services/create.board.service.ts
+++ b/backend/src/modules/boards/services/create.board.service.ts
@@ -51,7 +51,7 @@ export default class CreateBoardServiceImpl implements CreateBoardService {
 		private getBoardService: GetBoardServiceInterface,
 		@Inject(SchedulesType.TYPES.services.CreateSchedulesService)
 		private createSchedulesService: CreateSchedulesServiceInterface,
-		@Inject(CommunicationsType.TYPES.services.ExecuteCommunicationInterface)
+		@Inject(CommunicationsType.TYPES.services.ExecuteCommunication)
 		private slackCommunicationService: ExecuteCommunicationInterface
 	) {}
 

--- a/backend/src/modules/cards/services/create.card.service.ts
+++ b/backend/src/modules/cards/services/create.card.service.ts
@@ -17,7 +17,7 @@ export default class CreateCardServiceImpl implements CreateCardService {
 		card.createdBy = userId;
 
 		if (isEmpty(card.items)) {
-			card.items.push({
+			(card.items as any[]).push({
 				text: card.text,
 				createdBy: userId,
 				comments: [],

--- a/backend/src/modules/communication/applications/slack-execute-communication.application.ts
+++ b/backend/src/modules/communication/applications/slack-execute-communication.application.ts
@@ -109,9 +109,12 @@ export class SlackExecuteCommunication implements ExecuteCommunicationInterface 
 	}
 
 	private async createAllChannels(teams: TeamDto[]): Promise<TeamDto[]> {
+		const today = new Date();
+		const year = today.getFullYear();
+		const month = today.toLocaleString('default', { month: 'long' });
 		const createChannelsPromises = teams.map((i) =>
 			this.conversationsHandler.createChannel(
-				`${i.normalName}${i.for === BoardRoles.RESPONSIBLE ? '-responsibles' : ''}`
+				`${i.normalName}${i.for === BoardRoles.RESPONSIBLE ? '-responsibles' : ''}-${month}-${year}`
 			)
 		);
 
@@ -121,10 +124,10 @@ export class SlackExecuteCommunication implements ExecuteCommunicationInterface 
 		errors.forEach((i) => this.logger.warn(i));
 
 		success.forEach(({ id: channelId, name: channelName }) => {
-			const board = teams.find(
-				(i) =>
-					channelName ===
+			const board = teams.find((i) =>
+				channelName.includes(
 					`${i.normalName}${i.for === BoardRoles.RESPONSIBLE ? '-responsibles' : ''}`
+				)
 			);
 			if (board) {
 				board.channelId = channelId;

--- a/backend/src/modules/communication/applications/slack-execute-communication.application.ts
+++ b/backend/src/modules/communication/applications/slack-execute-communication.application.ts
@@ -111,7 +111,7 @@ export class SlackExecuteCommunication implements ExecuteCommunicationInterface 
 	private async createAllChannels(teams: TeamDto[]): Promise<TeamDto[]> {
 		const today = new Date();
 		const year = today.getFullYear();
-		const month = today.toLocaleString('default', { month: 'long' });
+		const month = today.toLocaleString('default', { month: 'long' }).toLowerCase();
 		const createChannelsPromises = teams.map((i) =>
 			this.conversationsHandler.createChannel(
 				`${i.normalName}${i.for === BoardRoles.RESPONSIBLE ? '-responsibles' : ''}-${month}-${year}`

--- a/backend/src/modules/communication/communication.module.ts
+++ b/backend/src/modules/communication/communication.module.ts
@@ -1,5 +1,5 @@
 import { BullModule } from '@nestjs/bull';
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { join } from 'path';
 
 import BoardsModule from 'modules/boards/boards.module';
@@ -8,14 +8,14 @@ import {
 	CommunicationGateAdapter,
 	ConversationsHandler,
 	ExecuteCommunication,
+	ExecuteCommunicationService,
 	UsersHandler
 } from 'modules/communication/communication.providers';
 import { CommunicationProducerService } from 'modules/communication/producers/slack-communication.producer.service';
-import { SlackExecuteCommunicationService } from 'modules/communication/services/slack-execute-communication.service';
 
 @Module({
 	imports: [
-		BoardsModule,
+		forwardRef(() => BoardsModule),
 		BullModule.registerQueueAsync({
 			name: CommunicationProducerService.QUEUE_NAME,
 			useFactory: async () => ({
@@ -25,7 +25,7 @@ import { SlackExecuteCommunicationService } from 'modules/communication/services
 		})
 	],
 	providers: [
-		SlackExecuteCommunicationService,
+		ExecuteCommunicationService,
 		CommunicationGateAdapter,
 		ChatHandler,
 		ConversationsHandler,
@@ -33,6 +33,6 @@ import { SlackExecuteCommunicationService } from 'modules/communication/services
 		ExecuteCommunication,
 		CommunicationProducerService
 	],
-	exports: [SlackExecuteCommunicationService]
+	exports: [ExecuteCommunicationService]
 })
 export class CommunicationModule {}

--- a/backend/src/modules/communication/communication.providers.ts
+++ b/backend/src/modules/communication/communication.providers.ts
@@ -14,7 +14,9 @@ import { UsersSlackHandler } from 'modules/communication/handlers/users-slack.ha
 import { ChatHandlerInterface } from 'modules/communication/interfaces/chat.handler.interface';
 import { CommunicationGateInterface } from 'modules/communication/interfaces/communication-gate.interface';
 import { ConversationsHandlerInterface } from 'modules/communication/interfaces/conversations.handler.interface';
+import { TYPES } from 'modules/communication/interfaces/types';
 import { UsersHandlerInterface } from 'modules/communication/interfaces/users.handler.interface';
+import { SlackExecuteCommunicationService } from 'modules/communication/services/slack-execute-communication.service';
 
 export const CommunicationGateAdapter = {
 	provide: SlackCommunicationGateAdapter,
@@ -74,4 +76,9 @@ export const ExecuteCommunication = {
 		);
 	},
 	inject: [ConfigService, ConversationsSlackHandler, UsersSlackHandler, ChatSlackHandler]
+};
+
+export const ExecuteCommunicationService = {
+	provide: TYPES.services.ExecuteCommunicationInterface,
+	useClass: SlackExecuteCommunicationService
 };

--- a/backend/src/modules/communication/communication.providers.ts
+++ b/backend/src/modules/communication/communication.providers.ts
@@ -79,6 +79,6 @@ export const ExecuteCommunication = {
 };
 
 export const ExecuteCommunicationService = {
-	provide: TYPES.services.ExecuteCommunicationInterface,
+	provide: TYPES.services.ExecuteCommunication,
 	useClass: SlackExecuteCommunicationService
 };

--- a/backend/src/modules/communication/interfaces/types.ts
+++ b/backend/src/modules/communication/interfaces/types.ts
@@ -1,5 +1,5 @@
 export const TYPES = {
 	services: {
-		ExecuteCommunicationInterface: 'ExecuteCommunicationInterface'
+		ExecuteCommunication: 'ExecuteCommunication'
 	}
 };

--- a/backend/src/modules/communication/interfaces/types.ts
+++ b/backend/src/modules/communication/interfaces/types.ts
@@ -1,0 +1,5 @@
+export const TYPES = {
+	services: {
+		ExecuteCommunicationInterface: 'ExecuteCommunicationInterface'
+	}
+};

--- a/backend/src/modules/communication/producers/slack-communication.producer.service.ts
+++ b/backend/src/modules/communication/producers/slack-communication.producer.service.ts
@@ -1,6 +1,7 @@
 import { InjectQueue } from '@nestjs/bull';
 import { Injectable, Logger } from '@nestjs/common';
 import { Job, Queue } from 'bull';
+import { createWriteStream } from 'fs';
 
 import { JobType } from 'modules/communication/dto/types';
 
@@ -15,8 +16,13 @@ export class CommunicationProducerService {
 		private readonly queue: Queue
 	) {
 		// https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#events
-		this.queue.on('completed', (job: Job<JobType>) => {
+		this.queue.on('completed', (job: Job<JobType>, result: any) => {
 			this.logger.verbose(`Completed Job id: "${job.id}"`);
+
+			console.log(result);
+
+			this.saveLog(result);
+
 			job.remove();
 		});
 		this.queue.on('error', (error: Error) => {
@@ -36,5 +42,15 @@ export class CommunicationProducerService {
 		);
 
 		return job;
+	}
+
+	saveLog(data: any) {
+		try {
+			const stream = createWriteStream('slackLog.txt', { flags: 'a' });
+			stream.write(`${JSON.stringify(data)}\n`);
+			stream.end();
+		} catch (error) {
+			this.logger.error(error);
+		}
 	}
 }

--- a/backend/src/modules/communication/producers/slack-communication.producer.service.ts
+++ b/backend/src/modules/communication/producers/slack-communication.producer.service.ts
@@ -18,11 +18,7 @@ export class CommunicationProducerService {
 		// https://github.com/OptimalBits/bull/blob/develop/REFERENCE.md#events
 		this.queue.on('completed', (job: Job<JobType>, result: any) => {
 			this.logger.verbose(`Completed Job id: "${job.id}"`);
-
-			console.log(result);
-
 			this.saveLog(result);
-
 			job.remove();
 		});
 		this.queue.on('error', (error: Error) => {

--- a/backend/src/test/boards/boards.controller.spec.ts
+++ b/backend/src/test/boards/boards.controller.spec.ts
@@ -13,6 +13,7 @@ import {
 	updateBoardService
 } from 'modules/boards/boards.providers';
 import BoardsController from 'modules/boards/controller/boards.controller';
+import * as CommunicationsType from 'modules/communication/interfaces/types';
 import { createSchedulesService } from 'modules/schedules/schedules.providers';
 import SocketGateway from 'modules/socket/gateway/socket.gateway';
 import { createTeamService, getTeamApplication, getTeamService } from 'modules/teams/providers';
@@ -61,6 +62,12 @@ describe('BoardsController', () => {
 				{
 					provide: getModelToken('Schedules'),
 					useValue: {}
+				},
+				{
+					provide: CommunicationsType.TYPES.services.ExecuteCommunication,
+					useValue: {
+						execute: jest.fn()
+					}
 				}
 			]
 		}).compile();

--- a/frontend/src/components/Board/Settings/index.tsx
+++ b/frontend/src/components/Board/Settings/index.tsx
@@ -1,10 +1,10 @@
-import React, { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
-import { FormProvider, useForm } from 'react-hook-form';
-import { useRecoilValue } from 'recoil';
 import { joiResolver } from '@hookform/resolvers/joi';
 import { Accordion } from '@radix-ui/react-accordion';
 import { Dialog, DialogClose, DialogTrigger } from '@radix-ui/react-dialog';
 import { deepClone } from 'fast-json-patch';
+import { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useRecoilValue } from 'recoil';
 
 import Icon from 'components/icons/Icon';
 import Avatar from 'components/Primitives/Avatar';
@@ -223,7 +223,6 @@ const BoardSettings = ({
 
 		const keyDownHandler = (event: KeyboardEvent) => {
 			if (event.key === 'Enter') {
-				console.log('---');
 				event.preventDefault();
 
 				if (submitBtnRef.current) {

--- a/frontend/src/components/CreateBoard/SubTeamsTab/MainBoardCard.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/MainBoardCard.tsx
@@ -70,16 +70,6 @@ const MainBoardCard = React.memo(({ team, timesOpen }: MainBoardCardInterface) =
 		teamMembers
 	} = useCreateBoard(team);
 
-	// const slackEnableHandler = () => {
-	// 	setCreateBoardData((prev) => {
-	// 		console.log('slackEnableHandler', { ...prev.board, slackEnable: board.slackEnable });
-	// 		return {
-	// 			...prev,
-	// 			board: { ...prev.board, slackEnable: !board.slackEnable }
-	// 		};
-	// 	});
-	// };
-
 	const teamMembersCount = teamMembers?.length ?? 0;
 
 	useEffect(() => {

--- a/frontend/src/components/CreateBoard/SubTeamsTab/MainBoardCard.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/MainBoardCard.tsx
@@ -70,12 +70,15 @@ const MainBoardCard = React.memo(({ team, timesOpen }: MainBoardCardInterface) =
 		teamMembers
 	} = useCreateBoard(team);
 
-	const slackGroupHandler = () => {
-		setCreateBoardData((prev) => ({
-			...prev,
-			board: { ...prev.board, slackGroup: !board.slackGroup }
-		}));
-	};
+	// const slackEnableHandler = () => {
+	// 	setCreateBoardData((prev) => {
+	// 		console.log('slackEnableHandler', { ...prev.board, slackEnable: board.slackEnable });
+	// 		return {
+	// 			...prev,
+	// 			board: { ...prev.board, slackEnable: !board.slackEnable }
+	// 		};
+	// 	});
+	// };
 
 	const teamMembersCount = teamMembers?.length ?? 0;
 
@@ -208,10 +211,11 @@ const MainBoardCard = React.memo(({ team, timesOpen }: MainBoardCardInterface) =
 				</Flex>
 			</MainContainer>
 			<SubBoardList dividedBoards={board.dividedBoards} setBoard={setCreateBoardData} />
-			<Box onClick={slackGroupHandler}>
+			<Box>
+				{/* onClick={slackEnableHandler} */}
 				<Checkbox
-					checked={board.slackGroup}
-					id="slack"
+					// checked={board.slackEnable}
+					id="slackEnable"
 					label="Create Slack group for each sub-team"
 					size="16"
 				/>

--- a/frontend/src/components/Primitives/Checkbox.tsx
+++ b/frontend/src/components/Primitives/Checkbox.tsx
@@ -1,6 +1,7 @@
-import React, { Dispatch, useState } from 'react';
 import * as CheckboxPrimitive from '@radix-ui/react-checkbox';
 import { styled } from '@stitches/react';
+import React, { Dispatch, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
 
 import Icon from 'components/icons/Icon';
 import Flex from './Flex';
@@ -77,6 +78,8 @@ const Checkbox: React.FC<{
 		setCheckedTerms: null
 	};
 
+	const { setValue } = useFormContext();
+
 	const [currentCheckValue, setCurrentCheckValue] = useState<
 		boolean | undefined | 'indeterminate'
 	>(checked);
@@ -84,6 +87,8 @@ const Checkbox: React.FC<{
 		if (handleChange) handleChange(id);
 		setCurrentCheckValue(isChecked);
 		if (setCheckedTerms != null) setCheckedTerms(!!isChecked);
+
+		setValue('slackEnable', !!isChecked);
 	};
 
 	return (

--- a/frontend/src/hooks/useBoard.tsx
+++ b/frontend/src/hooks/useBoard.tsx
@@ -1,6 +1,6 @@
+import { AxiosError } from 'axios';
 import { useMutation, useQuery } from 'react-query';
 import { useSetRecoilState } from 'recoil';
-import { AxiosError } from 'axios';
 
 import {
 	createBoardRequest,

--- a/frontend/src/pages/boards/new.tsx
+++ b/frontend/src/pages/boards/new.tsx
@@ -154,11 +154,6 @@ const NewBoard: NextPage = () => {
 						onSubmit={
 							!haveError
 								? methods.handleSubmit(({ text, maxVotes, slackEnable }) => {
-										console.log('methods.handleSubmit', {
-											text,
-											maxVotes,
-											slackEnable
-										});
 										saveBoard(text, maxVotes, slackEnable);
 								  })
 								: undefined

--- a/frontend/src/pages/boards/new.tsx
+++ b/frontend/src/pages/boards/new.tsx
@@ -1,10 +1,10 @@
+import { joiResolver } from '@hookform/resolvers/joi';
+import { GetServerSideProps, GetServerSidePropsContext, NextPage } from 'next';
+import { useRouter } from 'next/router';
 import { useCallback, useEffect } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { dehydrate, QueryClient } from 'react-query';
-import { GetServerSideProps, GetServerSidePropsContext, NextPage } from 'next';
-import { useRouter } from 'next/router';
 import { useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
-import { joiResolver } from '@hookform/resolvers/joi';
 
 import {
 	ButtonsContainer,
@@ -54,12 +54,13 @@ const NewBoard: NextPage = () => {
 	/**
 	 * React Hook Form
 	 */
-	const methods = useForm<{ text: string; maxVotes?: number }>({
+	const methods = useForm<{ text: string; maxVotes?: number; slackEnable?: boolean }>({
 		mode: 'onBlur',
 		reValidateMode: 'onBlur',
 		defaultValues: {
 			text: '',
-			maxVotes: boardState.board.maxVotes
+			maxVotes: boardState.board.maxVotes,
+			slackEnable: false
 		},
 		resolver: joiResolver(SchemaCreateBoard)
 	});
@@ -82,7 +83,7 @@ const NewBoard: NextPage = () => {
 	 * @param title Board Title
 	 * @param maxVotes Maxium number of votes allowed
 	 */
-	const saveBoard = (title: string, maxVotes?: number) => {
+	const saveBoard = (title: string, maxVotes?: number, slackEnable?: boolean) => {
 		const newDividedBoards: CreateBoardDto[] = boardState.board.dividedBoards.map(
 			(subBoard) => {
 				const newSubBoard: CreateBoardDto = { ...subBoard, users: [], dividedBoards: [] };
@@ -105,6 +106,7 @@ const NewBoard: NextPage = () => {
 			title,
 			dividedBoards: newDividedBoards,
 			maxVotes,
+			slackEnable,
 			maxUsers: boardState.count.maxUsersCount.toString()
 		});
 	};
@@ -151,9 +153,14 @@ const NewBoard: NextPage = () => {
 						status={!haveError}
 						onSubmit={
 							!haveError
-								? methods.handleSubmit(({ text, maxVotes }) =>
-										saveBoard(text, maxVotes)
-								  )
+								? methods.handleSubmit(({ text, maxVotes, slackEnable }) => {
+										console.log('methods.handleSubmit', {
+											text,
+											maxVotes,
+											slackEnable
+										});
+										saveBoard(text, maxVotes, slackEnable);
+								  })
 								: undefined
 						}
 					>

--- a/frontend/src/schema/schemaCreateBoardForm.ts
+++ b/frontend/src/schema/schemaCreateBoardForm.ts
@@ -8,6 +8,9 @@ const SchemaCreateBoard = Joi.object({
 	}),
 	maxVotes: Joi.number().min(1).optional().messages({
 		'number.min': 'Please insert a number greater than zero.'
+	}),
+	slackEnable: Joi.boolean().required().messages({
+		'boolean.required': 'Please enterm the value for slack enable.'
 	})
 });
 

--- a/frontend/src/store/createBoard/atoms/create-board.atom.tsx
+++ b/frontend/src/store/createBoard/atoms/create-board.atom.tsx
@@ -50,7 +50,7 @@ export const createBoardDataState = atom<CreateBoardData>({
 			isSubBoard: false,
 			hideCards: false,
 			hideVotes: false,
-			slackGroup: false,
+			slackEnable: false,
 			totalUsedVotes: 0
 		}
 	}

--- a/frontend/src/types/board/board.ts
+++ b/frontend/src/types/board/board.ts
@@ -38,7 +38,7 @@ export default interface BoardType {
 	votes?: string;
 	submitedByUser?: string;
 	submitedAt?: Date;
-	slackGroup?: boolean;
+	slackEnable?: boolean;
 	totalUsedVotes: number;
 }
 


### PR DESCRIPTION
Relates to #343 

## Proposed Changes

  - change the property name in the frontend regards the slack
  - when creating a new board it checks the field "slack" and calls the service from the slack module if necessary 
  - **Note**: It calls the slack service only creating the board, recursive boards are not calling the slack service!
  -  save the created data structure used in the slack process to a log file (in the root with the name "slackLog.txt")

@f-morgado  @CatiaBarroco-xgeeks 


This pull request closes #343