### PR TITLE
[BUG]: remove space between avatar icons

### DIFF
--- a/frontend/src/components/CardBoard/styles.tsx
+++ b/frontend/src/components/CardBoard/styles.tsx
@@ -2,7 +2,8 @@ import { styled } from 'styles/stitches/stitches.config';
 
 const IconButton = styled('button', {
 	border: 'none',
-	backgroundColor: 'transparent'
+	backgroundColor: 'transparent',
+	padding: 0
 });
 
 export { IconButton };


### PR DESCRIPTION

Fixes #562

## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/59372326/200581152-cb5382d4-62f4-4c62-94b0-407116d60ca7.png)


## Proposed Changes

  - Padding removed from buttonIcon


This pull request closes #562 