### PR TITLE
[BUG]: disable button to remove non-user votes 

### DIFF
--- a/frontend/src/components/Board/Card/CardFooter.tsx
+++ b/frontend/src/components/Board/Card/CardFooter.tsx
@@ -106,7 +106,7 @@ const CardFooter = React.memo<FooterProps>(
 		};
 		const votesData = calculateVotes();
 
-		const { cardItemId, votesInThisCard } = votesData;
+		const { cardItemId, votesInThisCard, votesOfUserInThisCard } = votesData;
 
 		const [countVotes, setCountVotes] = useState(0);
 
@@ -230,7 +230,8 @@ const CardFooter = React.memo<FooterProps>(
 									disableVoteButton ||
 									!isMainboard ||
 									votesInThisCard.length === 0 ||
-									!!(user && maxVotes && user.votesCount + countVotes <= 0)
+									!!(user && maxVotes && user.votesCount + countVotes <= 0) ||
+									votesOfUserInThisCard === 0
 								}
 								onClick={handleDeleteVote}
 							>


### PR DESCRIPTION
Fixes #439 

## Proposed Changes

  -if the user does not have votes on that card, the downvotes button will appear disabled



Mention people who discussed this issue previously
@miguel-felix1 

This pull request closes #439 