### PR TITLE
feat: user card actions

### DIFF
--- a/backend/src/libs/guards/superAdmin.guard.ts
+++ b/backend/src/libs/guards/superAdmin.guard.ts
@@ -1,14 +1,10 @@
-import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
 
 @Injectable()
 export class SuperAdminGuard implements CanActivate {
 	async canActivate(context: ExecutionContext) {
 		const request = context.switchToHttp().getRequest();
 
-		try {
-			return request.user.isSAdmin;
-		} catch (error) {
-			throw new ForbiddenException();
-		}
+		return request.user.isSAdmin;
 	}
 }

--- a/backend/src/libs/guards/superAdmin.guard.ts
+++ b/backend/src/libs/guards/superAdmin.guard.ts
@@ -1,0 +1,16 @@
+import { CanActivate, ExecutionContext, ForbiddenException, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class SuperAdminGuard implements CanActivate {
+	async canActivate(context: ExecutionContext) {
+		const request = context.switchToHttp().getRequest();
+
+		const user = request.user;
+
+		try {
+			return user.isSAdmin;
+		} catch (error) {
+			throw new ForbiddenException();
+		}
+	}
+}

--- a/backend/src/libs/guards/superAdmin.guard.ts
+++ b/backend/src/libs/guards/superAdmin.guard.ts
@@ -5,10 +5,8 @@ export class SuperAdminGuard implements CanActivate {
 	async canActivate(context: ExecutionContext) {
 		const request = context.switchToHttp().getRequest();
 
-		const user = request.user;
-
 		try {
-			return user.isSAdmin;
+			return request.user.isSAdmin;
 		} catch (error) {
 			throw new ForbiddenException();
 		}

--- a/backend/src/libs/repositories/interfaces/base.repository.interface.ts
+++ b/backend/src/libs/repositories/interfaces/base.repository.interface.ts
@@ -1,4 +1,4 @@
-import { UpdateQuery } from 'mongoose';
+import { QueryOptions, UpdateQuery } from 'mongoose';
 import { ModelProps, SelectedValues } from '../types';
 
 export interface BaseInterfaceRepository<T> {
@@ -14,5 +14,9 @@ export interface BaseInterfaceRepository<T> {
 
 	countDocuments(): Promise<number>;
 
-	findOneByFieldAndUpdate(value: ModelProps<T>, query: UpdateQuery<T>): Promise<T>;
+	findOneByFieldAndUpdate(
+		value: ModelProps<T>,
+		query: UpdateQuery<T>,
+		options?: QueryOptions<T>
+	): Promise<T>;
 }

--- a/backend/src/libs/repositories/mongo/mongo-generic.repository.ts
+++ b/backend/src/libs/repositories/mongo/mongo-generic.repository.ts
@@ -1,4 +1,4 @@
-import { Model, UpdateQuery } from 'mongoose';
+import { Model, QueryOptions, UpdateQuery } from 'mongoose';
 import { BaseInterfaceRepository } from '../interfaces/base.repository.interface';
 import { ModelProps, SelectedValues } from '../types';
 
@@ -39,7 +39,11 @@ export class MongoGenericRepository<T> implements BaseInterfaceRepository<T> {
 		return this._repository.countDocuments().exec();
 	}
 
-	findOneByFieldAndUpdate(value: ModelProps<T>, query: UpdateQuery<T>): Promise<T> {
-		return this._repository.findOneAndUpdate(value, query).exec();
+	findOneByFieldAndUpdate(
+		value: ModelProps<T>,
+		query: UpdateQuery<T>,
+		options?: QueryOptions<T>
+	): Promise<T> {
+		return this._repository.findOneAndUpdate(value, query, options).exec();
 	}
 }

--- a/backend/src/libs/repositories/mongo/mongo-generic.repository.ts
+++ b/backend/src/libs/repositories/mongo/mongo-generic.repository.ts
@@ -1,5 +1,5 @@
 import { ClientSession, FilterQuery, Model, QueryOptions, UpdateQuery } from 'mongoose';
-import { BaseInterfaceRepository, PopulateType} from '../interfaces/base.repository.interface';
+import { BaseInterfaceRepository, PopulateType } from '../interfaces/base.repository.interface';
 import { ModelProps, SelectedValues } from '../types';
 
 export class MongoGenericRepository<T> implements BaseInterfaceRepository<T> {
@@ -61,6 +61,7 @@ export class MongoGenericRepository<T> implements BaseInterfaceRepository<T> {
 		options?: QueryOptions<T>
 	): Promise<T> {
 		return this._repository.findOneAndUpdate(value, query, options).exec();
+	}
 
 	findOneAndRemove(id: string, withSession = false): Promise<T> {
 		return this._repository
@@ -104,6 +105,5 @@ export class MongoGenericRepository<T> implements BaseInterfaceRepository<T> {
 
 	async endSession() {
 		await this._session.endSession();
-
 	}
 }

--- a/backend/src/modules/teams/interfaces/users-with-teams.interface.ts
+++ b/backend/src/modules/teams/interfaces/users-with-teams.interface.ts
@@ -1,0 +1,6 @@
+import { ObjectId } from 'mongoose';
+
+export interface UsersWithTeams {
+	_id: ObjectId;
+	teamsNames: Array<Array<string>>;
+}

--- a/backend/src/modules/teams/interfaces/users-with-teams.interface.ts
+++ b/backend/src/modules/teams/interfaces/users-with-teams.interface.ts
@@ -1,6 +1,0 @@
-import { ObjectId } from 'mongoose';
-
-export interface UsersWithTeams {
-	_id: ObjectId;
-	teamsNames: Array<Array<string>>;
-}

--- a/backend/src/modules/users/applications/update.user.application.ts
+++ b/backend/src/modules/users/applications/update.user.application.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable } from '@nestjs/common';
-import RequestWithUser from 'src/libs/interfaces/requestWithUser.interface';
 import UpdateUserDto from '../dto/update.user.dto';
+import UserDto from '../dto/user.dto';
 import { UpdateUserApplication } from '../interfaces/applications/update.user.service.interface';
 import { UpdateUserService } from '../interfaces/services/update.user.service.interface';
 import { TYPES } from '../interfaces/types';
@@ -24,7 +24,7 @@ export class UpdateUserApplicationImpl implements UpdateUserApplication {
 		return this.updateUserService.checkEmail(token);
 	}
 
-	updateSuperAdmin(user: UpdateUserDto, requestUser: RequestWithUser) {
+	updateSuperAdmin(user: UpdateUserDto, requestUser: UserDto) {
 		return this.updateUserService.updateSuperAdmin(user, requestUser);
 	}
 }

--- a/backend/src/modules/users/applications/update.user.application.ts
+++ b/backend/src/modules/users/applications/update.user.application.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import RequestWithUser from 'src/libs/interfaces/requestWithUser.interface';
 import UpdateUserDto from '../dto/update.user.dto';
 import { UpdateUserApplication } from '../interfaces/applications/update.user.service.interface';
 import { UpdateUserService } from '../interfaces/services/update.user.service.interface';
@@ -23,7 +24,7 @@ export class UpdateUserApplicationImpl implements UpdateUserApplication {
 		return this.updateUserService.checkEmail(token);
 	}
 
-	updateSuperAdmin(user: UpdateUserDto) {
-		return this.updateUserService.updateSuperAdmin(user);
+	updateSuperAdmin(user: UpdateUserDto, requestUser: RequestWithUser) {
+		return this.updateUserService.updateSuperAdmin(user, requestUser);
 	}
 }

--- a/backend/src/modules/users/applications/update.user.application.ts
+++ b/backend/src/modules/users/applications/update.user.application.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import UpdateUserDto from '../dto/update.user.dto';
 import { UpdateUserApplication } from '../interfaces/applications/update.user.service.interface';
 import { UpdateUserService } from '../interfaces/services/update.user.service.interface';
 import { TYPES } from '../interfaces/types';
@@ -20,5 +21,9 @@ export class UpdateUserApplicationImpl implements UpdateUserApplication {
 
 	checkEmail(token: string) {
 		return this.updateUserService.checkEmail(token);
+	}
+
+	updateSuperAdmin(user: UpdateUserDto) {
+		return this.updateUserService.updateSuperAdmin(user);
 	}
 }

--- a/backend/src/modules/users/controller/users.controller.ts
+++ b/backend/src/modules/users/controller/users.controller.ts
@@ -112,7 +112,7 @@ export default class UsersController {
 	})
 	@UseGuards(SuperAdminGuard)
 	@Put('/sadmin')
-	async updateUserSuperAdmin(@Body() userData: UpdateUserDto) {
-		return await this.updateUserApp.updateSuperAdmin(userData);
+	updateUserSuperAdmin(@Body() userData: UpdateUserDto) {
+		return this.updateUserApp.updateSuperAdmin(userData);
 	}
 }

--- a/backend/src/modules/users/controller/users.controller.ts
+++ b/backend/src/modules/users/controller/users.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Body, Controller, Get, Inject, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Inject, Put, UseGuards } from '@nestjs/common';
 import {
 	ApiBadRequestResponse,
 	ApiBearerAuth,
@@ -21,7 +21,6 @@ import { GetUserApplication } from '../interfaces/applications/get.user.applicat
 import { UpdateUserApplication } from '../interfaces/applications/update.user.service.interface';
 import { TYPES } from '../interfaces/types';
 import { UsersWithTeamsResponse } from '../swagger/users-with-teams.swagger';
-import { UPDATE_FAILED } from 'src/libs/exceptions/messages';
 import { SuperAdminGuard } from 'src/libs/guards/superAdmin.guard';
 import { ForbiddenResponse } from '../../../libs/swagger/errors/forbidden.swagger';
 import { NotFoundResponse } from '../../../libs/swagger/errors/not-found.swagger';
@@ -114,10 +113,6 @@ export default class UsersController {
 	@UseGuards(SuperAdminGuard)
 	@Put('/sadmin')
 	async updateUserSuperAdmin(@Body() userData: UpdateUserDto) {
-		const user = await this.updateUserApp.updateSuperAdmin(userData);
-
-		if (!user) throw new BadRequestException(UPDATE_FAILED);
-
-		return user;
+		return await this.updateUserApp.updateSuperAdmin(userData);
 	}
 }

--- a/backend/src/modules/users/controller/users.controller.ts
+++ b/backend/src/modules/users/controller/users.controller.ts
@@ -114,6 +114,6 @@ export default class UsersController {
 	@UseGuards(SuperAdminGuard)
 	@Put('/sadmin')
 	updateUserSuperAdmin(@Req() request: RequestWithUser, @Body() userData: UpdateUserDto) {
-		return this.updateUserApp.updateSuperAdmin(userData, request);
+		return this.updateUserApp.updateSuperAdmin(userData, request.user);
 	}
 }

--- a/backend/src/modules/users/controller/users.controller.ts
+++ b/backend/src/modules/users/controller/users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Inject, Put, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Inject, Put, Req, UseGuards } from '@nestjs/common';
 import {
 	ApiBadRequestResponse,
 	ApiBearerAuth,
@@ -25,6 +25,7 @@ import { SuperAdminGuard } from 'src/libs/guards/superAdmin.guard';
 import { ForbiddenResponse } from '../../../libs/swagger/errors/forbidden.swagger';
 import { NotFoundResponse } from '../../../libs/swagger/errors/not-found.swagger';
 import { UpdateSuperAdminSwagger } from '../swagger/update.superadmin.swagger';
+import RequestWithUser from 'src/libs/interfaces/requestWithUser.interface';
 
 @ApiBearerAuth('access-token')
 @ApiTags('Users')
@@ -112,7 +113,7 @@ export default class UsersController {
 	})
 	@UseGuards(SuperAdminGuard)
 	@Put('/sadmin')
-	updateUserSuperAdmin(@Body() userData: UpdateUserDto) {
-		return this.updateUserApp.updateSuperAdmin(userData);
+	updateUserSuperAdmin(@Req() request: RequestWithUser, @Body() userData: UpdateUserDto) {
+		return this.updateUserApp.updateSuperAdmin(userData, request);
 	}
 }

--- a/backend/src/modules/users/dto/update.user.dto.ts
+++ b/backend/src/modules/users/dto/update.user.dto.ts
@@ -1,0 +1,30 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsMongoId, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export default class UpdateUserDto {
+	@ApiProperty()
+	@IsNotEmpty()
+	@IsMongoId()
+	@IsString()
+	@IsMongoId()
+	_id!: string;
+
+	@ApiProperty()
+	@IsOptional()
+	@IsString()
+	firstName?: string;
+
+	@ApiProperty()
+	@IsOptional()
+	@IsString()
+	lastName?: string;
+
+	@ApiProperty()
+	@IsOptional()
+	@IsString()
+	email?: string;
+
+	@ApiPropertyOptional({ default: false })
+	@IsOptional()
+	isSAdmin?: boolean;
+}

--- a/backend/src/modules/users/interfaces/applications/update.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/applications/update.user.service.interface.ts
@@ -1,7 +1,7 @@
 import { LeanDocument } from 'mongoose';
 import UpdateUserDto from '../../dto/update.user.dto';
 import User, { UserDocument } from '../../entities/user.schema';
-import RequestWithUser from 'src/libs/interfaces/requestWithUser.interface';
+import UserDto from '../../dto/user.dto';
 
 export interface UpdateUserApplication {
 	setCurrentRefreshToken(
@@ -17,8 +17,5 @@ export interface UpdateUserApplication {
 
 	checkEmail(token: string): Promise<string>;
 
-	updateSuperAdmin(
-		user: UpdateUserDto,
-		requestUser: RequestWithUser
-	): Promise<LeanDocument<UserDocument>>;
+	updateSuperAdmin(user: UpdateUserDto, requestUser: UserDto): Promise<LeanDocument<UserDocument>>;
 }

--- a/backend/src/modules/users/interfaces/applications/update.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/applications/update.user.service.interface.ts
@@ -1,5 +1,6 @@
 import { LeanDocument } from 'mongoose';
-import User, { UserDocument } from '../../entities/user.schema';
+import UpdateUserDto from '../../dto/update.user.dto';
+import { UserDocument } from '../../schemas/user.schema';
 
 export interface UpdateUserApplication {
 	setCurrentRefreshToken(
@@ -11,7 +12,9 @@ export interface UpdateUserApplication {
 		userEmail: string,
 		newPassword: string,
 		newPasswordConf: string
-	): Promise<User | null>;
+	): Promise<UserDocument | null>;
 
 	checkEmail(token: string): Promise<string>;
+
+	updateSuperAdmin(user: UpdateUserDto): Promise<LeanDocument<UserDocument>>;
 }

--- a/backend/src/modules/users/interfaces/applications/update.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/applications/update.user.service.interface.ts
@@ -1,6 +1,6 @@
 import { LeanDocument } from 'mongoose';
 import UpdateUserDto from '../../dto/update.user.dto';
-import { UserDocument } from '../../schemas/user.schema';
+import User, { UserDocument } from '../../entities/user.schema';
 
 export interface UpdateUserApplication {
 	setCurrentRefreshToken(
@@ -12,7 +12,7 @@ export interface UpdateUserApplication {
 		userEmail: string,
 		newPassword: string,
 		newPasswordConf: string
-	): Promise<UserDocument | null>;
+	): Promise<User | null>;
 
 	checkEmail(token: string): Promise<string>;
 

--- a/backend/src/modules/users/interfaces/applications/update.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/applications/update.user.service.interface.ts
@@ -1,6 +1,7 @@
 import { LeanDocument } from 'mongoose';
 import UpdateUserDto from '../../dto/update.user.dto';
 import User, { UserDocument } from '../../entities/user.schema';
+import RequestWithUser from 'src/libs/interfaces/requestWithUser.interface';
 
 export interface UpdateUserApplication {
 	setCurrentRefreshToken(
@@ -16,5 +17,8 @@ export interface UpdateUserApplication {
 
 	checkEmail(token: string): Promise<string>;
 
-	updateSuperAdmin(user: UpdateUserDto): Promise<LeanDocument<UserDocument>>;
+	updateSuperAdmin(
+		user: UpdateUserDto,
+		requestUser: RequestWithUser
+	): Promise<LeanDocument<UserDocument>>;
 }

--- a/backend/src/modules/users/interfaces/services/update.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/services/update.user.service.interface.ts
@@ -1,13 +1,17 @@
-import User from '../../entities/user.schema';
+import { LeanDocument } from 'mongoose';
+import UpdateUserDto from '../../dto/update.user.dto';
+import { UserDocument } from '../../schemas/user.schema';
 
 export interface UpdateUserService {
-	setCurrentRefreshToken(refreshToken: string, userId: string): Promise<User | null>;
+	setCurrentRefreshToken(refreshToken: string, userId: string): Promise<UserDocument | null>;
 
 	setPassword(
 		userEmail: string,
 		newPassword: string,
 		newPasswordConf: string
-	): Promise<User | null>;
+	): Promise<UserDocument | null>;
 
 	checkEmail(token: string): Promise<string>;
+
+	updateSuperAdmin(user: UpdateUserDto): Promise<LeanDocument<UserDocument>>;
 }

--- a/backend/src/modules/users/interfaces/services/update.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/services/update.user.service.interface.ts
@@ -1,6 +1,7 @@
 import { LeanDocument } from 'mongoose';
 import UpdateUserDto from '../../dto/update.user.dto';
 import User, { UserDocument } from '../../entities/user.schema';
+import RequestWithUser from 'src/libs/interfaces/requestWithUser.interface';
 
 export interface UpdateUserService {
 	setCurrentRefreshToken(refreshToken: string, userId: string): Promise<User | null>;
@@ -13,5 +14,8 @@ export interface UpdateUserService {
 
 	checkEmail(token: string): Promise<string>;
 
-	updateSuperAdmin(user: UpdateUserDto): Promise<LeanDocument<UserDocument>>;
+	updateSuperAdmin(
+		user: UpdateUserDto,
+		requestUser: RequestWithUser
+	): Promise<LeanDocument<UserDocument>>;
 }

--- a/backend/src/modules/users/interfaces/services/update.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/services/update.user.service.interface.ts
@@ -1,15 +1,15 @@
 import { LeanDocument } from 'mongoose';
 import UpdateUserDto from '../../dto/update.user.dto';
-import { UserDocument } from '../../schemas/user.schema';
+import User, { UserDocument } from '../../entities/user.schema';
 
 export interface UpdateUserService {
-	setCurrentRefreshToken(refreshToken: string, userId: string): Promise<UserDocument | null>;
+	setCurrentRefreshToken(refreshToken: string, userId: string): Promise<User | null>;
 
 	setPassword(
 		userEmail: string,
 		newPassword: string,
 		newPasswordConf: string
-	): Promise<UserDocument | null>;
+	): Promise<User | null>;
 
 	checkEmail(token: string): Promise<string>;
 

--- a/backend/src/modules/users/interfaces/services/update.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/services/update.user.service.interface.ts
@@ -1,7 +1,7 @@
 import { LeanDocument } from 'mongoose';
 import UpdateUserDto from '../../dto/update.user.dto';
 import User, { UserDocument } from '../../entities/user.schema';
-import RequestWithUser from 'src/libs/interfaces/requestWithUser.interface';
+import UserDto from '../../dto/user.dto';
 
 export interface UpdateUserService {
 	setCurrentRefreshToken(refreshToken: string, userId: string): Promise<User | null>;
@@ -14,8 +14,5 @@ export interface UpdateUserService {
 
 	checkEmail(token: string): Promise<string>;
 
-	updateSuperAdmin(
-		user: UpdateUserDto,
-		requestUser: RequestWithUser
-	): Promise<LeanDocument<UserDocument>>;
+	updateSuperAdmin(user: UpdateUserDto, requestUser: UserDto): Promise<LeanDocument<UserDocument>>;
 }

--- a/backend/src/modules/users/repository/user.repository.interface.ts
+++ b/backend/src/modules/users/repository/user.repository.interface.ts
@@ -5,4 +5,5 @@ export interface UserRepositoryInterface extends BaseInterfaceRepository<User> {
 	getById(userId: string): Promise<User>;
 	updateUserWithRefreshToken(refreshToken: string, userId: string): Promise<User>;
 	updateUserPassword(email: string, password: string): Promise<User>;
+	updateSuperAdmin(userId: string, isSAdmin: boolean): Promise<User>;
 }

--- a/backend/src/modules/users/repository/user.repository.ts
+++ b/backend/src/modules/users/repository/user.repository.ts
@@ -33,4 +33,8 @@ export class UserRepository
 			}
 		);
 	}
+
+	updateSuperAdmin(userId: string, isSAdmin: boolean) {
+		return this.findOneByFieldAndUpdate({ _id: userId }, { $set: { isSAdmin } }, { new: true });
+	}
 }

--- a/backend/src/modules/users/services/update.user.service.ts
+++ b/backend/src/modules/users/services/update.user.service.ts
@@ -11,6 +11,7 @@ import { TYPES } from '../interfaces/types';
 import { UserRepositoryInterface } from '../repository/user.repository.interface';
 import User, { UserDocument } from '../entities/user.schema';
 import { UPDATE_FAILED } from 'src/libs/exceptions/messages';
+import RequestWithUser from 'src/libs/interfaces/requestWithUser.interface';
 
 @Injectable()
 export default class updateUserServiceImpl implements UpdateUserService {
@@ -60,11 +61,16 @@ export default class updateUserServiceImpl implements UpdateUserService {
 		}
 	}
 
-	async updateSuperAdmin(user: UpdateUserDto) {
-		const userToUpdate = await this.userRepository.updateSuperAdmin(user._id, user.isSAdmin);
+	async updateSuperAdmin(user: UpdateUserDto, requestUser: RequestWithUser) {
+		if (requestUser.user._id.toString() === user._id) {
+			throw new BadRequestException(UPDATE_FAILED);
+		}
+		const userUpdated = await this.userRepository.updateSuperAdmin(user._id, user.isSAdmin);
 
-		if (!userToUpdate) throw new BadRequestException(UPDATE_FAILED);
+		if (!userUpdated) {
+			throw new BadRequestException(UPDATE_FAILED);
+		}
 
-		return userToUpdate;
+		return userUpdated;
 	}
 }

--- a/backend/src/modules/users/services/update.user.service.ts
+++ b/backend/src/modules/users/services/update.user.service.ts
@@ -11,7 +11,7 @@ import { TYPES } from '../interfaces/types';
 import { UserRepositoryInterface } from '../repository/user.repository.interface';
 import User, { UserDocument } from '../entities/user.schema';
 import { UPDATE_FAILED } from 'src/libs/exceptions/messages';
-import RequestWithUser from 'src/libs/interfaces/requestWithUser.interface';
+import UserDto from '../dto/user.dto';
 
 @Injectable()
 export default class updateUserServiceImpl implements UpdateUserService {
@@ -61,8 +61,8 @@ export default class updateUserServiceImpl implements UpdateUserService {
 		}
 	}
 
-	async updateSuperAdmin(user: UpdateUserDto, requestUser: RequestWithUser) {
-		if (requestUser.user._id.toString() === user._id) {
+	async updateSuperAdmin(user: UpdateUserDto, requestUser: UserDto) {
+		if (requestUser._id.toString() === user._id) {
 			throw new BadRequestException(UPDATE_FAILED);
 		}
 		const userUpdated = await this.userRepository.updateSuperAdmin(user._id, user.isSAdmin);

--- a/backend/src/modules/users/services/update.user.service.ts
+++ b/backend/src/modules/users/services/update.user.service.ts
@@ -5,6 +5,7 @@ import { encrypt } from 'src/libs/utils/bcrypt';
 import ResetPassword, {
 	ResetPasswordDocument
 } from 'src/modules/auth/schemas/reset-password.schema';
+import UpdateUserDto from '../dto/update.user.dto';
 import { UpdateUserService } from '../interfaces/services/update.user.service.interface';
 import { TYPES } from '../interfaces/types';
 import { UserRepositoryInterface } from '../repository/user.repository.interface';
@@ -54,5 +55,12 @@ export default class updateUserServiceImpl implements UpdateUserService {
 		if (!isTokenValid) {
 			throw new HttpException('EXPIRED_TOKEN', HttpStatus.BAD_REQUEST);
 		}
+	}
+
+	updateSuperAdmin(user: UpdateUserDto) {
+		return this.userModel
+			.findOneAndUpdate({ _id: user._id }, { $set: { isSAdmin: user.isSAdmin } }, { new: true })
+			.lean()
+			.exec();
 	}
 }

--- a/backend/src/modules/users/services/update.user.service.ts
+++ b/backend/src/modules/users/services/update.user.service.ts
@@ -60,9 +60,10 @@ export default class updateUserServiceImpl implements UpdateUserService {
 	}
 
 	updateSuperAdmin(user: UpdateUserDto) {
-		return this.userModel
-			.findOneAndUpdate({ _id: user._id }, { $set: { isSAdmin: user.isSAdmin } }, { new: true })
-			.lean()
-			.exec();
+		const userToUpdate = this.userRepository.updateSuperAdmin(user._id, user.isSAdmin);
+
+		if (!userToUpdate) throw new HttpException('UPDATE_FAILED', HttpStatus.BAD_REQUEST);
+
+		return userToUpdate;
 	}
 }

--- a/backend/src/modules/users/services/update.user.service.ts
+++ b/backend/src/modules/users/services/update.user.service.ts
@@ -1,4 +1,4 @@
-import { HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
+import { BadRequestException, HttpException, HttpStatus, Inject, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { encrypt } from 'src/libs/utils/bcrypt';
@@ -10,6 +10,7 @@ import { UpdateUserService } from '../interfaces/services/update.user.service.in
 import { TYPES } from '../interfaces/types';
 import { UserRepositoryInterface } from '../repository/user.repository.interface';
 import User, { UserDocument } from '../entities/user.schema';
+import { UPDATE_FAILED } from 'src/libs/exceptions/messages';
 
 @Injectable()
 export default class updateUserServiceImpl implements UpdateUserService {
@@ -62,7 +63,7 @@ export default class updateUserServiceImpl implements UpdateUserService {
 	async updateSuperAdmin(user: UpdateUserDto) {
 		const userToUpdate = await this.userRepository.updateSuperAdmin(user._id, user.isSAdmin);
 
-		if (!userToUpdate) throw new HttpException('UPDATE_FAILED', HttpStatus.BAD_REQUEST);
+		if (!userToUpdate) throw new BadRequestException(UPDATE_FAILED);
 
 		return userToUpdate;
 	}

--- a/backend/src/modules/users/services/update.user.service.ts
+++ b/backend/src/modules/users/services/update.user.service.ts
@@ -9,10 +9,12 @@ import UpdateUserDto from '../dto/update.user.dto';
 import { UpdateUserService } from '../interfaces/services/update.user.service.interface';
 import { TYPES } from '../interfaces/types';
 import { UserRepositoryInterface } from '../repository/user.repository.interface';
+import User, { UserDocument } from '../entities/user.schema';
 
 @Injectable()
 export default class updateUserServiceImpl implements UpdateUserService {
 	constructor(
+		@InjectModel(User.name) private userModel: Model<UserDocument>,
 		@Inject(TYPES.repository)
 		private readonly userRepository: UserRepositoryInterface,
 		@InjectModel(ResetPassword.name)

--- a/backend/src/modules/users/services/update.user.service.ts
+++ b/backend/src/modules/users/services/update.user.service.ts
@@ -59,8 +59,8 @@ export default class updateUserServiceImpl implements UpdateUserService {
 		}
 	}
 
-	updateSuperAdmin(user: UpdateUserDto) {
-		const userToUpdate = this.userRepository.updateSuperAdmin(user._id, user.isSAdmin);
+	async updateSuperAdmin(user: UpdateUserDto) {
+		const userToUpdate = await this.userRepository.updateSuperAdmin(user._id, user.isSAdmin);
 
 		if (!userToUpdate) throw new HttpException('UPDATE_FAILED', HttpStatus.BAD_REQUEST);
 

--- a/backend/src/modules/users/swagger/update.superadmin.swagger.ts
+++ b/backend/src/modules/users/swagger/update.superadmin.swagger.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UpdateSuperAdminSwagger {
+	@ApiProperty()
+	id!: string;
+
+	@ApiProperty()
+	isSAdmin!: boolean;
+}

--- a/frontend/src/__tests__/index.test.tsx
+++ b/frontend/src/__tests__/index.test.tsx
@@ -1,12 +1,15 @@
 import { QueryClient, QueryClientProvider } from 'react-query';
 import React from 'react';
 import { render } from '@testing-library/react';
+import { RecoilRoot } from 'recoil';
 import Home from '../pages';
 
 const queryClient = new QueryClient();
 
 export const Wrapper: React.FC = ({ children }) => (
-  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  <QueryClientProvider client={queryClient}>
+    <RecoilRoot>{children}</RecoilRoot>
+  </QueryClientProvider>
 );
 
 jest.mock('next/config', () => () => ({

--- a/frontend/src/api/userService.tsx
+++ b/frontend/src/api/userService.tsx
@@ -1,7 +1,7 @@
 import { GetServerSidePropsContext } from 'next';
 
 import fetchData from '@/utils/fetchData';
-import { User, UserWithTeams } from '../types/user/user';
+import { User, UserWithTeams, UpdateUserIsAdmin } from '../types/user/user';
 
 export const getAllUsers = (context?: GetServerSidePropsContext): Promise<User[]> =>
   fetchData(`/users`, { context, serverSide: !!context });
@@ -9,3 +9,6 @@ export const getAllUsers = (context?: GetServerSidePropsContext): Promise<User[]
 export const getAllUsersWithTeams = (
   context?: GetServerSidePropsContext,
 ): Promise<UserWithTeams[]> => fetchData(`/users/teams`, { context, serverSide: !!context });
+
+export const updateUserIsAdminRequest = (user: UpdateUserIsAdmin): Promise<User> =>
+  fetchData(`/users/sadmin/`, { method: 'PUT', data: user });

--- a/frontend/src/components/Board/Settings/partials/ConfigurationSettings/SwitchThumbComponent.tsx
+++ b/frontend/src/components/Board/Settings/partials/ConfigurationSettings/SwitchThumbComponent.tsx
@@ -1,0 +1,25 @@
+import Icon from '@/components/icons/Icon';
+import { SwitchThumb } from '@/components/Primitives/Switch';
+
+type Props = {
+  isChecked: boolean;
+  iconName: string;
+  color: string | undefined;
+};
+
+const SwitchThumbComponent = ({ isChecked, iconName, color }: Props) => (
+  <SwitchThumb variant="sm">
+    {isChecked && (
+      <Icon
+        name={iconName}
+        css={{
+          width: '$10',
+          height: '$10',
+          color: color || '$successBase',
+        }}
+      />
+    )}
+  </SwitchThumb>
+);
+
+export default SwitchThumbComponent;

--- a/frontend/src/components/Board/Settings/partials/ConfigurationSettings/index.tsx
+++ b/frontend/src/components/Board/Settings/partials/ConfigurationSettings/index.tsx
@@ -1,10 +1,10 @@
 import { ReactNode } from 'react';
 
-import Icon from '@/components/icons/Icon';
 import Flex from '@/components/Primitives/Flex';
-import { Switch, SwitchThumb } from '@/components/Primitives/Switch';
+import { Switch } from '@/components/Primitives/Switch';
 import Text from '@/components/Primitives/Text';
 import Tooltip from '@/components/Primitives/Tooltip';
+import SwitchThumbComponent from './SwitchThumbComponent';
 
 type Props = {
   title: string;
@@ -37,36 +37,14 @@ const ConfigurationSettings = ({
             onCheckedChange={handleCheckedChange}
             disabled={disabled}
           >
-            <SwitchThumb variant="sm">
-              {isChecked && (
-                <Icon
-                  name="check"
-                  css={{
-                    width: '$10',
-                    height: '$10',
-                    color: color || '$successBase',
-                  }}
-                />
-              )}
-            </SwitchThumb>
+            <SwitchThumbComponent isChecked={isChecked} iconName="check" color={color} />
           </Switch>
         </Flex>
       </Tooltip>
     )}
     {!styleVariant && (
       <Switch checked={isChecked} variant="sm" onCheckedChange={handleCheckedChange}>
-        <SwitchThumb variant="sm">
-          {isChecked && (
-            <Icon
-              name="check"
-              css={{
-                width: '$10',
-                height: '$10',
-                color: color || '$successBase',
-              }}
-            />
-          )}
-        </SwitchThumb>
+        <SwitchThumbComponent isChecked={isChecked} iconName="check" color={color} />
       </Switch>
     )}
     <Flex direction="column">

--- a/frontend/src/components/Board/Settings/partials/ConfigurationSettings/index.tsx
+++ b/frontend/src/components/Board/Settings/partials/ConfigurationSettings/index.tsx
@@ -4,6 +4,7 @@ import Icon from '@/components/icons/Icon';
 import Flex from '@/components/Primitives/Flex';
 import { Switch, SwitchThumb } from '@/components/Primitives/Switch';
 import Text from '@/components/Primitives/Text';
+import Tooltip from '@/components/Primitives/Tooltip';
 
 type Props = {
   title: string;
@@ -12,6 +13,8 @@ type Props = {
   handleCheckedChange: (checked: boolean) => void;
   children?: ReactNode;
   color?: string;
+  disabled?: boolean;
+  styleVariant?: boolean;
 };
 
 const ConfigurationSettings = ({
@@ -21,22 +24,51 @@ const ConfigurationSettings = ({
   handleCheckedChange,
   children,
   color,
+  disabled,
+  styleVariant,
 }: Props) => (
   <Flex gap={20}>
-    <Switch checked={isChecked} variant="sm" onCheckedChange={handleCheckedChange}>
-      <SwitchThumb variant="sm">
-        {isChecked && (
-          <Icon
-            name="check"
-            css={{
-              width: '$10',
-              height: '$10',
-              color: color || '$successBase',
-            }}
-          />
-        )}
-      </SwitchThumb>
-    </Switch>
+    {styleVariant && (
+      <Tooltip content="Can't change your own role">
+        <Flex>
+          <Switch
+            checked={isChecked}
+            variant="disabled"
+            onCheckedChange={handleCheckedChange}
+            disabled={disabled}
+          >
+            <SwitchThumb variant="sm">
+              {isChecked && (
+                <Icon
+                  name="check"
+                  css={{
+                    width: '$10',
+                    height: '$10',
+                    color: color || '$successBase',
+                  }}
+                />
+              )}
+            </SwitchThumb>
+          </Switch>
+        </Flex>
+      </Tooltip>
+    )}
+    {!styleVariant && (
+      <Switch checked={isChecked} variant="sm" onCheckedChange={handleCheckedChange}>
+        <SwitchThumb variant="sm">
+          {isChecked && (
+            <Icon
+              name="check"
+              css={{
+                width: '$10',
+                height: '$10',
+                color: color || '$successBase',
+              }}
+            />
+          )}
+        </SwitchThumb>
+      </Switch>
+    )}
     <Flex direction="column">
       <Text size="md" weight="medium">
         {title}

--- a/frontend/src/components/Primitives/Switch.tsx
+++ b/frontend/src/components/Primitives/Switch.tsx
@@ -22,6 +22,12 @@ const StyledSwitch = styled(SwitchPrimitive.Root, {
         height: '$20',
       },
       md: { flex: '0 0 $sizes$42', width: '$42', height: '$24' },
+      disabled: {
+        '&[data-state="checked"]': { backgroundColor: '$successBase', opacity: 0.5 },
+        flex: '0 0 $sizes$35',
+        width: '$35',
+        height: '$20',
+      },
     },
   },
   defaultVariants: {

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -8,6 +8,7 @@ import Box from '@/components/Primitives/Box';
 import Flex from '@/components/Primitives/Flex';
 import Text from '@/components/Primitives/Text';
 import { UserWithTeams } from '@/types/user/user';
+// eslint-disable-next-line import/no-named-as-default
 import SuperAdmin from './SuperAdmin';
 import CardEnd from './CardEnd';
 import CardTitle from './CardTitle';
@@ -78,7 +79,9 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
           </Flex>
           <Flex css={{ width: '40%' }} justify="end">
             <Flex align="center" css={{ width: '$237' }} justify="start">
-              {loggedUserIsSAdmin && <SuperAdmin userSAdmin={isSAdmin} />}
+              {loggedUserIsSAdmin && (
+                <SuperAdmin userSAdmin={isSAdmin} loggedUserSAdmin={loggedUserIsSAdmin} />
+              )}
             </Flex>
             {loggedUserIsSAdmin && <CardEnd user={userWithTeams.user} />}
           </Flex>

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -32,6 +32,7 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
   const { data: session } = useSession();
 
   const loggedUserIsSAdmin = session?.user.isSAdmin;
+  const userLoginId = session?.user.id;
 
   // eslint-disable-next-line @typescript-eslint/naming-convention
   const { firstName, lastName, email, isSAdmin, _id } = userWithTeams.user;
@@ -89,7 +90,7 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
           <Flex align="center" css={{ ml: '$40', alignItems: 'center' }} gap="8">
             <Flex align="center" css={{ width: '$147' }}>
               <Tooltip content={teamsSeparatedByComma}>
-                <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
+                <Text css={{ mr: '$2', fontWeight: '$bold', cursor: 'default' }} size="sm">
                   {getTeamsCountText()}
                 </Text>
               </Tooltip>
@@ -97,13 +98,12 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
           </Flex>
           <Flex css={{ width: '40%' }} justify="end">
             <Flex align="center" css={{ width: '$237' }} justify="start">
-              {loggedUserIsSAdmin && (
-                <SuperAdmin
-                  userSAdmin={isSAdmin}
-                  loggedUserSAdmin={loggedUserIsSAdmin}
-                  userId={_id}
-                />
-              )}
+              <SuperAdmin
+                userSAdmin={isSAdmin}
+                loggedUserSAdmin={loggedUserIsSAdmin}
+                userId={_id}
+                loggedUserId={userLoginId}
+              />
             </Flex>
             {loggedUserIsSAdmin && <CardEnd user={userWithTeams.user} />}
           </Flex>

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -48,15 +48,7 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
     return 'no teams';
   };
 
-  let teamsSeparatedByComma: string[] = [];
-  if (teamsNames) {
-    teamsSeparatedByComma = teamsNames?.map((team, index) => {
-      if (index !== teamsNames.length - 1) {
-        return team.concat(', ');
-      }
-      return team;
-    });
-  }
+  const teamsSeparatedByComma = teamsNames?.join(', ') || '';
 
   return (
     <Flex css={{ flex: '1 1 1', marginBottom: '$10' }} direction="column" gap="12">

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -8,7 +8,7 @@ import Box from '@/components/Primitives/Box';
 import Flex from '@/components/Primitives/Flex';
 import Text from '@/components/Primitives/Text';
 import { UserWithTeams } from '@/types/user/user';
-// eslint-disable-next-line import/no-named-as-default
+import Tooltip from '@/components/Primitives/Tooltip';
 import SuperAdmin from './SuperAdmin';
 import CardEnd from './CardEnd';
 import CardTitle from './CardTitle';
@@ -32,7 +32,8 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
 
   const loggedUserIsSAdmin = session?.user.isSAdmin;
 
-  const { firstName, lastName, email, isSAdmin } = userWithTeams.user;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  const { firstName, lastName, email, isSAdmin, _id } = userWithTeams.user;
   const { teamsNames } = userWithTeams;
 
   const getTeamsCountText = () => {
@@ -44,6 +45,16 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
     }
     return 'no teams';
   };
+
+  let teamsSeparatedByComma: string[] = [];
+  if (teamsNames) {
+    teamsSeparatedByComma = teamsNames?.map((team, index) => {
+      if (index !== teamsNames.length - 1) {
+        return team.concat(', ');
+      }
+      return team;
+    });
+  }
 
   return (
     <Flex css={{ flex: '1 1 1', marginBottom: '$10' }} direction="column" gap="12">
@@ -72,15 +83,21 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
         <Flex align="center" css={{ justifyContent: 'end', width: '$683' }} gap="8">
           <Flex align="center" css={{ ml: '$40', alignItems: 'center' }} gap="8">
             <Flex align="center" css={{ width: '$147' }}>
-              <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
-                {getTeamsCountText()}
-              </Text>
+              <Tooltip content={teamsSeparatedByComma}>
+                <Text css={{ mr: '$2', fontWeight: '$bold' }} size="sm">
+                  {getTeamsCountText()}
+                </Text>
+              </Tooltip>
             </Flex>
           </Flex>
           <Flex css={{ width: '40%' }} justify="end">
             <Flex align="center" css={{ width: '$237' }} justify="start">
               {loggedUserIsSAdmin && (
-                <SuperAdmin userSAdmin={isSAdmin} loggedUserSAdmin={loggedUserIsSAdmin} />
+                <SuperAdmin
+                  userSAdmin={isSAdmin}
+                  loggedUserSAdmin={loggedUserIsSAdmin}
+                  userId={_id}
+                />
               )}
             </Flex>
             {loggedUserIsSAdmin && <CardEnd user={userWithTeams.user} />}

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -9,6 +9,7 @@ import Flex from '@/components/Primitives/Flex';
 import Text from '@/components/Primitives/Text';
 import { UserWithTeams } from '@/types/user/user';
 import Tooltip from '@/components/Primitives/Tooltip';
+import Link from 'next/link';
 import SuperAdmin from './SuperAdmin';
 import CardEnd from './CardEnd';
 import CardTitle from './CardTitle';
@@ -70,7 +71,11 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
           />
 
           <Flex align="center" css={{ width: '$147' }} gap="8">
-            <CardTitle firstName={firstName} lastName={lastName} />
+            <Link href={`/users/${userWithTeams.user._id}`}>
+              <Flex>
+                <CardTitle firstName={firstName} lastName={lastName} />
+              </Flex>
+            </Link>
           </Flex>
 
           <Flex align="center" css={{ width: '$147' }}>

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardEnd.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardEnd.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Flex from '@/components/Primitives/Flex';
+import Separator from '@/components/Primitives/Separator';
 import { User } from '@/types/user/user';
 import DeleteUser from './DeleteUser';
 import EditUser from './EditUser';
@@ -11,6 +12,14 @@ type CardEndProps = {
 
 const CardEnd: React.FC<CardEndProps> = React.memo(({ user }) => (
   <Flex css={{ alignItems: 'center' }}>
+    <Separator
+      orientation="vertical"
+      css={{
+        ml: '$20',
+        backgroundColor: '$primary100',
+        height: '$24 !important',
+      }}
+    />
     <Flex align="center" css={{ ml: '$24' }} gap="24">
       <EditUser user={user} />
     </Flex>

--- a/frontend/src/components/Users/UsersList/partials/CardUser/EditUser.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/EditUser.tsx
@@ -2,20 +2,23 @@ import Icon from '@/components/icons/Icon';
 import Flex from '@/components/Primitives/Flex';
 import Tooltip from '@/components/Primitives/Tooltip';
 import { User } from '@/types/user/user';
+import Link from 'next/link';
 
 type EditUserProps = { user: User };
 
-const EditUser: React.FC<EditUserProps> = () => (
+const EditUser: React.FC<EditUserProps> = ({ user }) => (
   <Tooltip content="Edit User">
     <Flex pointer>
-      <Icon
-        name="edit"
-        css={{
-          color: '$primary400',
-          width: '$20',
-          height: '$20',
-        }}
-      />
+      <Link href={`/users/${user._id}`}>
+        <Icon
+          name="edit"
+          css={{
+            color: '$primary400',
+            width: '$20',
+            height: '$20',
+          }}
+        />
+      </Link>
     </Flex>
   </Tooltip>
 );

--- a/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
@@ -1,45 +1,45 @@
 import Flex from '@/components/Primitives/Flex';
 import Text from '@/components/Primitives/Text';
-import { Switch, SwitchThumb } from '@/components/Primitives/Switch';
-import Icon from '@/components/icons/Icon';
 import { useState } from 'react';
+import { ConfigurationSettings } from '@/components/Board/Settings/partials/ConfigurationSettings';
 
 import Separator from '@/components/Primitives/Separator';
+import useUser from '@/hooks/useUser';
+import { UpdateUserIsAdmin } from '@/types/user/user';
 
 type SuperAdminProps = {
   userSAdmin: boolean;
   loggedUserSAdmin: boolean | undefined;
+  userId: string;
 };
 
-const SuperAdmin = ({ userSAdmin, loggedUserSAdmin }: SuperAdminProps) => {
+const SuperAdmin = ({ userSAdmin, loggedUserSAdmin, userId }: SuperAdminProps) => {
   const [checkedState, setCheckedState] = useState(userSAdmin);
 
-  const handleSuperAdminChange = () => {
-    setCheckedState(!checkedState);
-  };
+  const {
+    updateUserIsAdmin: { mutate },
+  } = useUser();
 
+  const handleSuperAdminChange = (checked: boolean) => {
+    const updateTeamUser: UpdateUserIsAdmin = {
+      _id: userId,
+      isSAdmin: checked,
+    };
+
+    setCheckedState(checked);
+    mutate(updateTeamUser);
+  };
 
   if (loggedUserSAdmin) {
     return (
-      <Flex css={{ ml: '$20', display: 'flex', alignItems: 'center' }}>
-        <Switch checked={checkedState} onCheckedChange={handleSuperAdminChange}>
-          {checkedState && (
-            <SwitchThumb>
-              <Icon
-                name="check"
-                css={{
-                  width: '$14',
-                  height: '$14',
-                  color: '$successBase',
-                }}
-              />
-            </SwitchThumb>
-          )}
-          {!checkedState && <SwitchThumb />}
-        </Switch>
-        <Text css={{ ml: '$14' }} size="sm" weight="medium">
-          Super Admin
-        </Text>
+      <Flex css={{ ml: '$2', display: 'flex', alignItems: 'center' }}>
+        <ConfigurationSettings
+          handleCheckedChange={handleSuperAdminChange}
+          isChecked={checkedState}
+          text=""
+          title="Super Admin"
+        />
+
         <Separator
           orientation="vertical"
           css={{
@@ -73,7 +73,6 @@ const SuperAdmin = ({ userSAdmin, loggedUserSAdmin }: SuperAdminProps) => {
           SUPER ADMIN
         </Text>
       )}
->>>>>>> bd6d377 (feat: member only sees user teams count and which user is an admin)
     </Flex>
   );
 };

--- a/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
@@ -3,7 +3,6 @@ import Text from '@/components/Primitives/Text';
 import { useState } from 'react';
 import { ConfigurationSettings } from '@/components/Board/Settings/partials/ConfigurationSettings';
 
-import Separator from '@/components/Primitives/Separator';
 import useUser from '@/hooks/useUser';
 import { UpdateUserIsAdmin } from '@/types/user/user';
 
@@ -11,10 +10,12 @@ type SuperAdminProps = {
   userSAdmin: boolean;
   loggedUserSAdmin: boolean | undefined;
   userId: string;
+  loggedUserId: string | undefined;
 };
 
-const SuperAdmin = ({ userSAdmin, loggedUserSAdmin, userId }: SuperAdminProps) => {
+const SuperAdmin = ({ userSAdmin, loggedUserSAdmin, userId, loggedUserId }: SuperAdminProps) => {
   const [checkedState, setCheckedState] = useState(userSAdmin);
+  const isDisabledState = true;
 
   const {
     updateUserIsAdmin: { mutateAsync },
@@ -37,21 +38,25 @@ const SuperAdmin = ({ userSAdmin, loggedUserSAdmin, userId }: SuperAdminProps) =
   if (loggedUserSAdmin) {
     return (
       <Flex css={{ ml: '$2', display: 'flex', alignItems: 'center' }}>
-        <ConfigurationSettings
-          handleCheckedChange={handleSuperAdminChange}
-          isChecked={checkedState}
-          text=""
-          title="Super Admin"
-        />
+        {loggedUserId !== userId && (
+          <ConfigurationSettings
+            handleCheckedChange={handleSuperAdminChange}
+            isChecked={checkedState}
+            text=""
+            title="Super Admin"
+          />
+        )}
 
-        <Separator
-          orientation="vertical"
-          css={{
-            ml: '$20',
-            backgroundColor: '$primary100',
-            height: '$24 !important',
-          }}
-        />
+        {loggedUserId === userId && (
+          <ConfigurationSettings
+            handleCheckedChange={handleSuperAdminChange}
+            isChecked={checkedState}
+            text=""
+            title="Super Admin"
+            disabled={isDisabledState}
+            styleVariant={isDisabledState}
+          />
+        )}
       </Flex>
     );
   }

--- a/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
@@ -17,17 +17,21 @@ const SuperAdmin = ({ userSAdmin, loggedUserSAdmin, userId }: SuperAdminProps) =
   const [checkedState, setCheckedState] = useState(userSAdmin);
 
   const {
-    updateUserIsAdmin: { mutate },
+    updateUserIsAdmin: { mutateAsync },
   } = useUser();
 
-  const handleSuperAdminChange = (checked: boolean) => {
+  const handleSuperAdminChange = async (checked: boolean) => {
     const updateTeamUser: UpdateUserIsAdmin = {
       _id: userId,
       isSAdmin: checked,
     };
 
-    setCheckedState(checked);
-    mutate(updateTeamUser);
+    try {
+      await mutateAsync(updateTeamUser);
+      setCheckedState(checked);
+    } catch (error) {
+      setCheckedState(!checked);
+    }
   };
 
   if (loggedUserSAdmin) {

--- a/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
@@ -4,37 +4,76 @@ import { Switch, SwitchThumb } from '@/components/Primitives/Switch';
 import Icon from '@/components/icons/Icon';
 import { useState } from 'react';
 
+import Separator from '@/components/Primitives/Separator';
+
 type SuperAdminProps = {
   userSAdmin: boolean;
+  loggedUserSAdmin: boolean | undefined;
 };
 
-const SuperAdmin = ({ userSAdmin }: SuperAdminProps) => {
+const SuperAdmin = ({ userSAdmin, loggedUserSAdmin }: SuperAdminProps) => {
   const [checkedState, setCheckedState] = useState(userSAdmin);
 
   const handleSuperAdminChange = () => {
     setCheckedState(!checkedState);
   };
 
+
+  if (loggedUserSAdmin) {
+    return (
+      <Flex css={{ ml: '$20', display: 'flex', alignItems: 'center' }}>
+        <Switch checked={checkedState} onCheckedChange={handleSuperAdminChange}>
+          {checkedState && (
+            <SwitchThumb>
+              <Icon
+                name="check"
+                css={{
+                  width: '$14',
+                  height: '$14',
+                  color: '$successBase',
+                }}
+              />
+            </SwitchThumb>
+          )}
+          {!checkedState && <SwitchThumb />}
+        </Switch>
+        <Text css={{ ml: '$14' }} size="sm" weight="medium">
+          Super Admin
+        </Text>
+        <Separator
+          orientation="vertical"
+          css={{
+            ml: '$20',
+            backgroundColor: '$primary100',
+            height: '$24 !important',
+          }}
+        />
+      </Flex>
+    );
+  }
   return (
     <Flex css={{ ml: '$20', display: 'flex', alignItems: 'center' }}>
-      <Switch checked={checkedState} onCheckedChange={handleSuperAdminChange}>
-        {checkedState && (
-          <SwitchThumb>
-            <Icon
-              name="check"
-              css={{
-                width: '$14',
-                height: '$14',
-                color: '$successBase',
-              }}
-            />
-          </SwitchThumb>
-        )}
-        {!checkedState && <SwitchThumb />}
-      </Switch>
-      <Text css={{ ml: '$14' }} size="sm" weight="medium">
-        Super Admin
-      </Text>
+      {userSAdmin && (
+        <Text
+          css={{
+            ml: '$14',
+            background: '#E3FFF5',
+            borderStyle: 'solid',
+            borderColor: '#3EC796',
+            borderWidth: 'thin',
+            color: '#3EC796',
+            borderRadius: '$12',
+            padding: '$8',
+            height: '1.55rem',
+            lineHeight: '$8',
+          }}
+          size="sm"
+          weight="medium"
+        >
+          SUPER ADMIN
+        </Text>
+      )}
+>>>>>>> bd6d377 (feat: member only sees user teams count and which user is an admin)
     </Flex>
   );
 };

--- a/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/SuperAdmin.tsx
@@ -38,25 +38,14 @@ const SuperAdmin = ({ userSAdmin, loggedUserSAdmin, userId, loggedUserId }: Supe
   if (loggedUserSAdmin) {
     return (
       <Flex css={{ ml: '$2', display: 'flex', alignItems: 'center' }}>
-        {loggedUserId !== userId && (
-          <ConfigurationSettings
-            handleCheckedChange={handleSuperAdminChange}
-            isChecked={checkedState}
-            text=""
-            title="Super Admin"
-          />
-        )}
-
-        {loggedUserId === userId && (
-          <ConfigurationSettings
-            handleCheckedChange={handleSuperAdminChange}
-            isChecked={checkedState}
-            text=""
-            title="Super Admin"
-            disabled={isDisabledState}
-            styleVariant={isDisabledState}
-          />
-        )}
+        <ConfigurationSettings
+          handleCheckedChange={handleSuperAdminChange}
+          isChecked={checkedState}
+          text=""
+          title="Super Admin"
+          disabled={loggedUserId !== userId ? undefined : isDisabledState}
+          styleVariant={loggedUserId !== userId ? undefined : isDisabledState}
+        />
       </Flex>
     );
   }

--- a/frontend/src/components/Users/UsersList/partials/ListOfCards/index.tsx
+++ b/frontend/src/components/Users/UsersList/partials/ListOfCards/index.tsx
@@ -20,7 +20,7 @@ const ListOfCards = React.memo<ListOfCardsProp>(({ isLoading }) => {
     <>
       <Flex>
         <Text css={{ fontWeight: '$bold', flex: 1, mt: '$36' }}>
-          {usersWithTeams?.length} registered users
+          {usersWithTeams.length} registered users
         </Text>
         <Flex css={{ width: '460px' }} direction="column" gap={16}>
           <SearchInput icon="search" iconPosition="left" id="search" placeholder="Search user" />

--- a/frontend/src/hooks/useUserUtils.tsx
+++ b/frontend/src/hooks/useUserUtils.tsx
@@ -1,0 +1,43 @@
+import { QueryClient, useQueryClient } from 'react-query';
+import { NextRouter, useRouter } from 'next/router';
+import { useSession } from 'next-auth/react';
+import { SetterOrUpdater, useRecoilState, useSetRecoilState } from 'recoil';
+
+import { toastState } from '@/store/toast/atom/toast.atom';
+import { UserWithTeams } from '@/types/user/user';
+import { usersWithTeamsState } from '../store/user/atoms/user.atom';
+import { ToastStateEnum } from '../utils/enums/toast-types';
+
+type UserUtilsType = {
+  userId: string;
+  queryClient: QueryClient;
+  setToastState: SetterOrUpdater<{ open: boolean; type: ToastStateEnum; content: string }>;
+  router: NextRouter;
+  usersWithTeamsList: UserWithTeams[];
+  setUsersWithTeamsList: SetterOrUpdater<UserWithTeams[]>;
+};
+
+const useUserUtils = (): UserUtilsType => {
+  const router = useRouter();
+  const { data: session } = useSession({ required: false });
+
+  const queryClient = useQueryClient();
+
+  let userId = '';
+
+  if (session) userId = session.user.id;
+
+  const setToastState = useSetRecoilState(toastState);
+  const [usersWithTeamsList, setUsersWithTeamsList] = useRecoilState(usersWithTeamsState);
+
+  return {
+    userId,
+    queryClient,
+    setToastState,
+    router,
+    usersWithTeamsList,
+    setUsersWithTeamsList,
+  };
+};
+
+export default useUserUtils;

--- a/frontend/src/hooks/useUserUtils.tsx
+++ b/frontend/src/hooks/useUserUtils.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, useQueryClient } from 'react-query';
 import { NextRouter, useRouter } from 'next/router';
-import { useSession } from 'next-auth/react';
+
 import { SetterOrUpdater, useRecoilState, useSetRecoilState } from 'recoil';
 
 import { toastState } from '@/store/toast/atom/toast.atom';
@@ -9,7 +9,6 @@ import { usersWithTeamsState } from '../store/user/atoms/user.atom';
 import { ToastStateEnum } from '../utils/enums/toast-types';
 
 type UserUtilsType = {
-  userId: string;
   queryClient: QueryClient;
   setToastState: SetterOrUpdater<{ open: boolean; type: ToastStateEnum; content: string }>;
   router: NextRouter;
@@ -19,19 +18,13 @@ type UserUtilsType = {
 
 const useUserUtils = (): UserUtilsType => {
   const router = useRouter();
-  const { data: session } = useSession({ required: false });
 
   const queryClient = useQueryClient();
-
-  let userId = '';
-
-  if (session) userId = session.user.id;
 
   const setToastState = useSetRecoilState(toastState);
   const [usersWithTeamsList, setUsersWithTeamsList] = useRecoilState(usersWithTeamsState);
 
   return {
-    userId,
     queryClient,
     setToastState,
     router,

--- a/frontend/src/pages/users/[userId].tsx
+++ b/frontend/src/pages/users/[userId].tsx
@@ -1,0 +1,3 @@
+const UserDetails = () => <h1>User Details</h1>;
+
+export default UserDetails;

--- a/frontend/src/pages/users/index.tsx
+++ b/frontend/src/pages/users/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, Suspense, useEffect } from 'react';
+import { ReactElement, Suspense } from 'react';
 import { dehydrate, QueryClient, useQuery } from 'react-query';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { useSession } from 'next-auth/react';
@@ -21,7 +21,7 @@ const Users = () => {
   const setUsersWithTeamsState = useSetRecoilState(usersWithTeamsState);
 
   const { data, isFetching } = useQuery(['usersWithTeams'], () => getAllUsersWithTeams(), {
-    enabled: true,
+    enabled: false,
     refetchOnWindowFocus: false,
     onError: () => {
       setToastState({
@@ -32,14 +32,9 @@ const Users = () => {
     },
   });
 
-  useEffect(() => {
-    if (!data) {
-      return;
-    }
-
+  if (data) {
     setUsersWithTeamsState(data);
-  }, [data, setUsersWithTeamsState]);
-
+  }
   if (!session || !data) return null;
 
   return (

--- a/frontend/src/store/user/atoms/user.atom.tsx
+++ b/frontend/src/store/user/atoms/user.atom.tsx
@@ -12,7 +12,7 @@ export const userState = atom({
   },
 });
 
-export const usersWithTeamsState = atom<UserWithTeams[] | undefined>({
+export const usersWithTeamsState = atom<UserWithTeams[]>({
   key: 'usersWithTeams',
   default: [],
 });

--- a/frontend/src/types/user/user.ts
+++ b/frontend/src/types/user/user.ts
@@ -21,6 +21,7 @@ export interface UseUserType {
   loginAzure: () => Promise<void>;
   resetToken: UseMutationResult<ResetTokenResponse, AxiosError, EmailUser>;
   resetPassword: UseMutationResult<ResetPasswordResponse, AxiosError, NewPassword>;
+  updateUserIsAdmin: UseMutationResult<User, unknown, UpdateUserIsAdmin, unknown>;
 }
 
 export interface LoginUser {
@@ -56,6 +57,11 @@ export interface ResetPasswordResponse {
 export interface UserWithTeams {
   user: User;
   teamsNames?: string[];
+}
+
+export interface UpdateUserIsAdmin {
+  _id: string;
+  isSAdmin: boolean;
 }
 
 export type UserZod = 'name' | 'email' | 'password' | 'passwordConf';


### PR DESCRIPTION

#599 

Relates to #594 


## Screenshots (if visual changes)
As Super Admin:
![image](https://user-images.githubusercontent.com/118206043/205910792-132400c4-6a36-4da0-a667-e68f6bc00a68.png)

As member:
![image](https://user-images.githubusercontent.com/118206043/205911124-810dfdd1-7c33-47f2-81f0-64d0262ccc89.png)


## Proposed Changes
  - As a super admin the switch button should be visible and editable. This action makes a request to the backend in order to change the user role in the app. 
  - The edit button and when the user clicks in the user's name should redirect to the user details. 
  - The delete button should be present and this will be done in issue https://github.com/xgeekshq/split/issues/600. 
  - Both icons and user's name must have a hover behaviour.
  - A member only sees the user teams count and which user is an admin.


Mention people who discussed this issue previously
@GuiSanto 



This pull request closes #599 