### PR TITLE
chore: add  communication service for slack disabled

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -32,7 +32,8 @@ const imports = [
 	TeamsModule,
 	mongooseResetModule,
 	mongooseUserModule,
-	ScheduleModule.forRoot()
+	ScheduleModule.forRoot(),
+	QueueModule
 ];
 
 if (configuration().azure.enabled) {
@@ -44,7 +45,6 @@ if (configuration().smtp.enabled) {
 }
 
 if (configuration().slack.enable) {
-	imports.push(QueueModule);
 	imports.push(CommunicationModule);
 }
 

--- a/backend/src/modules/communication/communication.providers.ts
+++ b/backend/src/modules/communication/communication.providers.ts
@@ -1,5 +1,6 @@
 import { ConfigService } from '@nestjs/config';
 
+import { configuration } from 'infrastructure/config/configuration';
 import { FRONTEND_URL } from 'libs/constants/frontend';
 import {
 	SLACK_API_BOT_TOKEN,
@@ -16,6 +17,7 @@ import { CommunicationGateInterface } from 'modules/communication/interfaces/com
 import { ConversationsHandlerInterface } from 'modules/communication/interfaces/conversations.handler.interface';
 import { TYPES } from 'modules/communication/interfaces/types';
 import { UsersHandlerInterface } from 'modules/communication/interfaces/users.handler.interface';
+import { SlackDisabledCommunicationService } from 'modules/communication/services/slack-disabled-communication.service';
 import { SlackExecuteCommunicationService } from 'modules/communication/services/slack-execute-communication.service';
 
 export const CommunicationGateAdapter = {
@@ -80,5 +82,7 @@ export const ExecuteCommunication = {
 
 export const ExecuteCommunicationService = {
 	provide: TYPES.services.ExecuteCommunication,
-	useClass: SlackExecuteCommunicationService
+	useClass: configuration().slack.enable
+		? SlackExecuteCommunicationService
+		: SlackDisabledCommunicationService
 };

--- a/backend/src/modules/communication/services/slack-disabled-communication.service.ts
+++ b/backend/src/modules/communication/services/slack-disabled-communication.service.ts
@@ -1,0 +1,14 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import { BoardType } from 'modules/communication/dto/types';
+
+@Injectable()
+export class SlackDisabledCommunicationService {
+	private logger = new Logger(SlackDisabledCommunicationService.name);
+
+	public async execute(board: BoardType): Promise<void> {
+		this.logger.warn(
+			`Call execute method with SLACK_ENABLE "false" for board with id: "${board.id}"`
+		);
+	}
+}


### PR DESCRIPTION
Relates to #452 
Fixes #343

## Proposed Changes

  Since the Communication module should be loaded only if the SLACK_ENABLE environment variable is set to "true". This module should have the responsibility to check it and load accordingly, for that:
  - registers the queue only if necessary
  - instantiate only the necessary classes
  - provide a class service in case the SLACK_ENABLE is set to "false" in order not to break the use of "ExecuteCommunicationService"
  - move Queue Module to app module imports, this module should load independent of the communication module. From now on the **REDIS environment variables are mandatory**.

@f-morgado @CatiaBarroco-xgeeks 

This pull request closes #452 