### PR TITLE
[SUGGESTION]: Checking if the users is from the sub-team

### DIFF
--- a/frontend/src/pages/boards/[boardId].tsx
+++ b/frontend/src/pages/boards/[boardId].tsx
@@ -128,7 +128,9 @@ const Board: NextPage<Props> = ({ boardId, mainBoardId }) => {
 	// Socket IO
 	useEffect(() => cleanSocket, [cleanSocket]);
 
-	return board && userId && socketId ? (
+	const userIsInBoard = board?.users.find((user) => user.user._id === userId);
+
+	return board && userId && socketId && (userIsInBoard || havePermissionsToEditBoardSettings) ? (
 		<>
 			<BoardHeader />
 			<Container direction="column">


### PR DESCRIPTION
Relates to #382 

## Proposed Changes

  -if the user does not belong to the board, he will not be able to enter it


This pull request closes #382 