### PR TITLE
[FEATURE]: add form buttons to create team page

### DIFF
--- a/frontend/src/components/Teams/CreateTeam/ListCardsMembers/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListCardsMembers/index.tsx
@@ -10,7 +10,7 @@ const TeamMembersList = () => {
 	const { data: session } = useSession();
 
 	return session ? (
-		<Flex css={{ mt: '$56' }} direction="column">
+		<Flex css={{ mt: '$48' }} direction="column">
 			<Text css={{ mb: '$16' }} heading="3">
 				Team Members
 			</Text>

--- a/frontend/src/pages/teams/new.tsx
+++ b/frontend/src/pages/teams/new.tsx
@@ -12,6 +12,7 @@ import TeamName from '../../components/Teams/CreateTeam/TeamName';
 import TipBar from '../../components/Teams/CreateTeam/TipBar';
 import SchemaCreateTeam from '../../schema/schemaCreateTeamForm';
 import {
+	ButtonsContainer,
 	Container,
 	ContentContainer,
 	InnerContent,
@@ -61,6 +62,12 @@ const NewTeam: NextPage = () => {
 								<TeamsMembersList />
 							</FormProvider>
 						</InnerContent>
+						<ButtonsContainer gap="24" justify="end">
+							<Button type="button" variant="lightOutline" onClick={handleBack}>
+								Cancel
+							</Button>
+							<Button type="submit">Create team</Button>
+						</ButtonsContainer>
 					</StyledForm>
 				</SubContainer>
 				<TipBar />

--- a/frontend/src/styles/pages/boards/new.styles.tsx
+++ b/frontend/src/styles/pages/boards/new.styles.tsx
@@ -93,7 +93,7 @@ const ButtonsContainer = styled(Flex, {
 	bottom: 0,
 	left: 0,
 	right: 0,
-
+	borderTop: '0.8px solid $primary200',
 	py: '$16',
 	pr: '$32',
 


### PR DESCRIPTION


Relates to #518 


## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/59372326/197221452-1954e9f1-e46a-4d98-bbbd-1e428f007738.png)


## Proposed Changes

  - Add cancel and create team buttons layout to the create new team page.


This pull request closes #518 