### PR TITLE
[BUG] Sub-board Name

### DIFF
--- a/frontend/src/schema/schemaCreateBoardForm.ts
+++ b/frontend/src/schema/schemaCreateBoardForm.ts
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 const SchemaCreateBoard = Joi.object({
-	text: Joi.string().required().max(30).messages({
+	text: Joi.string().required().trim().max(30).messages({
 		'any.required': 'Please enter the board name',
 		'string.empty': 'Please enter the board name',
 		'string.max': 'Maximum of 30 characters'

--- a/frontend/src/schema/schemaUpdateBoardForm.ts
+++ b/frontend/src/schema/schemaUpdateBoardForm.ts
@@ -1,7 +1,7 @@
 import Joi from 'joi';
 
 const SchemaUpdateBoard = Joi.object({
-	title: Joi.string().required().max(30).messages({
+	title: Joi.string().required().trim().max(30).messages({
 		'any.required': 'Please enter the board name',
 		'string.empty': 'Please enter the board name',
 		'string.max': 'Maximum of 30 characters'


### PR DESCRIPTION
Fixes #462 

## Screenshots (if visual changes)
![imagem](https://user-images.githubusercontent.com/104831678/192720744-fc039bec-83bc-4b4f-a36a-47735c85679a.png)


## Proposed Changes

  - if the responsible tries to update the board name to an empty name, it will return an error and will not let update the board

This pull request closes #462 