### PR TITLE
[FIX] password regex

### DIFF
--- a/frontend/src/schema/schemaRegisterForm.ts
+++ b/frontend/src/schema/schemaRegisterForm.ts
@@ -20,7 +20,7 @@ const SchemaRegisterForm = Joi.object({
 		}),
 	password: Joi.string()
 		.required()
-		.regex(/^(?=.*[A-Z])(?=.*\d)(?=.*\W)[A-Za-z\d\W]{8,}$/)
+		.regex(/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[^A-Za-z0-9]).{8,}$/)
 		.min(8)
 		.messages({
 			'string.min': 'Password must be at least 8 characters.',

--- a/frontend/src/schema/schemaResetPasswordForm.ts
+++ b/frontend/src/schema/schemaResetPasswordForm.ts
@@ -3,7 +3,7 @@ import Joi from 'joi';
 const SchemaResetPasswordForm = Joi.object({
 	newPassword: Joi.string()
 		.required()
-		.regex(/^(?=.*[A-Z])(?=.*\d)(?=.*\W)[A-Za-z\d\W]{8,}$/)
+		.regex(/^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[^A-Za-z0-9]).{8,}$/)
 		.min(8)
 		.messages({
 			'string.min': 'Password must be at least 8 characters.',


### PR DESCRIPTION
Fixes #481

## Screenshots (if visual changes)

## Proposed Changes

  - Change the "not word" character class to a multiple negate sets because in regex underscore is in the word set

This pull request closes #481