### PR TITLE
Feat/add page for creating a new team

### DIFF
--- a/frontend/src/components/Teams/CreateTeam/TeamName.tsx
+++ b/frontend/src/components/Teams/CreateTeam/TeamName.tsx
@@ -1,0 +1,24 @@
+import Input from '../../Primitives/Input';
+import Text from '../../Primitives/Text';
+
+type Props = { teamName: string };
+
+const TeamName = ({ teamName }: Props) => {
+	return (
+		<>
+			<Text heading="3">Team Name</Text>
+
+			<Input
+				forceState
+				currentValue={teamName}
+				id="text"
+				maxChars="40"
+				placeholder="Team name"
+				state="default"
+				type="text"
+			/>
+		</>
+	);
+};
+
+export default TeamName;

--- a/frontend/src/components/Teams/CreateTeam/TeamName.tsx
+++ b/frontend/src/components/Teams/CreateTeam/TeamName.tsx
@@ -6,7 +6,9 @@ type Props = { teamName: string };
 const TeamName = ({ teamName }: Props) => {
 	return (
 		<>
-			<Text heading="3">Team Name</Text>
+			<Text css={{ mb: '$16' }} heading="3">
+				Team Name
+			</Text>
 
 			<Input
 				forceState

--- a/frontend/src/components/Teams/CreateTeam/TipBar.tsx
+++ b/frontend/src/components/Teams/CreateTeam/TipBar.tsx
@@ -1,0 +1,51 @@
+import { styled } from 'styles/stitches/stitches.config';
+
+import Icon from 'components/icons/Icon';
+import Flex from 'components/Primitives/Flex';
+import Text from 'components/Primitives/Text';
+
+const TextWhite = styled(Text, { color: 'white', mt: '$24' });
+const LiWhite = styled('li', Text, { color: '$primary100', fontSize: '$14', lineHeight: '$20' });
+
+const CreateTeamTipBar = () => {
+	return (
+		<Flex
+			direction="column"
+			justify="center"
+			css={{
+				minHeight: 'calc(100vh - $sizes$92)',
+				backgroundColor: '$primary800',
+				padding: '$32',
+				maxWidth: '$384',
+				position: 'fixed',
+				right: 0,
+				top: 0,
+				bottom: 0
+			}}
+		>
+			<Icon
+				name="blob-idea"
+				css={{
+					width: '47px',
+					height: '$48'
+				}}
+			/>
+			<TextWhite heading="6">Team Admin</TextWhite>
+
+			<LiWhite as="span">
+				You will be the team admin of this team. You can also choose other team admins later
+				on out of your team members.
+			</LiWhite>
+
+			<TextWhite css={{ mb: '$8' }} heading="6">
+				Stakeholders
+			</TextWhite>
+			<LiWhite as="span">
+				If you select the role <b>stakeholder</b>, this person will not be included in
+				sub-team retros later on when you create a SPLIT retrospective.
+			</LiWhite>
+		</Flex>
+	);
+};
+
+export default CreateTeamTipBar;

--- a/frontend/src/components/icons/Sprite.tsx
+++ b/frontend/src/components/icons/Sprite.tsx
@@ -1,3 +1,5 @@
+/* eslint react/no-unknown-property: 0 */
+
 const Sprite = () => (
 	<svg
 		focusable="false"

--- a/frontend/src/components/layouts/DashboardLayout/index.tsx
+++ b/frontend/src/components/layouts/DashboardLayout/index.tsx
@@ -33,7 +33,7 @@ const DashboardLayout = (props: DashboardLayoutProps) => {
 						</Link>
 					)}
 					{isTeams && (
-						<Link href="/">
+						<Link href="/teams/new">
 							<AddNewBoardButton size={isDashboard ? 'sm' : 'md'}>
 								<Icon css={{ color: 'white' }} name="plus" />
 								Create new team

--- a/frontend/src/pages/teams/new.tsx
+++ b/frontend/src/pages/teams/new.tsx
@@ -44,7 +44,7 @@ const NewTeam: NextPage = () => {
 		<Container>
 			<PageHeader>
 				<Text color="primary800" heading={3} weight="bold">
-					Add new SPLIT board
+					Create new team
 				</Text>
 
 				<Button isIcon onClick={handleBack}>

--- a/frontend/src/pages/teams/new.tsx
+++ b/frontend/src/pages/teams/new.tsx
@@ -1,0 +1,70 @@
+import { useCallback } from 'react';
+import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { NextPage } from 'next';
+import { useRouter } from 'next/router';
+import { joiResolver } from '@hookform/resolvers/joi/dist/joi';
+
+import Icon from '../../components/icons/Icon';
+import Button from '../../components/Primitives/Button';
+import Text from '../../components/Primitives/Text';
+import TeamName from '../../components/Teams/CreateTeam/TeamName';
+import TipBar from '../../components/Teams/CreateTeam/TipBar';
+import SchemaCreateTeam from '../../schema/schemaCreateTeamForm';
+import {
+	Container,
+	ContentContainer,
+	InnerContent,
+	PageHeader,
+	StyledForm,
+	SubContainer
+} from '../../styles/pages/boards/new.styles';
+
+const NewTeam: NextPage = () => {
+	const router = useRouter();
+
+	const methods = useForm<{ text: string }>({
+		mode: 'onBlur',
+		reValidateMode: 'onBlur',
+		defaultValues: {
+			text: ''
+		},
+		resolver: joiResolver(SchemaCreateTeam)
+	});
+
+	const teamName = useWatch({
+		control: methods.control,
+		name: 'text'
+	});
+
+	const handleBack = useCallback(() => {
+		router.back();
+	}, [router]);
+
+	return (
+		<Container>
+			<PageHeader>
+				<Text color="primary800" heading={3} weight="bold">
+					Add new SPLIT board
+				</Text>
+
+				<Button isIcon onClick={handleBack}>
+					<Icon name="close" />
+				</Button>
+			</PageHeader>
+			<ContentContainer>
+				<SubContainer>
+					<StyledForm direction="column">
+						<InnerContent direction="column">
+							<FormProvider {...methods}>
+								<TeamName teamName={teamName} />
+							</FormProvider>
+						</InnerContent>
+					</StyledForm>
+				</SubContainer>
+				<TipBar />
+			</ContentContainer>
+		</Container>
+	);
+};
+
+export default NewTeam;

--- a/frontend/src/schema/schemaCreateTeamForm.ts
+++ b/frontend/src/schema/schemaCreateTeamForm.ts
@@ -1,0 +1,11 @@
+import Joi from 'joi';
+
+const SchemaCreateTeam = Joi.object({
+	text: Joi.string().required().trim().max(40).messages({
+		'any.required': 'Please enter the team name',
+		'string.empty': 'Please enter the team name',
+		'string.max': 'Maximum of 40 characters'
+	})
+});
+
+export default SchemaCreateTeam;


### PR DESCRIPTION
Relates to #514 


## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/59372326/196754406-cc195d98-b391-4fe9-bcf2-80b1d4260115.png)


## Proposed Changes

  - Add a new page to create a new team
  - Add input to insert team name
  - Add tipbar


This pull request closes #514 