### PR TITLE
[REFACTOR]: list boards without showing subboards 

### DIFF
--- a/frontend/src/components/CardBoard/CardBody/CardBody.tsx
+++ b/frontend/src/components/CardBoard/CardBody/CardBody.tsx
@@ -106,7 +106,7 @@ const CardBody = React.memo<CardBodyProps>(
 	}) => {
 		const { _id: id, columns, users, team, dividedBoards, isSubBoard } = board;
 		const countDividedBoards = dividedBoardsCount || dividedBoards.length;
-		const [openSubBoards, setSubBoardsOpen] = useState(true);
+		const [openSubBoards, setSubBoardsOpen] = useState(false);
 
 		const newBoard = useRecoilValue(newBoardState);
 


### PR DESCRIPTION

Relates to #556


## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/59372326/200307062-d0bb4244-799f-4d26-ba54-d0e6261c1fdc.png)


## Proposed Changes

  - Only the main boards card are shown in the list of boards page by default.


This pull request closes #556 