### PR TITLE
[FEATURE]: show boards members 

### DIFF
--- a/frontend/src/components/Board/Header/index.tsx
+++ b/frontend/src/components/Board/Header/index.tsx
@@ -149,6 +149,7 @@ const BoardHeader = () => {
 							{isSubBoard ? title.replace('board', '') : team.name}
 						</Text>
 						<CardAvatars
+							isBoardsPage
 							listUsers={users}
 							responsible={false}
 							teamAdmins={false}

--- a/frontend/src/components/CardBoard/CardAvatars.tsx
+++ b/frontend/src/components/CardBoard/CardAvatars.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import Avatar from 'components/Primitives/Avatar';
 import Flex from 'components/Primitives/Flex';
@@ -6,6 +6,7 @@ import Tooltip from 'components/Primitives/Tooltip';
 import { User } from 'types/user/user';
 import { BoardUserRoles } from 'utils/enums/board.user.roles';
 import { TeamUserRoles } from 'utils/enums/team.user.roles';
+import { IconButton } from './styles';
 
 type ListUsersType = {
 	user: User | string;
@@ -21,10 +22,26 @@ type CardAvatarProps = {
 	userId: string;
 	myBoards?: boolean;
 	haveError?: boolean;
+	isBoardsPage?: boolean;
 };
 
 const CardAvatars = React.memo<CardAvatarProps>(
-	({ listUsers, teamAdmins, stakeholders, userId, haveError, responsible, myBoards }) => {
+	({
+		listUsers,
+		teamAdmins,
+		stakeholders,
+		userId,
+		haveError,
+		responsible,
+		myBoards,
+		isBoardsPage
+	}) => {
+		const [viewAllUsers, setViewAllUsers] = useState(false);
+
+		const handleViewAllUsers = useCallback(() => {
+			setViewAllUsers(!viewAllUsers);
+		}, [viewAllUsers]);
+
 		const data = useMemo(() => {
 			if (responsible)
 				return listUsers
@@ -56,12 +73,12 @@ const CardAvatars = React.memo<CardAvatarProps>(
 
 		const getInitials = useCallback(
 			(user: User | undefined, index) => {
-				if (usersCount - 1 > index && index > 1) {
+				if (!viewAllUsers && usersCount - 1 > index && index > 1) {
 					return `+${usersCount - 2}`;
 				}
 				return user ?? '--';
 			},
-			[usersCount]
+			[usersCount, viewAllUsers]
 		);
 
 		const stakeholdersColors = useMemo(
@@ -77,15 +94,30 @@ const CardAvatars = React.memo<CardAvatarProps>(
 			(value: User | string, avatarColor, idx) => {
 				if (typeof value === 'string') {
 					return (
-						<Avatar
+						<IconButton
 							key={`${value}-${idx}-${Math.random()}`}
-							colors={avatarColor}
-							css={{ position: 'relative', ml: idx > 0 ? '-7px' : 0 }}
-							fallbackText={value}
-							id={value}
-							isDefaultColor={value === userId}
-							size={32}
-						/>
+							aria-hidden="true"
+							disabled={!isBoardsPage}
+							type="button"
+							css={{
+								'&:hover': isBoardsPage
+									? {
+											cursor: 'pointer'
+									  }
+									: 'none'
+							}}
+							onClick={handleViewAllUsers}
+						>
+							<Avatar
+								key={`${value}-${idx}-${Math.random()}`}
+								colors={avatarColor}
+								css={{ position: 'relative', ml: idx > 0 ? '-7px' : 0 }}
+								fallbackText={value}
+								id={value}
+								isDefaultColor={value === userId}
+								size={32}
+							/>
+						</IconButton>
 					);
 				}
 
@@ -95,7 +127,19 @@ const CardAvatars = React.memo<CardAvatarProps>(
 						key={`${value}-${idx}-${Math.random()}`}
 						content={`${value.firstName} ${value.lastName}`}
 					>
-						<div>
+						<IconButton
+							aria-hidden="true"
+							disabled={!isBoardsPage}
+							type="button"
+							css={{
+								'&:hover': isBoardsPage
+									? {
+											cursor: 'pointer'
+									  }
+									: 'none'
+							}}
+							onClick={handleViewAllUsers}
+						>
 							<Avatar
 								key={`${value}-${idx}-${Math.random()}`}
 								colors={avatarColor}
@@ -105,12 +149,21 @@ const CardAvatars = React.memo<CardAvatarProps>(
 								isDefaultColor={value._id === userId}
 								size={32}
 							/>
-						</div>
+						</IconButton>
 					</Tooltip>
 				);
 			},
-			[userId]
+			[handleViewAllUsers, userId, isBoardsPage]
 		);
+
+		const numberOfAvatars = useMemo(() => {
+			if (!myBoards) {
+				if (viewAllUsers && isBoardsPage) return data.length;
+				return 3;
+			}
+
+			return 1;
+		}, [data.length, isBoardsPage, myBoards, viewAllUsers]);
 
 		return (
 			<Flex align="center" css={{ height: 'fit-content', overflow: 'hidden' }}>
@@ -122,7 +175,7 @@ const CardAvatars = React.memo<CardAvatarProps>(
 								index
 							);
 					  })
-					: (data.slice(0, !myBoards ? 3 : 1) as User[]).map(
+					: (data.slice(0, numberOfAvatars) as User[]).map(
 							(user: User, index: number) => {
 								return renderAvatar(
 									getInitials(user, index),

--- a/frontend/src/components/CardBoard/CardAvatars.tsx
+++ b/frontend/src/components/CardBoard/CardAvatars.tsx
@@ -60,7 +60,7 @@ const CardAvatars = React.memo<CardAvatarProps>(
 			}
 
 			return listUsers.reduce((acc: User[], userFound: ListUsersType) => {
-				if ((userFound.user as User)._id === userId) {
+				if ((userFound.user as User)?._id === userId) {
 					acc.unshift(userFound.user as User);
 				} else {
 					acc.push(userFound.user as User);

--- a/frontend/src/components/CardBoard/CardAvatars.tsx
+++ b/frontend/src/components/CardBoard/CardAvatars.tsx
@@ -158,12 +158,11 @@ const CardAvatars = React.memo<CardAvatarProps>(
 
 		const numberOfAvatars = useMemo(() => {
 			if (!myBoards) {
-				if (viewAllUsers && isBoardsPage) return usersCount;
-				return 3;
+				return viewAllUsers && isBoardsPage ? data.length : 3;
 			}
 
 			return 1;
-		}, [isBoardsPage, myBoards, usersCount, viewAllUsers]);
+		}, [data.length, isBoardsPage, myBoards, viewAllUsers]);
 
 		return (
 			<Flex align="center" css={{ height: 'fit-content', overflow: 'hidden' }}>

--- a/frontend/src/components/CardBoard/CardAvatars.tsx
+++ b/frontend/src/components/CardBoard/CardAvatars.tsx
@@ -158,12 +158,12 @@ const CardAvatars = React.memo<CardAvatarProps>(
 
 		const numberOfAvatars = useMemo(() => {
 			if (!myBoards) {
-				if (viewAllUsers && isBoardsPage) return data.length;
+				if (viewAllUsers && isBoardsPage) return usersCount;
 				return 3;
 			}
 
 			return 1;
-		}, [data.length, isBoardsPage, myBoards, viewAllUsers]);
+		}, [isBoardsPage, myBoards, usersCount, viewAllUsers]);
 
 		return (
 			<Flex align="center" css={{ height: 'fit-content', overflow: 'hidden' }}>

--- a/frontend/src/components/CardBoard/styles.tsx
+++ b/frontend/src/components/CardBoard/styles.tsx
@@ -1,0 +1,8 @@
+import { styled } from 'styles/stitches/stitches.config';
+
+const IconButton = styled('button', {
+	border: 'none',
+	backgroundColor: 'transparent'
+});
+
+export { IconButton };


### PR DESCRIPTION

Relates to #555 

## Proposed Changes

  - If the user is in a board or sub-board page, he can click on the avatars icon to see all the users in that board. If he clicks again on an avatar, the list goes back to the default (only 3 avatars)

This pull request closes #555 