### PR TITLE
[FEATURE]: render members card

### DIFF
--- a/frontend/src/components/Teams/CreateTeam/CardEnd.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardEnd.tsx
@@ -4,13 +4,12 @@ import Flex from 'components/Primitives/Flex';
 import Text from 'components/Primitives/Text';
 
 type CardEndProps = {
-	userSAdmin?: boolean;
 	role: string;
 };
 
-export const CardEnd: React.FC<CardEndProps> = React.memo(({ role }) => {
+const CardEnd = ({ role }: CardEndProps) => {
 	return (
-		<Flex align="center" css={{ justifySelf: 'end' }}>
+		<Flex align="center" css={{ width: '23%' }} justify="end">
 			<Text color="primary200" size="sm">
 				Role |
 			</Text>
@@ -19,4 +18,6 @@ export const CardEnd: React.FC<CardEndProps> = React.memo(({ role }) => {
 			</Text>
 		</Flex>
 	);
-});
+};
+
+export default CardEnd;

--- a/frontend/src/components/Teams/CreateTeam/CardEnd.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardEnd.tsx
@@ -2,22 +2,20 @@ import React from 'react';
 
 import Flex from 'components/Primitives/Flex';
 import Text from 'components/Primitives/Text';
-import { Team } from '../../../types/team/team';
 
 type CardEndProps = {
-	userId: string;
 	userSAdmin?: boolean;
-	team?: Team;
+	role: string;
 };
 
-export const CardEnd: React.FC<CardEndProps> = React.memo(() => {
+export const CardEnd: React.FC<CardEndProps> = React.memo(({ role }) => {
 	return (
 		<Flex align="center" css={{ justifySelf: 'end' }}>
 			<Text color="primary200" size="sm">
 				Role |
 			</Text>
 			<Text color="primary800" css={{ mx: '$8' }} size="sm" weight="medium">
-				Team Admin
+				Team {role.substring(0, 1).toUpperCase() + role.substring(1, role.length)}
 			</Text>
 		</Flex>
 	);

--- a/frontend/src/components/Teams/CreateTeam/CardMember/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardMember/index.tsx
@@ -4,7 +4,7 @@ import Icon from 'components/icons/Icon';
 import Flex from 'components/Primitives/Flex';
 import { User } from '../../../../types/user/user';
 import { ConfigurationSettings } from '../../../Board/Settings/partials/ConfigurationSettings';
-import { CardEnd } from '../CardEnd';
+import CardEnd from '../CardEnd';
 import { InnerContainer, StyledMemberTitle } from './styles';
 
 type CardBodyProps = {
@@ -13,9 +13,9 @@ type CardBodyProps = {
 	role: string;
 };
 
-const CardMember = React.memo<CardBodyProps>(({ member, role, userSAdmin }) => {
+const CardMember = React.memo<CardBodyProps>(({ member, role }) => {
 	return (
-		<Flex css={{ flex: '1 1 0', marginBottom: '$10' }} direction="column" gap="12">
+		<Flex css={{ flex: '1 1 1', marginBottom: '$10' }} direction="column" gap="12">
 			<Flex>
 				<InnerContainer
 					align="center"
@@ -29,26 +29,24 @@ const CardMember = React.memo<CardBodyProps>(({ member, role, userSAdmin }) => {
 						ml: 0
 					}}
 				>
-					<Flex align="center">
-						<Flex align="center" gap="8">
-							<Icon
-								name="blob-personal"
-								css={{
-									width: '32px',
-									height: '$32',
-									zIndex: 1
-								}}
-							/>
+					<Flex align="center" css={{ width: '23%' }} gap="8">
+						<Icon
+							name="blob-personal"
+							css={{
+								width: '32px',
+								height: '$32',
+								zIndex: 1
+							}}
+						/>
 
-							<Flex align="center" gap="8">
-								<StyledMemberTitle>
-									{`${member.firstName} ${member.lastName}`}
-								</StyledMemberTitle>
-							</Flex>
+						<Flex align="center" gap="8">
+							<StyledMemberTitle>
+								{`${member.firstName} ${member.lastName}`}
+							</StyledMemberTitle>
 						</Flex>
 					</Flex>
 
-					<Flex align="center" gap="8">
+					<Flex align="center" css={{ width: '23%' }} gap="8" justify="center">
 						<ConfigurationSettings
 							handleCheckedChange={() => {}}
 							isChecked={false}
@@ -56,7 +54,7 @@ const CardMember = React.memo<CardBodyProps>(({ member, role, userSAdmin }) => {
 							title="Newbee"
 						/>
 					</Flex>
-					<CardEnd role={role} userSAdmin={userSAdmin} />
+					<CardEnd role={role} />
 				</InnerContainer>
 			</Flex>
 		</Flex>

--- a/frontend/src/components/Teams/CreateTeam/CardMember/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardMember/index.tsx
@@ -2,20 +2,20 @@ import React from 'react';
 
 import Icon from 'components/icons/Icon';
 import Flex from 'components/Primitives/Flex';
-import { Team } from 'types/team/team';
+import { User } from '../../../../types/user/user';
 import { ConfigurationSettings } from '../../../Board/Settings/partials/ConfigurationSettings';
 import { CardEnd } from '../CardEnd';
 import { InnerContainer, StyledMemberTitle } from './styles';
 
 type CardBodyProps = {
-	userId: string;
-	userSAdmin: boolean;
-	team?: Team;
+	userSAdmin: boolean | undefined;
+	member: User;
+	role: string;
 };
 
-const CardMember = React.memo<CardBodyProps>(({ userId, userSAdmin }) => {
+const CardMember = React.memo<CardBodyProps>(({ member, role, userSAdmin }) => {
 	return (
-		<Flex css={{ flex: '1 1 0' }} direction="column" gap="12">
+		<Flex css={{ flex: '1 1 0', marginBottom: '$10' }} direction="column" gap="12">
 			<Flex>
 				<InnerContainer
 					align="center"
@@ -41,7 +41,9 @@ const CardMember = React.memo<CardBodyProps>(({ userId, userSAdmin }) => {
 							/>
 
 							<Flex align="center" gap="8">
-								<StyledMemberTitle>Cátia Antunes</StyledMemberTitle>
+								<StyledMemberTitle>
+									{`${member.firstName} ${member.lastName}`}
+								</StyledMemberTitle>
 							</Flex>
 						</Flex>
 					</Flex>
@@ -54,7 +56,7 @@ const CardMember = React.memo<CardBodyProps>(({ userId, userSAdmin }) => {
 							title="Newbee"
 						/>
 					</Flex>
-					<CardEnd userId={userId} userSAdmin={userSAdmin} />
+					<CardEnd role={role} userSAdmin={userSAdmin} />
 				</InnerContainer>
 			</Flex>
 		</Flex>

--- a/frontend/src/components/Teams/CreateTeam/ListCardsMembers/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListCardsMembers/index.tsx
@@ -1,21 +1,40 @@
-import React from 'react';
+import React, { useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
+import { useRecoilValue } from 'recoil';
 
 import Flex from 'components/Primitives/Flex';
 import Text from 'components/Primitives/Text';
+import { membersListState } from '../../../../store/team/atom/team.atom';
 import CardMember from '../CardMember';
+import { ListMembers } from '../ListMembers';
+import { ScrollableContent } from './styles';
 
 const TeamMembersList = () => {
-	const { data: session } = useSession();
+	const [isOpen, setIsOpen] = useState(false);
 
-	return session ? (
-		<Flex css={{ mt: '$48' }} direction="column">
+	const { data: session } = useSession({ required: true });
+	const membersList = useRecoilValue(membersListState);
+
+	const scrollRef = useRef<HTMLDivElement>(null);
+
+	return (
+		<Flex css={{ mt: '$38' }} direction="column">
 			<Text css={{ mb: '$16' }} heading="3">
 				Team Members
 			</Text>
-			<CardMember userId={session.user.id} userSAdmin={session.isSAdmin} />
+			<ScrollableContent direction="column" justify="start" ref={scrollRef}>
+				{membersList?.map((member) => (
+					<CardMember
+						key={member.user._id}
+						member={member.user}
+						role={member.role}
+						userSAdmin={session?.isSAdmin}
+					/>
+				))}
+				<ListMembers isOpen={isOpen} setIsOpen={setIsOpen} />
+			</ScrollableContent>
 		</Flex>
-	) : null;
+	);
 };
 
 export default TeamMembersList;

--- a/frontend/src/components/Teams/CreateTeam/ListCardsMembers/styles.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListCardsMembers/styles.tsx
@@ -1,0 +1,11 @@
+import { styled } from '../../../../styles/stitches/stitches.config';
+import Flex from '../../../Primitives/Flex';
+
+const ScrollableContent = styled(Flex, {
+	mt: '$24',
+	maxHeight: 'calc(100vh - 500px)',
+	overflowY: 'auto',
+	pb: '$10'
+});
+
+export { ScrollableContent };

--- a/frontend/src/components/Teams/CreateTeam/TeamName.tsx
+++ b/frontend/src/components/Teams/CreateTeam/TeamName.tsx
@@ -6,7 +6,7 @@ type Props = { teamName: string };
 const TeamName = ({ teamName }: Props) => {
 	return (
 		<>
-			<Text css={{ mb: '$16' }} heading="3">
+			<Text css={{ mb: '$12' }} heading="3">
 				Team Name
 			</Text>
 

--- a/frontend/src/components/Teams/CreateTeam/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 import { useRouter } from 'next/router';
 import { joiResolver } from '@hookform/resolvers/joi';
@@ -17,14 +17,11 @@ import Icon from '../../icons/Icon';
 import Button from '../../Primitives/Button';
 import Text from '../../Primitives/Text';
 import TeamMembersList from './ListCardsMembers';
-import { ListMembers } from './ListMembers';
 import TeamName from './TeamName';
 import TipBar from './TipBar';
 
 const CreateTeam = () => {
 	const router = useRouter();
-
-	const [isOpen, setIsOpen] = useState(false);
 
 	const methods = useForm<{ text: string }>({
 		mode: 'onBlur',
@@ -50,7 +47,6 @@ const CreateTeam = () => {
 				<Text color="primary800" heading={3} weight="bold">
 					Create New Team
 				</Text>
-
 				<Button isIcon onClick={handleBack}>
 					<Icon name="close" />
 				</Button>
@@ -62,7 +58,6 @@ const CreateTeam = () => {
 							<FormProvider {...methods}>
 								<TeamName teamName={teamName} />
 								<TeamMembersList />
-								<ListMembers isOpen={isOpen} setIsOpen={setIsOpen} />
 							</FormProvider>
 						</InnerContent>
 						<ButtonsContainer gap="24" justify="end">

--- a/frontend/src/pages/teams/new.tsx
+++ b/frontend/src/pages/teams/new.tsx
@@ -1,16 +1,20 @@
 import { useEffect } from 'react';
 import { dehydrate, QueryClient, useQuery } from 'react-query';
 import { GetServerSideProps, GetServerSidePropsContext, NextPage } from 'next';
+import { useSession } from 'next-auth/react';
 import { useSetRecoilState } from 'recoil';
 
 import { getAllUsers } from '../../api/userService';
 import requireAuthentication from '../../components/HOC/requireAuthentication';
 import CreateTeam from '../../components/Teams/CreateTeam';
-import { usersListState } from '../../store/team/atom/team.atom';
+import { membersListState, usersListState } from '../../store/team/atom/team.atom';
 import { toastState } from '../../store/toast/atom/toast.atom';
+import { TeamUser } from '../../types/team/team.user';
+import { TeamUserRoles } from '../../utils/enums/team.user.roles';
 import { ToastStateEnum } from '../../utils/enums/toast-types';
 
 const NewTeam: NextPage = () => {
+	const { data: session } = useSession({ required: true });
 	const setToastState = useSetRecoilState(toastState);
 
 	const { data } = useQuery(['users'], () => getAllUsers(), {
@@ -26,14 +30,24 @@ const NewTeam: NextPage = () => {
 	});
 
 	const setUsersListState = useSetRecoilState(usersListState);
+	const setMembersListState = useSetRecoilState(membersListState);
 
 	useEffect(() => {
+		const listMembers: TeamUser[] | undefined = [];
 		const usersWithChecked = data?.map((user) => {
-			return { ...user, isChecked: false };
+			if (user._id === session?.user.id) {
+				listMembers.push({
+					user,
+					role: TeamUserRoles.ADMIN
+				});
+			}
+			return { ...user, isChecked: user._id === session?.user.id };
 		});
 
 		setUsersListState(usersWithChecked);
-	}, [data, setUsersListState]);
+
+		setMembersListState(listMembers);
+	}, [data, session?.user.id, setMembersListState, setUsersListState]);
 
 	return <CreateTeam />;
 };

--- a/frontend/src/store/team/atom/team.atom.tsx
+++ b/frontend/src/store/team/atom/team.atom.tsx
@@ -1,11 +1,11 @@
 import { atom } from 'recoil';
 
-import { CreateTeamUser } from '../../../types/team/team.user';
+import { TeamUser } from '../../../types/team/team.user';
 import { UserList } from '../../../types/team/userList';
 
-export const membersListState = atom<CreateTeamUser[] | undefined>({
+export const membersListState = atom<TeamUser[]>({
 	key: 'membersList',
-	default: undefined
+	default: []
 });
 
 export const usersListState = atom<UserList[] | undefined>({

--- a/frontend/src/types/team/team.user.ts
+++ b/frontend/src/types/team/team.user.ts
@@ -4,8 +4,8 @@ import { User } from '../user/user';
 export interface TeamUser {
 	user: User;
 	role: TeamUserRoles;
-	_id: string;
-	team: string;
+	_id?: string;
+	team?: string;
 }
 
 export interface CreateTeamUser {


### PR DESCRIPTION

Relates to #544 

## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/59372326/199805586-4c0f1595-ad94-45ea-a401-43e34f38fab3.png)



## Proposed Changes

  - Instead of just keep a list of objects with userId and role, now the object is keeping the whole user and his role (they are needed in the card member)
  -The members list is initialise with the user that is creating the team with the role as 'Admin'. This is being done at the same time that the prop isChecked is being added to each user.  
  -When the members are added, the cards with each user are rendered.


This pull request closes #544