### PR TITLE
feat: user card on the list

### DIFF
--- a/backend/src/modules/teams/interfaces/users-with-teams.interface.ts
+++ b/backend/src/modules/teams/interfaces/users-with-teams.interface.ts
@@ -1,0 +1,6 @@
+import { ObjectId } from 'mongoose';
+
+export interface UsersWithTeams {
+	_id: ObjectId;
+	teamsNames: Array<Array<string>>;
+}

--- a/backend/src/modules/teams/interfaces/users-with-teams.interface.ts
+++ b/backend/src/modules/teams/interfaces/users-with-teams.interface.ts
@@ -1,6 +1,0 @@
-import { ObjectId } from 'mongoose';
-
-export interface UsersWithTeams {
-	_id: ObjectId;
-	teamsNames: Array<Array<string>>;
-}

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -124,10 +124,9 @@ export default class GetTeamService implements GetTeamServiceInterface {
 			{
 				$unset: [
 					'_id',
-					'user.currentHashedRefreshToken',
-					'user.isSAdmin',
-					'user.joinedAt',
-					'user.isDeleted'
+					'userWithTeam.currentHashedRefreshToken',
+					'userWithTeam.joinedAt',
+					'userWithTeam.isDeleted'
 				]
 			},
 			{

--- a/frontend/src/api/userService.tsx
+++ b/frontend/src/api/userService.tsx
@@ -1,7 +1,12 @@
 import { GetServerSidePropsContext } from 'next';
 
 import fetchData from '@/utils/fetchData';
-import { User } from '../types/user/user';
+import { User, UserWithTeams } from '../types/user/user';
 
 export const getAllUsers = (context?: GetServerSidePropsContext): Promise<User[]> =>
   fetchData(`/users`, { context, serverSide: !!context });
+
+export const getAllUsersWithTeams = (
+  context?: GetServerSidePropsContext,
+): Promise<UserWithTeams[]> =>
+  fetchData(`/users/users-with-teams`, { context, serverSide: !!context });

--- a/frontend/src/api/userService.tsx
+++ b/frontend/src/api/userService.tsx
@@ -8,5 +8,4 @@ export const getAllUsers = (context?: GetServerSidePropsContext): Promise<User[]
 
 export const getAllUsersWithTeams = (
   context?: GetServerSidePropsContext,
-): Promise<UserWithTeams[]> =>
-  fetchData(`/users/users-with-teams`, { context, serverSide: !!context });
+): Promise<UserWithTeams[]> => fetchData(`/users/teams`, { context, serverSide: !!context });

--- a/frontend/src/components/Users/UsersList/index.tsx
+++ b/frontend/src/components/Users/UsersList/index.tsx
@@ -1,0 +1,15 @@
+import { UserWithTeams } from '@/types/user/user';
+import React from 'react';
+
+import ListOfCards from './partials/ListOfCards';
+
+type UsersWithTeamsProps = {
+  usersWithTeams: UserWithTeams[];
+  isFetching: boolean;
+};
+
+const TeamsList = ({ isFetching, usersWithTeams }: UsersWithTeamsProps) => (
+  <ListOfCards isLoading={isFetching} usersWithTeams={usersWithTeams} />
+);
+
+export default TeamsList;

--- a/frontend/src/components/Users/UsersList/index.tsx
+++ b/frontend/src/components/Users/UsersList/index.tsx
@@ -1,15 +1,11 @@
-import { UserWithTeams } from '@/types/user/user';
 import React from 'react';
 
 import ListOfCards from './partials/ListOfCards';
 
 type UsersWithTeamsProps = {
-  usersWithTeams: UserWithTeams[];
   isFetching: boolean;
 };
 
-const TeamsList = ({ isFetching, usersWithTeams }: UsersWithTeamsProps) => (
-  <ListOfCards isLoading={isFetching} usersWithTeams={usersWithTeams} />
-);
+const TeamsList = ({ isFetching }: UsersWithTeamsProps) => <ListOfCards isLoading={isFetching} />;
 
 export default TeamsList;

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -68,13 +68,19 @@ const CardBody = React.memo<CardBodyProps>(({ user }) => {
         <Flex align="center" css={{ justifyContent: 'end', width: '$683' }} gap="8">
           <Flex align="center" css={{ ml: '$40', alignItems: 'center' }} gap="8">
             <Flex align="center" css={{ width: '$147' }}>
-              {teamsNames.length === 1 ? (
+              {!teamsNames && (
                 <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
-                  in {teamsNames.length} team
+                  in 0 teams
                 </Text>
-              ) : (
+              )}
+              {teamsNames?.length === 1 && (
                 <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
-                  in {teamsNames.length} teams
+                  in 1 team
+                </Text>
+              )}
+              {teamsNames?.length !== 0 && teamsNames?.length !== 1 && teamsNames && (
+                <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
+                  in {teamsNames?.length} teams
                 </Text>
               )}
             </Flex>

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -26,7 +26,7 @@ type CardBodyProps = {
 const CardBody = React.memo<CardBodyProps>(({ user }) => {
   const { data: session } = useSession();
 
-  const loggedUserIsSAdmin = session?.isSAdmin;
+  const loggedUserIsSAdmin = session?.user.isSAdmin;
 
   const { firstName, lastName, email, isSAdmin } = user.user;
   const { teamsNames } = user;

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -29,7 +29,7 @@ const CardBody = React.memo<CardBodyProps>(({ user }) => {
   const loggedUserIsSAdmin = session?.isSAdmin;
 
   const { firstName, lastName, email, isSAdmin } = user.user;
-  const { teams } = user;
+  const { teamsNames } = user;
 
   return (
     <Flex css={{ flex: '1 1 1', marginBottom: '$10' }} direction="column" gap="12">
@@ -68,13 +68,13 @@ const CardBody = React.memo<CardBodyProps>(({ user }) => {
         <Flex align="center" css={{ justifyContent: 'end', width: '$683' }} gap="8">
           <Flex align="center" css={{ ml: '$40', alignItems: 'center' }} gap="8">
             <Flex align="center" css={{ width: '$147' }}>
-              {teams.length === 1 ? (
+              {teamsNames.length === 1 ? (
                 <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
-                  in {teams.length} team
+                  in {teamsNames.length} team
                 </Text>
               ) : (
                 <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
-                  in {teams.length} teams
+                  in {teamsNames.length} teams
                 </Text>
               )}
             </Flex>

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -1,0 +1,102 @@
+import React from 'react';
+import { useSession } from 'next-auth/react';
+
+import { styled } from '@/styles/stitches/stitches.config';
+
+import Icon from '@/components/icons/Icon';
+import Box from '@/components/Primitives/Box';
+import Flex from '@/components/Primitives/Flex';
+import Separator from '@/components/Primitives/Separator';
+import Text from '@/components/Primitives/Text';
+import { UserWithTeams } from '@/types/user/user';
+import SuperAdmin from './SuperAdmin';
+import CardEnd from './CardEnd';
+import CardTitle from './CardTitle';
+
+const InnerContainer = styled(Flex, Box, {
+  px: '$32',
+  backgroundColor: '$white',
+  borderRadius: '$12',
+});
+
+type CardBodyProps = {
+  user: UserWithTeams;
+};
+
+const CardBody = React.memo<CardBodyProps>(({ user }) => {
+  const { data: session } = useSession();
+
+  const loggedUserIsSAdmin = session?.isSAdmin;
+
+  const { firstName, lastName, email, isSAdmin } = user.user;
+  const { teams } = user;
+
+  return (
+    <Flex css={{ flex: '1 1 1', marginBottom: '$10' }} direction="column" gap="12">
+      <InnerContainer
+        align="center"
+        elevation="1"
+        justify="between"
+        css={{
+          position: 'relative',
+          py: '$22',
+          maxHeight: '$76',
+          ml: 0,
+        }}
+      >
+        <Flex align="center" css={{ width: '25%' }} gap="8">
+          <Icon
+            name="blob-personal"
+            css={{
+              width: '$32',
+              height: '$32',
+              zIndex: 1,
+            }}
+          />
+
+          <Flex align="center" css={{ width: '$147' }} gap="8">
+            <CardTitle firstName={firstName} lastName={lastName} />
+          </Flex>
+
+          <Flex align="center" css={{ width: '$147' }}>
+            <Text color="primary300" size="sm">
+              {email}
+            </Text>
+          </Flex>
+        </Flex>
+
+        <Flex align="center" css={{ justifyContent: 'end', width: '$683' }} gap="8">
+          <Flex align="center" css={{ ml: '$40', alignItems: 'center' }} gap="8">
+            <Flex align="center" css={{ width: '$147' }}>
+              {teams.length === 1 ? (
+                <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
+                  in {teams.length} team
+                </Text>
+              ) : (
+                <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
+                  in {teams.length} teams
+                </Text>
+              )}
+            </Flex>
+          </Flex>
+          <Flex css={{ width: '40%' }} justify="end">
+            <Flex align="center" css={{ width: '$237' }} justify="start">
+              <SuperAdmin userSAdmin={isSAdmin} loggedUserSAdmin={loggedUserIsSAdmin} />
+            </Flex>
+            <Separator
+              orientation="vertical"
+              css={{
+                ml: '$20',
+                backgroundColor: '$primary100',
+                height: '$24 !important',
+              }}
+            />
+            <CardEnd user={user.user} userSAdmin={loggedUserIsSAdmin} />
+          </Flex>
+        </Flex>
+      </InnerContainer>
+    </Flex>
+  );
+});
+
+export default CardBody;

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -6,7 +6,6 @@ import { styled } from '@/styles/stitches/stitches.config';
 import Icon from '@/components/icons/Icon';
 import Box from '@/components/Primitives/Box';
 import Flex from '@/components/Primitives/Flex';
-import Separator from '@/components/Primitives/Separator';
 import Text from '@/components/Primitives/Text';
 import { UserWithTeams } from '@/types/user/user';
 import SuperAdmin from './SuperAdmin';
@@ -17,33 +16,37 @@ const InnerContainer = styled(Flex, Box, {
   px: '$32',
   backgroundColor: '$white',
   borderRadius: '$12',
+  position: 'relative',
+  py: '$22',
+  maxHeight: '$76',
+  ml: 0,
 });
 
 type CardBodyProps = {
-  user: UserWithTeams;
+  userWithTeams: UserWithTeams;
 };
 
-const CardBody = React.memo<CardBodyProps>(({ user }) => {
+const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
   const { data: session } = useSession();
 
   const loggedUserIsSAdmin = session?.user.isSAdmin;
 
-  const { firstName, lastName, email, isSAdmin } = user.user;
-  const { teamsNames } = user;
+  const { firstName, lastName, email, isSAdmin } = userWithTeams.user;
+  const { teamsNames } = userWithTeams;
+
+  const getTeamsCountText = () => {
+    if (teamsNames?.length === 1) {
+      return 'in 1 team';
+    }
+    if (teamsNames?.length !== 0 && teamsNames?.length !== 1 && teamsNames) {
+      return `in ${teamsNames.length} teams`;
+    }
+    return 'no teams';
+  };
 
   return (
     <Flex css={{ flex: '1 1 1', marginBottom: '$10' }} direction="column" gap="12">
-      <InnerContainer
-        align="center"
-        elevation="1"
-        justify="between"
-        css={{
-          position: 'relative',
-          py: '$22',
-          maxHeight: '$76',
-          ml: 0,
-        }}
-      >
+      <InnerContainer align="center" elevation="1" justify="between">
         <Flex align="center" css={{ width: '25%' }} gap="8">
           <Icon
             name="blob-personal"
@@ -68,36 +71,16 @@ const CardBody = React.memo<CardBodyProps>(({ user }) => {
         <Flex align="center" css={{ justifyContent: 'end', width: '$683' }} gap="8">
           <Flex align="center" css={{ ml: '$40', alignItems: 'center' }} gap="8">
             <Flex align="center" css={{ width: '$147' }}>
-              {!teamsNames && (
-                <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
-                  in 0 teams
-                </Text>
-              )}
-              {teamsNames?.length === 1 && (
-                <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
-                  in 1 team
-                </Text>
-              )}
-              {teamsNames?.length !== 0 && teamsNames?.length !== 1 && teamsNames && (
-                <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
-                  in {teamsNames?.length} teams
-                </Text>
-              )}
+              <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
+                {getTeamsCountText()}
+              </Text>
             </Flex>
           </Flex>
           <Flex css={{ width: '40%' }} justify="end">
             <Flex align="center" css={{ width: '$237' }} justify="start">
-              <SuperAdmin userSAdmin={isSAdmin} loggedUserSAdmin={loggedUserIsSAdmin} />
+              {loggedUserIsSAdmin && <SuperAdmin userSAdmin={isSAdmin} />}
             </Flex>
-            <Separator
-              orientation="vertical"
-              css={{
-                ml: '$20',
-                backgroundColor: '$primary100',
-                height: '$24 !important',
-              }}
-            />
-            <CardEnd user={user.user} userSAdmin={loggedUserIsSAdmin} />
+            {loggedUserIsSAdmin && <CardEnd user={userWithTeams.user} />}
           </Flex>
         </Flex>
       </InnerContainer>

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardEnd.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardEnd.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import Flex from '@/components/Primitives/Flex';
+import { User } from '@/types/user/user';
+import DeleteUser from './DeleteUser';
+import EditUser from './EditUser';
+
+type CardEndProps = {
+  user: User;
+  userSAdmin?: boolean;
+};
+
+const CardEnd: React.FC<CardEndProps> = React.memo(({ user, userSAdmin = undefined }) => {
+  CardEnd.defaultProps = {
+    userSAdmin: undefined,
+  };
+
+  if (userSAdmin) {
+    return (
+      <Flex css={{ alignItems: 'center' }}>
+        <Flex align="center" css={{ ml: '$24' }} gap="24">
+          <EditUser user={user} />
+        </Flex>
+        <Flex align="center" css={{ ml: '$24' }} gap="24">
+          <DeleteUser userId={user._id} firstName={user.firstName} lastName={user.lastName} />
+        </Flex>
+      </Flex>
+    );
+  }
+
+  return null;
+});
+
+export default CardEnd;

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardEnd.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardEnd.tsx
@@ -7,28 +7,17 @@ import EditUser from './EditUser';
 
 type CardEndProps = {
   user: User;
-  userSAdmin?: boolean;
 };
 
-const CardEnd: React.FC<CardEndProps> = React.memo(({ user, userSAdmin = undefined }) => {
-  CardEnd.defaultProps = {
-    userSAdmin: undefined,
-  };
-
-  if (userSAdmin) {
-    return (
-      <Flex css={{ alignItems: 'center' }}>
-        <Flex align="center" css={{ ml: '$24' }} gap="24">
-          <EditUser user={user} />
-        </Flex>
-        <Flex align="center" css={{ ml: '$24' }} gap="24">
-          <DeleteUser userId={user._id} firstName={user.firstName} lastName={user.lastName} />
-        </Flex>
-      </Flex>
-    );
-  }
-
-  return null;
-});
+const CardEnd: React.FC<CardEndProps> = React.memo(({ user }) => (
+  <Flex css={{ alignItems: 'center' }}>
+    <Flex align="center" css={{ ml: '$24' }} gap="24">
+      <EditUser user={user} />
+    </Flex>
+    <Flex align="center" css={{ ml: '$24' }} gap="24">
+      <DeleteUser userId={user._id} firstName={user.firstName} lastName={user.lastName} />
+    </Flex>
+  </Flex>
+));
 
 export default CardEnd;

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardTitle.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardTitle.tsx
@@ -1,0 +1,37 @@
+import { styled } from '@/styles/stitches/stitches.config';
+
+import Text from '@/components/Primitives/Text';
+
+type CardTitleProps = {
+  firstName: string;
+  lastName: string;
+};
+
+const StyledBoardTitle = styled(Text, {
+  fontWeight: '$bold',
+  fontSize: '$14',
+  letterSpacing: '$0-17',
+  '&[data-disabled="true"]': { opacity: 0.4 },
+  '@hover': {
+    '&:hover': {
+      '&[data-disabled="true"]': {
+        textDecoration: 'none',
+        cursor: 'default',
+      },
+      textDecoration: 'underline',
+      cursor: 'pointer',
+    },
+  },
+});
+
+const CardTitle: React.FC<CardTitleProps> = ({ firstName, lastName }) => {
+  const getTitle = () => (
+    <StyledBoardTitle>
+      {firstName} {lastName}
+    </StyledBoardTitle>
+  );
+
+  return getTitle();
+};
+
+export default CardTitle;

--- a/frontend/src/components/Users/UsersList/partials/CardUser/DeleteUser.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/DeleteUser.tsx
@@ -1,0 +1,35 @@
+import Icon from '@/components/icons/Icon';
+import AlertCustomDialog from '@/components/Primitives/AlertCustomDialog';
+import { AlertDialogTrigger } from '@/components/Primitives/AlertDialog';
+import Flex from '@/components/Primitives/Flex';
+import Tooltip from '@/components/Primitives/Tooltip';
+
+type DeleteUserProps = { userId: string; firstName: string; lastName: string };
+
+const DeleteUser: React.FC<DeleteUserProps> = ({ firstName, lastName }) => (
+  <AlertCustomDialog
+    cancelText="Cancel"
+    confirmText="Delete"
+    css={undefined}
+    defaultOpen={false}
+    text={`Do you really want to delete the user “${firstName} ${lastName}”?`}
+    title="Delete User"
+  >
+    <Tooltip content="Delete User">
+      <AlertDialogTrigger asChild>
+        <Flex pointer>
+          <Icon
+            name="trash-alt"
+            css={{
+              color: '$primary400',
+              width: '$20',
+              height: '$20',
+            }}
+          />
+        </Flex>
+      </AlertDialogTrigger>
+    </Tooltip>
+  </AlertCustomDialog>
+);
+
+export default DeleteUser;

--- a/frontend/src/components/Users/UsersList/partials/CardUser/EditUser.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/EditUser.tsx
@@ -1,0 +1,23 @@
+import Icon from '@/components/icons/Icon';
+import Flex from '@/components/Primitives/Flex';
+import Tooltip from '@/components/Primitives/Tooltip';
+import { User } from '@/types/user/user';
+
+type EditUserProps = { user: User };
+
+const EditUser: React.FC<EditUserProps> = () => (
+  <Tooltip content="Edit User">
+    <Flex pointer>
+      <Icon
+        name="edit"
+        css={{
+          color: '$primary400',
+          width: '$20',
+          height: '$20',
+        }}
+      />
+    </Flex>
+  </Tooltip>
+);
+
+export default EditUser;

--- a/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
@@ -6,41 +6,36 @@ import { useState } from 'react';
 
 type SuperAdminProps = {
   userSAdmin: boolean;
-  loggedUserSAdmin: boolean | undefined;
 };
 
-const SuperAdmin = ({ userSAdmin, loggedUserSAdmin }: SuperAdminProps) => {
+const SuperAdmin = ({ userSAdmin }: SuperAdminProps) => {
   const [checkedState, setCheckedState] = useState(userSAdmin);
 
   const handleSuperAdminChange = () => {
     setCheckedState(!checkedState);
   };
 
-  if (loggedUserSAdmin) {
-    return (
-      <Flex css={{ ml: '$20', display: 'flex', alignItems: 'center' }}>
-        <Switch checked={checkedState} onCheckedChange={handleSuperAdminChange}>
-          {checkedState && (
-            <SwitchThumb>
-              <Icon
-                name="check"
-                css={{
-                  width: '$14',
-                  height: '$14',
-                  color: '$successBase',
-                }}
-              />
-            </SwitchThumb>
-          )}
-          {!checkedState && <SwitchThumb />}
-        </Switch>
-        <Text css={{ ml: '$14' }} size="sm" weight="medium">
-          Super Admin
-        </Text>
-      </Flex>
-    );
-  }
-  return null;
+  return (
+    <Flex css={{ ml: '$20', display: 'flex', alignItems: 'center' }}>
+      <Switch checked={checkedState} onCheckedChange={handleSuperAdminChange}>
+        {checkedState && (
+          <SwitchThumb>
+            <Icon
+              name="check"
+              css={{
+                width: '$14',
+                height: '$14',
+                color: '$successBase',
+              }}
+            />
+          </SwitchThumb>
+        )}
+        {!checkedState && <SwitchThumb />}
+      </Switch>
+      <Text css={{ ml: '$14' }} size="sm" weight="medium">
+        Super Admin
+      </Text>
+    </Flex>
+  );
 };
-
 export default SuperAdmin;

--- a/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
@@ -1,0 +1,46 @@
+import Flex from '@/components/Primitives/Flex';
+import Text from '@/components/Primitives/Text';
+import { Switch, SwitchThumb } from '@/components/Primitives/Switch';
+import Icon from '@/components/icons/Icon';
+import { useState } from 'react';
+
+type SuperAdminProps = {
+  userSAdmin: boolean;
+  loggedUserSAdmin: boolean | undefined;
+};
+
+const SuperAdmin = ({ userSAdmin, loggedUserSAdmin }: SuperAdminProps) => {
+  const [checkedState, setCheckedState] = useState(userSAdmin);
+
+  const handleSuperAdminChange = () => {
+    setCheckedState(!checkedState);
+  };
+
+  if (loggedUserSAdmin) {
+    return (
+      <Flex css={{ ml: '$20', display: 'flex', alignItems: 'center' }}>
+        <Switch checked={checkedState} onCheckedChange={handleSuperAdminChange}>
+          {checkedState && (
+            <SwitchThumb>
+              <Icon
+                name="check"
+                css={{
+                  width: '$14',
+                  height: '$14',
+                  color: '$successBase',
+                }}
+              />
+            </SwitchThumb>
+          )}
+          {!checkedState && <SwitchThumb />}
+        </Switch>
+        <Text css={{ ml: '$14' }} size="sm" weight="medium">
+          Super Admin
+        </Text>
+      </Flex>
+    );
+  }
+  return null;
+};
+
+export default SuperAdmin;

--- a/frontend/src/components/Users/UsersList/partials/ListOfCards/index.tsx
+++ b/frontend/src/components/Users/UsersList/partials/ListOfCards/index.tsx
@@ -5,38 +5,42 @@ import Flex from '@/components/Primitives/Flex';
 import { UserWithTeams } from '@/types/user/user';
 import Text from '@/components/Primitives/Text';
 import SearchInput from '@/components/Teams/CreateTeam/ListMembers/SearchInput';
+import { useRecoilValue } from 'recoil';
+import { usersWithTeamsState } from '@/store/user/atoms/user.atom';
 import { ScrollableContent } from '../../../../Boards/MyBoards/styles';
 import CardBody from '../CardUser/CardBody';
 
 type ListOfCardsProp = {
-  usersWithTeams: UserWithTeams[];
   isLoading: boolean;
 };
 
-const ListOfCards = React.memo<ListOfCardsProp>(({ usersWithTeams, isLoading }) => (
-  <>
-    <Flex>
-      <Text css={{ fontWeight: '$bold', flex: 1, mt: '$36' }}>
-        {usersWithTeams.length} registered users
-      </Text>
-      <Flex css={{ width: '460px' }} direction="column" gap={16}>
-        <SearchInput icon="search" iconPosition="left" id="search" placeholder="Search user" />
-      </Flex>
-    </Flex>
-    <ScrollableContent direction="column" gap="24" justify="start" css={{ mt: '-1px' }}>
-      <Flex direction="column">
-        {usersWithTeams.map((user: UserWithTeams) => (
-          <CardBody key={user.user._id} user={user} />
-        ))}
-      </Flex>
-
-      {isLoading && (
-        <Flex justify="center">
-          <DotsLoading />
+const ListOfCards = React.memo<ListOfCardsProp>(({ isLoading }) => {
+  const usersWithTeams = useRecoilValue(usersWithTeamsState);
+  return (
+    <>
+      <Flex>
+        <Text css={{ fontWeight: '$bold', flex: 1, mt: '$36' }}>
+          {usersWithTeams?.length} registered users
+        </Text>
+        <Flex css={{ width: '460px' }} direction="column" gap={16}>
+          <SearchInput icon="search" iconPosition="left" id="search" placeholder="Search user" />
         </Flex>
-      )}
-    </ScrollableContent>
-  </>
-));
+      </Flex>
+      <ScrollableContent direction="column" gap="24" justify="start" css={{ mt: '-1px' }}>
+        <Flex direction="column">
+          {usersWithTeams?.map((user: UserWithTeams) => (
+            <CardBody key={user.user._id} user={user} />
+          ))}
+        </Flex>
+
+        {isLoading && (
+          <Flex justify="center">
+            <DotsLoading />
+          </Flex>
+        )}
+      </ScrollableContent>
+    </>
+  );
+});
 
 export default ListOfCards;

--- a/frontend/src/components/Users/UsersList/partials/ListOfCards/index.tsx
+++ b/frontend/src/components/Users/UsersList/partials/ListOfCards/index.tsx
@@ -29,7 +29,7 @@ const ListOfCards = React.memo<ListOfCardsProp>(({ isLoading }) => {
       <ScrollableContent direction="column" gap="24" justify="start" css={{ mt: '-1px' }}>
         <Flex direction="column">
           {usersWithTeams?.map((user: UserWithTeams) => (
-            <CardBody key={user.user._id} user={user} />
+            <CardBody key={user.user._id} userWithTeams={user} />
           ))}
         </Flex>
 

--- a/frontend/src/components/Users/UsersList/partials/ListOfCards/index.tsx
+++ b/frontend/src/components/Users/UsersList/partials/ListOfCards/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { DotsLoading } from '@/components/loadings/DotsLoading';
+import Flex from '@/components/Primitives/Flex';
+import { UserWithTeams } from '@/types/user/user';
+import Text from '@/components/Primitives/Text';
+import SearchInput from '@/components/Teams/CreateTeam/ListMembers/SearchInput';
+import { ScrollableContent } from '../../../../Boards/MyBoards/styles';
+import CardBody from '../CardUser/CardBody';
+
+type ListOfCardsProp = {
+  usersWithTeams: UserWithTeams[];
+  isLoading: boolean;
+};
+
+const ListOfCards = React.memo<ListOfCardsProp>(({ usersWithTeams, isLoading }) => (
+  <>
+    <Flex>
+      <Text css={{ fontWeight: '$bold', flex: 1, mt: '$36' }}>
+        {usersWithTeams.length} registered users
+      </Text>
+      <Flex css={{ width: '460px' }} direction="column" gap={16}>
+        <SearchInput icon="search" iconPosition="left" id="search" placeholder="Search user" />
+      </Flex>
+    </Flex>
+    <ScrollableContent direction="column" gap="24" justify="start" css={{ mt: '-1px' }}>
+      <Flex direction="column">
+        {usersWithTeams.map((user: UserWithTeams) => (
+          <CardBody key={user.user._id} user={user} />
+        ))}
+      </Flex>
+
+      {isLoading && (
+        <Flex justify="center">
+          <DotsLoading />
+        </Flex>
+      )}
+    </ScrollableContent>
+  </>
+));
+
+export default ListOfCards;

--- a/frontend/src/pages/users/index.tsx
+++ b/frontend/src/pages/users/index.tsx
@@ -46,7 +46,7 @@ const Users = () => {
     <Flex direction="column">
       <Suspense fallback={<LoadingPage />}>
         <QueryError>
-          <UsersList isFetching={isFetching} usersWithTeams={data} />
+          <UsersList isFetching={isFetching} />
         </QueryError>
       </Suspense>
     </Flex>

--- a/frontend/src/pages/users/index.tsx
+++ b/frontend/src/pages/users/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, Suspense } from 'react';
+import { ReactElement, Suspense, useEffect } from 'react';
 import { dehydrate, QueryClient, useQuery } from 'react-query';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { useSession } from 'next-auth/react';
@@ -32,7 +32,13 @@ const Users = () => {
     },
   });
 
-  setUsersWithTeamsState(data);
+  useEffect(() => {
+    if (!data) {
+      return;
+    }
+
+    setUsersWithTeamsState(data);
+  }, [data, setUsersWithTeamsState]);
 
   if (!session || !data) return null;
 

--- a/frontend/src/pages/users/index.tsx
+++ b/frontend/src/pages/users/index.tsx
@@ -8,16 +8,19 @@ import QueryError from '@/components/Errors/QueryError';
 import Layout from '@/components/layouts/Layout';
 import LoadingPage from '@/components/loadings/LoadingPage';
 import Flex from '@/components/Primitives/Flex';
-import { getAllUsers } from '../../api/userService';
+import UsersList from '@/components/Users/UsersList';
+import { getAllUsersWithTeams } from '../../api/userService';
 import requireAuthentication from '../../components/HOC/requireAuthentication';
 import { toastState } from '../../store/toast/atom/toast.atom';
+import { usersWithTeamsState } from '../../store/user/atoms/user.atom';
 import { ToastStateEnum } from '../../utils/enums/toast-types';
 
 const Users = () => {
   const { data: session } = useSession({ required: true });
   const setToastState = useSetRecoilState(toastState);
+  const setUsersWithTeamsState = useSetRecoilState(usersWithTeamsState);
 
-  const { data } = useQuery(['users'], () => getAllUsers(), {
+  const { data, isFetching } = useQuery(['usersWithTeams'], () => getAllUsersWithTeams(), {
     enabled: true,
     refetchOnWindowFocus: false,
     onError: () => {
@@ -29,15 +32,15 @@ const Users = () => {
     },
   });
 
+  setUsersWithTeamsState(data);
+
   if (!session || !data) return null;
 
   return (
     <Flex direction="column">
       <Suspense fallback={<LoadingPage />}>
         <QueryError>
-          {data.map((user) => (
-            <h2 key={user._id}>{user.email}</h2>
-          ))}
+          <UsersList isFetching={isFetching} usersWithTeams={data} />
         </QueryError>
       </Suspense>
     </Flex>
@@ -51,7 +54,7 @@ export default Users;
 export const getServerSideProps: GetServerSideProps = requireAuthentication(
   async (context: GetServerSidePropsContext) => {
     const queryClient = new QueryClient();
-    await queryClient.prefetchQuery('users', () => getAllUsers(context));
+    await queryClient.prefetchQuery('usersWithTeams', () => getAllUsersWithTeams(context));
 
     return {
       props: {

--- a/frontend/src/store/user/atoms/user.atom.tsx
+++ b/frontend/src/store/user/atoms/user.atom.tsx
@@ -1,3 +1,4 @@
+import { UserWithTeams } from '@/types/user/user';
 import { atom } from 'recoil';
 
 export const userState = atom({
@@ -9,4 +10,9 @@ export const userState = atom({
     id: '',
     strategy: '',
   },
+});
+
+export const usersWithTeamsState = atom<UserWithTeams[] | undefined>({
+  key: 'usersWithTeams',
+  default: [],
 });

--- a/frontend/src/types/user/user.ts
+++ b/frontend/src/types/user/user.ts
@@ -56,7 +56,7 @@ export interface ResetPasswordResponse {
 
 export interface UserWithTeams {
   user: User;
-  teams: string[];
+  teamsNames: string[];
 }
 
 export type UserZod = 'name' | 'email' | 'password' | 'passwordConf';

--- a/frontend/src/types/user/user.ts
+++ b/frontend/src/types/user/user.ts
@@ -54,4 +54,9 @@ export interface ResetPasswordResponse {
   message: string;
 }
 
+export interface UserWithTeams {
+  user: User;
+  teams: string[];
+}
+
 export type UserZod = 'name' | 'email' | 'password' | 'passwordConf';

--- a/frontend/src/types/user/user.ts
+++ b/frontend/src/types/user/user.ts
@@ -56,7 +56,7 @@ export interface ResetPasswordResponse {
 
 export interface UserWithTeams {
   user: User;
-  teamsNames: string[];
+  teamsNames?: string[];
 }
 
 export type UserZod = 'name' | 'email' | 'password' | 'passwordConf';


### PR DESCRIPTION
<!--
#597 
-->

Relates to #594 

## Screenshots (if visual changes)
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/99729373/204784189-e026916f-d9a5-4f40-86bb-5d3ccd07a2ef.png">


## Proposed Changes

  - user cards containing: name, email, number of teams, switch to change Super Admin role, edit button and delete button
  - number of registered users on the platform
  - search input to search for users
  - in the users with teams API, removed the "isSAdmin" from the $unset field, because we need this field for the cards



This pull request closes #597 