### PR TITLE
feat: automatically update isnewjoiner status

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -31,6 +31,7 @@
 				"class-transformer": "^0.5.1",
 				"class-validator": "^0.13.2",
 				"cron": "2.1.0",
+				"dayjs": "^1.11.6",
 				"dotenv": "^16.0.0",
 				"eslint-config-airbnb": "^19.0.4",
 				"eslint-config-airbnb-typescript": "^17.0.0",
@@ -5708,9 +5709,9 @@
 			}
 		},
 		"node_modules/dayjs": {
-			"version": "1.11.4",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
-			"integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g=="
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+			"integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -20543,9 +20544,9 @@
 			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
 		},
 		"dayjs": {
-			"version": "1.11.4",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
-			"integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g=="
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+			"integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
 		},
 		"debug": {
 			"version": "4.3.4",

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -31,7 +31,7 @@
 				"class-transformer": "^0.5.1",
 				"class-validator": "^0.13.2",
 				"cron": "2.1.0",
-				"dayjs": "^1.11.6",
+				"date-fns": "^2.29.3",
 				"dotenv": "^16.0.0",
 				"eslint-config-airbnb": "^19.0.4",
 				"eslint-config-airbnb-typescript": "^17.0.0",
@@ -5706,6 +5706,18 @@
 			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og==",
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/date-fns": {
+			"version": "2.29.3",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+			"integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+			"engines": {
+				"node": ">=0.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/date-fns"
 			}
 		},
 		"node_modules/dayjs": {
@@ -20542,6 +20554,11 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-3.0.1.tgz",
 			"integrity": "sha512-WboRycPNsVw3B3TL559F7kuBUM4d8CgMEvk6xEJlOp7OBPjt6G7z8WMWlD2rOFZLk6OYfFIUGsCOWzcQH9K2og=="
+		},
+		"date-fns": {
+			"version": "2.29.3",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+			"integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
 		},
 		"dayjs": {
 			"version": "1.11.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,6 +45,7 @@
 		"class-transformer": "^0.5.1",
 		"class-validator": "^0.13.2",
 		"cron": "2.1.0",
+		"dayjs": "^1.11.6",
 		"dotenv": "^16.0.0",
 		"eslint-config-airbnb": "^19.0.4",
 		"eslint-config-airbnb-typescript": "^17.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,7 +45,7 @@
 		"class-transformer": "^0.5.1",
 		"class-validator": "^0.13.2",
 		"cron": "2.1.0",
-		"dayjs": "^1.11.6",
+		"date-fns": "^2.29.3",
 		"dotenv": "^16.0.0",
 		"eslint-config-airbnb": "^19.0.4",
 		"eslint-config-airbnb-typescript": "^17.0.0",

--- a/backend/src/modules/auth/controller/auth.controller.spec.ts
+++ b/backend/src/modules/auth/controller/auth.controller.spec.ts
@@ -18,7 +18,12 @@ import {
 import AuthController from 'src/modules/auth/controller/auth.controller';
 import { getBoardApplication, getBoardService } from 'src/modules/boards/boards.providers';
 import EmailModule from 'src/modules/mailer/mailer.module';
-import { createTeamService, getTeamApplication, getTeamService } from 'src/modules/teams/providers';
+import {
+	createTeamService,
+	getTeamApplication,
+	getTeamService,
+	updateTeamService
+} from 'src/modules/teams/providers';
 import {
 	createUserService,
 	getUserApplication,
@@ -58,6 +63,7 @@ describe('AuthController', () => {
 				getUserApplication,
 				getUserService,
 				userRepository,
+				updateTeamService,
 				ConfigService,
 				{
 					provide: ConfigService,

--- a/backend/src/modules/auth/services/validate-user.auth.service.spec.ts
+++ b/backend/src/modules/auth/services/validate-user.auth.service.spec.ts
@@ -7,7 +7,7 @@ import configService from 'src/libs/test-utils/mocks/configService.mock';
 import jwtService from 'src/libs/test-utils/mocks/jwtService.mock';
 import mockedUser from 'src/libs/test-utils/mocks/user.mock';
 import ValidateUserAuthServiceImpl from 'src/modules/auth/services/validate-user.auth.service';
-import { getTeamService } from 'src/modules/teams/providers';
+import { getTeamService, updateTeamService } from 'src/modules/teams/providers';
 import { GetUserService } from 'src/modules/users/interfaces/services/get.user.service.interface';
 import { TYPES } from 'src/modules/users/interfaces/types';
 import { getUserService, userRepository } from 'src/modules/users/users.providers';
@@ -38,6 +38,7 @@ describe('The AuthenticationService', () => {
 				getUserService,
 				getTeamService,
 				userRepository,
+				updateTeamService,
 				{
 					provide: ConfigService,
 					useValue: configService

--- a/backend/src/modules/auth/shared/login.auth.ts
+++ b/backend/src/modules/auth/shared/login.auth.ts
@@ -8,10 +8,10 @@ export const signIn = async (
 	getTokenService: GetTokenAuthService | GetTokenAuthApplication,
 	strategy: string
 ) => {
-	const { email, firstName, lastName, _id, isSAdmin } = user;
+	const { email, firstName, lastName, _id, isSAdmin, userAzureCreatedAt } = user;
 	const jwt = await getTokenService.getTokens(_id);
 
 	if (!jwt) return null;
 
-	return { ...jwt, email, firstName, lastName, strategy, _id, isSAdmin };
+	return { ...jwt, email, firstName, lastName, strategy, id: _id, isSAdmin, userAzureCreatedAt };
 };

--- a/backend/src/modules/auth/shared/login.auth.ts
+++ b/backend/src/modules/auth/shared/login.auth.ts
@@ -13,5 +13,15 @@ export const signIn = async (
 
 	if (!jwt) return null;
 
-	return { ...jwt, email, firstName, lastName, strategy, id: _id, isSAdmin, userAzureCreatedAt };
+	return {
+		...jwt,
+		email,
+		firstName,
+		lastName,
+		strategy,
+		id: _id,
+		isSAdmin,
+		userAzureCreatedAt,
+		_id
+	};
 };

--- a/backend/src/modules/auth/shared/login.auth.ts
+++ b/backend/src/modules/auth/shared/login.auth.ts
@@ -8,7 +8,7 @@ export const signIn = async (
 	getTokenService: GetTokenAuthService | GetTokenAuthApplication,
 	strategy: string
 ) => {
-	const { email, firstName, lastName, _id, isSAdmin, userAzureCreatedAt } = user;
+	const { email, firstName, lastName, _id, isSAdmin, providerAccountCreatedAt } = user;
 	const jwt = await getTokenService.getTokens(_id);
 
 	if (!jwt) return null;
@@ -21,7 +21,7 @@ export const signIn = async (
 		strategy,
 		id: _id,
 		isSAdmin,
-		userAzureCreatedAt,
+		providerAccountCreatedAt,
 		_id
 	};
 };

--- a/backend/src/modules/azure/services/auth.azure.service.ts
+++ b/backend/src/modules/azure/services/auth.azure.service.ts
@@ -63,7 +63,7 @@ export default class AuthAzureServiceImpl implements AuthAzureService {
 			email: emailOrUniqueName,
 			firstName,
 			lastName,
-			userAzureCreatedAt: userFromAzure.value[0].createdDateTime
+			providerAccountCreatedAt: userFromAzure.value[0].createdDateTime
 		});
 
 		if (!createdUser) return null;

--- a/backend/src/modules/boards/controller/boards.controller.spec.ts
+++ b/backend/src/modules/boards/controller/boards.controller.spec.ts
@@ -18,7 +18,12 @@ import {
 	deleteSchedulesService
 } from 'src/modules/schedules/schedules.providers';
 import SocketGateway from 'src/modules/socket/gateway/socket.gateway';
-import { createTeamService, getTeamApplication, getTeamService } from 'src/modules/teams/providers';
+import {
+	createTeamService,
+	getTeamApplication,
+	getTeamService,
+	updateTeamService
+} from 'src/modules/teams/providers';
 
 describe('BoardsController', () => {
 	let controller: BoardsController;
@@ -42,6 +47,7 @@ describe('BoardsController', () => {
 				createTeamService,
 				createSchedulesService,
 				deleteSchedulesService,
+				updateTeamService,
 				{
 					provide: getModelToken('User'),
 					useValue: {}

--- a/backend/src/modules/boards/dto/board.user.dto.ts
+++ b/backend/src/modules/boards/dto/board.user.dto.ts
@@ -1,5 +1,13 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsEnum, IsMongoId, IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
+import {
+	IsBoolean,
+	IsEnum,
+	IsMongoId,
+	IsNotEmpty,
+	IsNumber,
+	IsOptional,
+	IsString
+} from 'class-validator';
 import { BoardRoles } from 'src/libs/enum/board.roles';
 
 export default class BoardUserDto {
@@ -24,4 +32,9 @@ export default class BoardUserDto {
 	@IsOptional()
 	@IsNumber()
 	votesCount?: number;
+
+	@ApiPropertyOptional()
+	@IsOptional()
+	@IsBoolean()
+	isNewJoiner?: boolean;
 }

--- a/backend/src/modules/boards/services/create.board.service.ts
+++ b/backend/src/modules/boards/services/create.board.service.ts
@@ -293,13 +293,13 @@ export default class CreateBoardServiceImpl implements CreateBoardService {
 	generateSubBoards(maxTeams: number, splitUsers: BoardUserDto[][], subBoards: BoardDto[]) {
 		new Array(maxTeams).fill(0).forEach((_, i) => {
 			const newBoard = generateSubBoardDtoData(i + 1);
-			const teamUsersWotIsNEwJoiner = splitUsers[i].filter((user) => !user.isNewJoiner);
+			const teamUsersWotIsNewJoiner = splitUsers[i].filter((user) => !user.isNewJoiner);
 
-			teamUsersWotIsNEwJoiner[Math.floor(Math.random() * teamUsersWotIsNEwJoiner.length)].role =
+			teamUsersWotIsNewJoiner[Math.floor(Math.random() * teamUsersWotIsNewJoiner.length)].role =
 				BoardRoles.RESPONSIBLE;
 
 			const result = splitUsers[i].map(
-				(user) => teamUsersWotIsNEwJoiner.find((member) => member._id === user._id) || user
+				(user) => teamUsersWotIsNewJoiner.find((member) => member._id === user._id) || user
 			);
 
 			newBoard.users = result;

--- a/backend/src/modules/boards/services/create.board.service.ts
+++ b/backend/src/modules/boards/services/create.board.service.ts
@@ -277,7 +277,8 @@ export default class CreateBoardServiceImpl implements CreateBoardService {
 				{
 					user: (teamUser.user as LeanDocument<UserDocument>)._id.toString(),
 					role: BoardRoles.MEMBER,
-					votesCount: 0
+					votesCount: 0,
+					isNewJoiner: teamUser.isNewJoiner
 				}
 			];
 
@@ -292,8 +293,16 @@ export default class CreateBoardServiceImpl implements CreateBoardService {
 	generateSubBoards(maxTeams: number, splitUsers: BoardUserDto[][], subBoards: BoardDto[]) {
 		new Array(maxTeams).fill(0).forEach((_, i) => {
 			const newBoard = generateSubBoardDtoData(i + 1);
-			splitUsers[i][Math.floor(Math.random() * splitUsers[i].length)].role = BoardRoles.RESPONSIBLE;
-			newBoard.users = splitUsers[i];
+			const teamUsersWotIsNEwJoiner = splitUsers[i].filter((user) => !user.isNewJoiner);
+
+			teamUsersWotIsNEwJoiner[Math.floor(Math.random() * teamUsersWotIsNEwJoiner.length)].role =
+				BoardRoles.RESPONSIBLE;
+
+			const result = splitUsers[i].map(
+				(user) => teamUsersWotIsNEwJoiner.find((member) => member._id === user._id) || user
+			);
+
+			newBoard.users = result;
 			subBoards.push(newBoard);
 		});
 	}

--- a/backend/src/modules/boards/services/get.board.service.spec.ts
+++ b/backend/src/modules/boards/services/get.board.service.spec.ts
@@ -6,7 +6,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Document, LeanDocument } from 'mongoose';
 import Board from 'src/modules/boards/schemas/board.schema';
 import GetBoardServiceImpl from 'src/modules/boards/services/get.board.service';
-import { getTeamService } from 'src/modules/teams/providers';
+import { getTeamService, updateTeamService } from 'src/modules/teams/providers';
 import { getBoardService } from '../boards.providers';
 
 describe('GetBoardServiceImpl', () => {
@@ -17,6 +17,7 @@ describe('GetBoardServiceImpl', () => {
 			providers: [
 				getTeamService,
 				getBoardService,
+				updateTeamService,
 				{
 					provide: getModelToken('Team'),
 					useValue: {}

--- a/backend/src/modules/teams/controller/team.controller.ts
+++ b/backend/src/modules/teams/controller/team.controller.ts
@@ -155,7 +155,7 @@ export default class TeamsController {
 		return this.getTeamApp.getTeamsOfUser(request.user._id);
 	}
 
-	@ApiOperation({ summary: 'Get a list of users belongs to the team' })
+	@ApiOperation({ summary: 'Get a specific team' })
 	@ApiParam({ name: 'teamId', type: String })
 	@ApiQuery({
 		name: 'teamUserRole',

--- a/backend/src/modules/teams/schemas/team.user.schema.ts
+++ b/backend/src/modules/teams/schemas/team.user.schema.ts
@@ -24,6 +24,7 @@ export default class TeamUser {
 
 	@Prop({ type: SchemaTypes.ObjectId, ref: 'User', nullable: false })
 	user!: User | ObjectId;
+	//user!: User;
 
 	@Prop({ type: SchemaTypes.ObjectId, ref: 'Team', nullable: false })
 	team!: Team | ObjectId;

--- a/backend/src/modules/teams/schemas/team.user.schema.ts
+++ b/backend/src/modules/teams/schemas/team.user.schema.ts
@@ -9,6 +9,8 @@ export type TeamUserDocument = TeamUser & Document;
 
 @Schema()
 export default class TeamUser {
+	_id?: string;
+
 	@Prop({
 		nullable: false,
 		type: String,
@@ -23,11 +25,12 @@ export default class TeamUser {
 	isNewJoiner!: boolean;
 
 	@Prop({ type: SchemaTypes.ObjectId, ref: 'User', nullable: false })
-	user!: User | ObjectId;
-	//user!: User;
+	user!: User | ObjectId | string;
 
 	@Prop({ type: SchemaTypes.ObjectId, ref: 'Team', nullable: false })
 	team!: Team | ObjectId;
+
+	userCreated?: Date;
 }
 
 export const TeamUserSchema = SchemaFactory.createForClass(TeamUser);

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -140,7 +140,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 			.find({ team: teamId })
 			.populate({
 				path: 'user',
-				select: '_id firstName lastName email isSAdmin userAzureCreatedAt'
+				select: '_id firstName lastName email isSAdmin joinedAt userAzureCreatedAt'
 			})
 			.exec();
 	}

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -31,7 +31,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 				select: 'user role isNewJoiner',
 				populate: {
 					path: 'user',
-					select: '_id firstName lastName email joinedAt'
+					select: '_id firstName lastName email joinedAt userAzureCreatedAt'
 				}
 			})
 			.exec();
@@ -48,7 +48,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 				select: 'user role',
 				populate: {
 					path: 'user',
-					select: '_id firstName lastName email joinedAt'
+					select: '_id firstName lastName email joinedAt userAzureCreatedAt'
 				}
 			})
 			.populate({
@@ -128,7 +128,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 				select: 'user role email',
 				populate: {
 					path: 'user',
-					select: '_id firstName lastName email joinedAt'
+					select: '_id firstName lastName email joinedAt userAzureCreatedAt'
 				}
 			})
 			.lean({ virtuals: true })
@@ -140,7 +140,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 			.find({ team: teamId })
 			.populate({
 				path: 'user',
-				select: '_id firstName lastName email isSAdmin'
+				select: '_id firstName lastName email isSAdmin userAzureCreatedAt'
 			})
 			.exec();
 	}

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -31,7 +31,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 				select: 'user role isNewJoiner',
 				populate: {
 					path: 'user',
-					select: '_id firstName lastName email joinedAt userAzureCreatedAt'
+					select: '_id firstName lastName email joinedAt providerAccountCreatedAt'
 				}
 			})
 			.exec();
@@ -48,7 +48,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 				select: 'user role',
 				populate: {
 					path: 'user',
-					select: '_id firstName lastName email joinedAt userAzureCreatedAt'
+					select: '_id firstName lastName email joinedAt providerAccountCreatedAt'
 				}
 			})
 			.populate({
@@ -128,7 +128,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 				select: 'user role email isNewJoiner',
 				populate: {
 					path: 'user',
-					select: '_id firstName lastName email joinedAt userAzureCreatedAt'
+					select: '_id firstName lastName email joinedAt providerAccountCreatedAt'
 				}
 			})
 			.lean({ virtuals: true })
@@ -140,7 +140,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 			.find({ team: teamId })
 			.populate({
 				path: 'user',
-				select: '_id firstName lastName email isSAdmin joinedAt userAzureCreatedAt'
+				select: '_id firstName lastName email isSAdmin joinedAt providerAccountCreatedAt'
 			})
 			.exec();
 	}

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -125,7 +125,7 @@ export default class GetTeamService implements GetTeamServiceInterface {
 			.find()
 			.populate({
 				path: 'users',
-				select: 'user role email',
+				select: 'user role email isNewJoiner',
 				populate: {
 					path: 'user',
 					select: '_id firstName lastName email joinedAt userAzureCreatedAt'

--- a/backend/src/modules/users/dto/create.user.azure.dto.ts
+++ b/backend/src/modules/users/dto/create.user.azure.dto.ts
@@ -17,8 +17,8 @@ export default class CreateUserAzureDto {
 	@IsString()
 	email!: string;
 
-	@ApiProperty({ type: String, format: 'date' })
+	@ApiProperty()
 	@IsNotEmpty()
 	@IsDateString()
-	userAzureCreatedAt!: Date;
+	userAzureCreatedAt!: string;
 }

--- a/backend/src/modules/users/dto/create.user.azure.dto.ts
+++ b/backend/src/modules/users/dto/create.user.azure.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsDateString, IsNotEmpty, IsString } from 'class-validator';
 
 export default class CreateUserAzureDto {
 	@ApiProperty()
@@ -16,4 +16,9 @@ export default class CreateUserAzureDto {
 	@IsNotEmpty()
 	@IsString()
 	email!: string;
+
+	@ApiProperty({ type: String, format: 'date' })
+	@IsNotEmpty()
+	@IsDateString()
+	userAzureCreatedAt!: Date;
 }

--- a/backend/src/modules/users/dto/create.user.azure.dto.ts
+++ b/backend/src/modules/users/dto/create.user.azure.dto.ts
@@ -20,5 +20,5 @@ export default class CreateUserAzureDto {
 	@ApiProperty()
 	@IsNotEmpty()
 	@IsDateString()
-	userAzureCreatedAt!: string;
+	userAzureCreatedAt!: Date;
 }

--- a/backend/src/modules/users/dto/create.user.azure.dto.ts
+++ b/backend/src/modules/users/dto/create.user.azure.dto.ts
@@ -20,5 +20,5 @@ export default class CreateUserAzureDto {
 	@ApiProperty()
 	@IsNotEmpty()
 	@IsDateString()
-	userAzureCreatedAt!: Date;
+	providerAccountCreatedAt!: Date;
 }

--- a/backend/src/modules/users/dto/create.user.dto.ts
+++ b/backend/src/modules/users/dto/create.user.dto.ts
@@ -48,5 +48,5 @@ export default class CreateUserDto {
 	@ApiProperty()
 	@IsOptional()
 	@IsDateString()
-	userAzureCreatedAt?: string;
+	userAzureCreatedAt?: Date;
 }

--- a/backend/src/modules/users/dto/create.user.dto.ts
+++ b/backend/src/modules/users/dto/create.user.dto.ts
@@ -48,5 +48,5 @@ export default class CreateUserDto {
 	@ApiProperty()
 	@IsOptional()
 	@IsDateString()
-	userAzureCreatedAt?: Date;
+	providerAccountCreatedAt?: Date;
 }

--- a/backend/src/modules/users/dto/create.user.dto.ts
+++ b/backend/src/modules/users/dto/create.user.dto.ts
@@ -1,6 +1,14 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform, TransformFnParams } from 'class-transformer';
-import { IsEmail, IsNotEmpty, IsString, Matches, MinLength } from 'class-validator';
+import {
+	IsDateString,
+	IsEmail,
+	IsNotEmpty,
+	IsOptional,
+	IsString,
+	Matches,
+	MinLength
+} from 'class-validator';
 
 export default class CreateUserDto {
 	@ApiProperty({ type: String, format: 'email' })
@@ -36,4 +44,9 @@ export default class CreateUserDto {
 			'Use at least 8 characters, upper and lower case letters, numbers and symbols like !“?$%^&).'
 	})
 	password!: string;
+
+	@ApiProperty()
+	@IsOptional()
+	@IsDateString()
+	userAzureCreatedAt?: Date;
 }

--- a/backend/src/modules/users/dto/create.user.dto.ts
+++ b/backend/src/modules/users/dto/create.user.dto.ts
@@ -48,5 +48,5 @@ export default class CreateUserDto {
 	@ApiProperty()
 	@IsOptional()
 	@IsDateString()
-	userAzureCreatedAt?: Date;
+	userAzureCreatedAt?: string;
 }

--- a/backend/src/modules/users/dto/user.dto.ts
+++ b/backend/src/modules/users/dto/user.dto.ts
@@ -36,5 +36,5 @@ export default class UserDto {
 	@ApiProperty()
 	@IsOptional()
 	@IsDateString()
-	userAzureCreatedAt: Date;
+	userAzureCreatedAt: string;
 }

--- a/backend/src/modules/users/dto/user.dto.ts
+++ b/backend/src/modules/users/dto/user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import { IsMongoId, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsDateString, IsMongoId, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export default class UserDto {
 	@ApiProperty()
@@ -32,4 +32,9 @@ export default class UserDto {
 	@ApiPropertyOptional({ default: false })
 	@IsOptional()
 	isSAdmin?: boolean;
+
+	@ApiProperty()
+	@IsOptional()
+	@IsDateString()
+	userAzureCreatedAt: Date;
 }

--- a/backend/src/modules/users/dto/user.dto.ts
+++ b/backend/src/modules/users/dto/user.dto.ts
@@ -36,5 +36,5 @@ export default class UserDto {
 	@ApiProperty()
 	@IsOptional()
 	@IsDateString()
-	userAzureCreatedAt?: Date;
+	providerAccountCreatedAt?: Date;
 }

--- a/backend/src/modules/users/dto/user.dto.ts
+++ b/backend/src/modules/users/dto/user.dto.ts
@@ -36,5 +36,5 @@ export default class UserDto {
 	@ApiProperty()
 	@IsOptional()
 	@IsDateString()
-	userAzureCreatedAt: string;
+	userAzureCreatedAt?: Date;
 }

--- a/backend/src/modules/users/entities/user.schema.ts
+++ b/backend/src/modules/users/entities/user.schema.ts
@@ -35,6 +35,9 @@ export default class User {
 
 	@Prop({ nullable: false, default: false })
 	isDeleted!: boolean;
+
+	@Prop({ nullable: true })
+	userAzureCreatedAt?: Date;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);

--- a/backend/src/modules/users/entities/user.schema.ts
+++ b/backend/src/modules/users/entities/user.schema.ts
@@ -37,7 +37,7 @@ export default class User {
 	isDeleted!: boolean;
 
 	@Prop({ nullable: true })
-	userAzureCreatedAt?: Date;
+	providerAccountCreatedAt?: Date;
 }
 
 export const UserSchema = SchemaFactory.createForClass(User);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,7 @@
 				"@testing-library/dom": "^8.13.0",
 				"@testing-library/react": "^12.1.5",
 				"axios": "^0.26.1",
-				"dayjs": "^1.11.6",
+				"dayjs": "^1.11.7",
 				"dotenv": "^16.0.0",
 				"fast-json-patch": "^3.1.1",
 				"joi": "^17.6.0",
@@ -4608,9 +4608,9 @@
 			}
 		},
 		"node_modules/dayjs": {
-			"version": "1.11.6",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-			"integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
+			"version": "1.11.7",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+			"integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -15928,9 +15928,9 @@
 			}
 		},
 		"dayjs": {
-			"version": "1.11.6",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
-			"integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
+			"version": "1.11.7",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+			"integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
 		},
 		"debug": {
 			"version": "4.3.4",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,7 @@
 				"@testing-library/dom": "^8.13.0",
 				"@testing-library/react": "^12.1.5",
 				"axios": "^0.26.1",
-				"dayjs": "^1.11.7",
+				"date-fns": "^2.29.3",
 				"dotenv": "^16.0.0",
 				"fast-json-patch": "^3.1.1",
 				"joi": "^17.6.0",
@@ -4607,10 +4607,17 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/dayjs": {
-			"version": "1.11.7",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-			"integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+		"node_modules/date-fns": {
+			"version": "2.29.3",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+			"integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
+			"engines": {
+				"node": ">=0.11"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/date-fns"
+			}
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -15927,10 +15934,10 @@
 				"whatwg-url": "^8.0.0"
 			}
 		},
-		"dayjs": {
-			"version": "1.11.7",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-			"integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+		"date-fns": {
+			"version": "2.29.3",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
+			"integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA=="
 		},
 		"debug": {
 			"version": "4.3.4",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
 				"@testing-library/dom": "^8.13.0",
 				"@testing-library/react": "^12.1.5",
 				"axios": "^0.26.1",
+				"dayjs": "^1.11.6",
 				"dotenv": "^16.0.0",
 				"fast-json-patch": "^3.1.1",
 				"joi": "^17.6.0",
@@ -4605,6 +4606,11 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+			"integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -15920,6 +15926,11 @@
 				"whatwg-mimetype": "^2.3.0",
 				"whatwg-url": "^8.0.0"
 			}
+		},
+		"dayjs": {
+			"version": "1.11.6",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.6.tgz",
+			"integrity": "sha512-zZbY5giJAinCG+7AGaw0wIhNZ6J8AhWuSXKvuc1KAyMiRsvGQWqh4L+MomvhdAYjN+lqvVCMq1I41e3YHvXkyQ=="
 		},
 		"debug": {
 			"version": "4.3.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
 		"@testing-library/dom": "^8.13.0",
 		"@testing-library/react": "^12.1.5",
 		"axios": "^0.26.1",
+		"dayjs": "^1.11.6",
 		"dotenv": "^16.0.0",
 		"fast-json-patch": "^3.1.1",
 		"joi": "^17.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
 		"@testing-library/dom": "^8.13.0",
 		"@testing-library/react": "^12.1.5",
 		"axios": "^0.26.1",
-		"dayjs": "^1.11.6",
+		"dayjs": "^1.11.7",
 		"dotenv": "^16.0.0",
 		"fast-json-patch": "^3.1.1",
 		"joi": "^17.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
 		"@testing-library/dom": "^8.13.0",
 		"@testing-library/react": "^12.1.5",
 		"axios": "^0.26.1",
-		"dayjs": "^1.11.7",
+		"date-fns": "^2.29.3",
 		"dotenv": "^16.0.0",
 		"fast-json-patch": "^3.1.1",
 		"joi": "^17.6.0",

--- a/frontend/src/components/CreateBoard/SubTeamsTab/SubCardBoard.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/SubCardBoard.tsx
@@ -48,13 +48,17 @@ const SubCardBoard: React.FC<SubCardBoardProps> = ({ board, index, setBoard }) =
     if (!userFound) return;
     userFound.role = BoardUserRoles.RESPONSIBLE;
 
+    const listUsers = users.map(
+      (user) => cloneUsers.find((member) => member._id === user._id) || user,
+    );
+
     setBoard((prevBoard) => ({
       ...prevBoard,
       board: {
         ...prevBoard.board,
         dividedBoards: prevBoard.board.dividedBoards.map((boardFound, i) => {
           if (i === index) {
-            return { ...boardFound, users: cloneUsers };
+            return { ...boardFound, users: listUsers };
           }
           return boardFound;
         }),

--- a/frontend/src/components/CreateBoard/SubTeamsTab/SubCardBoard.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/SubCardBoard.tsx
@@ -31,10 +31,12 @@ const SubCardBoard: React.FC<SubCardBoardProps> = ({ board, index, setBoard }) =
   const responsible = users.find((user) => user.role === BoardUserRoles.RESPONSIBLE)?.user;
 
   const handleLottery = () => {
-    const cloneUsers = [...deepClone(users)].map((user) => ({
+    let cloneUsers = [...deepClone(users)].map((user) => ({
       ...user,
       role: BoardUserRoles.MEMBER,
     }));
+
+    cloneUsers = cloneUsers.filter((user) => !user.isNewJoiner);
 
     if (cloneUsers.length <= 1) return;
 

--- a/frontend/src/components/CreateBoard/SubTeamsTab/SubCardBoard.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/SubCardBoard.tsx
@@ -31,12 +31,14 @@ const SubCardBoard: React.FC<SubCardBoardProps> = ({ board, index, setBoard }) =
   const responsible = users.find((user) => user.role === BoardUserRoles.RESPONSIBLE)?.user;
 
   const handleLottery = () => {
-    let cloneUsers = [...deepClone(users)].map((user) => ({
-      ...user,
-      role: BoardUserRoles.MEMBER,
-    }));
-
-    cloneUsers = cloneUsers.filter((user) => !user.isNewJoiner);
+    const cloneUsers = [...deepClone(users)].flatMap((user) => {
+      if (!user.isNewJoiner)
+        return {
+          ...user,
+          role: BoardUserRoles.MEMBER,
+        };
+      return [];
+    });
 
     if (cloneUsers.length <= 1) return;
 

--- a/frontend/src/components/Teams/CreateTeam/CardMember/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardMember/index.tsx
@@ -12,7 +12,7 @@ import { membersListState } from '@/store/team/atom/team.atom';
 import Tooltip from '@/components/Primitives/Tooltip';
 import { ConfigurationSettings } from '@/components/Board/Settings/partials/ConfigurationSettings';
 import CardEndTeam from '@/components/Teams/Team/CardEnd';
-import dayjs from 'dayjs';
+
 import { IconButton, InnerContainer, StyledMemberTitle } from './styles';
 import CardEndCreateTeam from '../CardEnd';
 
@@ -33,18 +33,6 @@ const CardMember = React.memo<CardBodyProps>(
     const {
       updateTeamUser: { mutate },
     } = useTeam({ autoFetchTeam: false });
-
-    const verifyIfIsNewJoiner = () => {
-      const currentDate = dayjs();
-
-      const dateToCompare = member.user.userAzureCreatedAt
-        ? dayjs(member.user.userAzureCreatedAt)
-        : dayjs(member.user.joinedAt);
-
-      const maxDateToBeNewJoiner = dateToCompare.add(3, 'month');
-
-      return currentDate.isBefore(maxDateToBeNewJoiner) || currentDate.isSame(maxDateToBeNewJoiner);
-    };
 
     const handleIsNewJoiner = (checked: boolean) => {
       const listUsersMembers = membersList.map((user) =>
@@ -129,7 +117,7 @@ const CardMember = React.memo<CardBodyProps>(
               <Flex align="center" css={{ width: '35%' }} gap="8" justify="end">
                 <ConfigurationSettings
                   handleCheckedChange={handleSelectFunction}
-                  isChecked={isNewTeamPage ? verifyIfIsNewJoiner() : member.isNewJoiner}
+                  isChecked={member.isNewJoiner}
                   text=""
                   title="New Joiner"
                 />

--- a/frontend/src/components/Teams/CreateTeam/CardMember/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardMember/index.tsx
@@ -12,6 +12,7 @@ import { membersListState } from '@/store/team/atom/team.atom';
 import Tooltip from '@/components/Primitives/Tooltip';
 import { ConfigurationSettings } from '@/components/Board/Settings/partials/ConfigurationSettings';
 import CardEndTeam from '@/components/Teams/Team/CardEnd';
+import dayjs from 'dayjs';
 import { IconButton, InnerContainer, StyledMemberTitle } from './styles';
 import CardEndCreateTeam from '../CardEnd';
 
@@ -32,6 +33,18 @@ const CardMember = React.memo<CardBodyProps>(
     const {
       updateTeamUser: { mutate },
     } = useTeam({ autoFetchTeam: false });
+
+    const verifyIfIsNewJoiner = () => {
+      const currentDate = dayjs();
+
+      const dateToCompare = member.user.userAzureCreatedAt
+        ? dayjs(member.user.userAzureCreatedAt)
+        : dayjs(member.user.joinedAt);
+
+      const maxDateToBeNewJoiner = dateToCompare.add(3, 'month');
+
+      return currentDate.isBefore(maxDateToBeNewJoiner) || currentDate.isSame(maxDateToBeNewJoiner);
+    };
 
     const handleIsNewJoiner = (checked: boolean) => {
       const listUsersMembers = membersList.map((user) =>
@@ -116,7 +129,7 @@ const CardMember = React.memo<CardBodyProps>(
               <Flex align="center" css={{ width: '35%' }} gap="8" justify="end">
                 <ConfigurationSettings
                   handleCheckedChange={handleSelectFunction}
-                  isChecked={member.isNewJoiner}
+                  isChecked={isNewTeamPage ? verifyIfIsNewJoiner() : member.isNewJoiner}
                   text=""
                   title="New Joiner"
                 />

--- a/frontend/src/components/Teams/CreateTeam/ListMembers/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListMembers/index.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, SetStateAction, useMemo, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { Dialog, DialogClose, DialogTrigger } from '@radix-ui/react-dialog';
 
 import Icon from '@/components/icons/Icon';
@@ -35,12 +35,10 @@ const ListMembers = ({ isOpen, setIsOpen }: Props) => {
   const { data: session } = useSession({ required: true });
   const [searchMember, setSearchMember] = useState<string>('');
 
-  const usersList = useRecoilValue(usersListState);
-  const membersList = useRecoilValue(membersListState);
+  const [usersList, setUsersListState] = useRecoilState(usersListState);
+  const [membersList, setMembersListState] = useRecoilState(membersListState);
 
   const setToastState = useSetRecoilState(toastState);
-  const setMembersListState = useSetRecoilState(membersListState);
-  const setUsersListState = useSetRecoilState(usersListState);
 
   // References
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -85,7 +83,7 @@ const ListMembers = ({ isOpen, setIsOpen }: Props) => {
         listOfUsers.find((member) => member.user._id === user._id) || {
           user,
           role: TeamUserRoles.MEMBER,
-          isNewJoiner: verifyIfIsNewJoiner(user.userAzureCreatedAt, user.joinedAt),
+          isNewJoiner: verifyIfIsNewJoiner(user.providerAccountCreatedAt, user.joinedAt),
         },
     );
 

--- a/frontend/src/components/Teams/CreateTeam/ListMembers/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListMembers/index.tsx
@@ -83,7 +83,7 @@ const ListMembers = ({ isOpen, setIsOpen }: Props) => {
         listOfUsers.find((member) => member.user._id === user._id) || {
           user,
           role: TeamUserRoles.MEMBER,
-          isNewJoiner: verifyIfIsNewJoiner(user.providerAccountCreatedAt, user.joinedAt),
+          isNewJoiner: verifyIfIsNewJoiner(user.joinedAt, user.providerAccountCreatedAt),
         },
     );
 

--- a/frontend/src/components/Teams/CreateTeam/ListMembers/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListMembers/index.tsx
@@ -21,6 +21,8 @@ import {
 import Flex from '@/components/Primitives/Flex';
 import Checkbox from '@/components/Primitives/Checkbox';
 import Button from '@/components/Primitives/Button';
+
+import { verifyIfIsNewJoiner } from '@/utils/verifyIfIsNewJoiner';
 import SearchInput from './SearchInput';
 import { ButtonAddMember, ScrollableContent } from './styles';
 
@@ -83,7 +85,7 @@ const ListMembers = ({ isOpen, setIsOpen }: Props) => {
         listOfUsers.find((member) => member.user._id === user._id) || {
           user,
           role: TeamUserRoles.MEMBER,
-          isNewJoiner: false,
+          isNewJoiner: verifyIfIsNewJoiner(user.userAzureCreatedAt, user.joinedAt),
         },
     );
 

--- a/frontend/src/components/Teams/CreateTeam/TipBar/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/TipBar/index.tsx
@@ -47,10 +47,10 @@ const CreateTeamTipBar = () => {
       {listMembers.length > 1 && (
         <>
           <TextWhite css={{ mb: '$8' }} heading="6">
-            Newbie
+            New Joiner
           </TextWhite>
           <LiWhite as="span">
-            The newbie will not be selected as a responsible for the SPLIT sub-teams.
+            The new joiner will not be selected as a responsible for the SPLIT sub-teams.
           </LiWhite>
         </>
       )}

--- a/frontend/src/hooks/useCreateBoard.tsx
+++ b/frontend/src/hooks/useCreateBoard.tsx
@@ -55,10 +55,21 @@ const useCreateBoard = (team: Team) => {
       if (splitUsers && team.users.length >= MIN_MEMBERS) {
         new Array(maxTeams).fill(0).forEach((_, i) => {
           const newBoard = generateSubBoard(i + 1);
+          const teamUsersWotIsNEwJoiner = splitUsers[i].filter((user) => !user.isNewJoiner);
 
           splitUsers[i][Math.floor(Math.random() * splitUsers[i].length)].role =
             BoardUserRoles.RESPONSIBLE;
-          newBoard.users = splitUsers[i];
+
+          teamUsersWotIsNEwJoiner[Math.floor(Math.random() * teamUsersWotIsNEwJoiner.length)].role =
+            BoardUserRoles.RESPONSIBLE;
+
+          const result = splitUsers[i].map((user) =>
+            teamUsersWotIsNEwJoiner.find((member) => member._id === user._id)
+              ? teamUsersWotIsNEwJoiner.find((member) => member._id === user._id)
+              : user,
+          ) as BoardUserToAdd[];
+
+          newBoard.users = result;
           subBoards.push(newBoard);
         });
       }
@@ -76,9 +87,16 @@ const useCreateBoard = (team: Team) => {
       new Array(teamMembers.length).fill(0).reduce((j) => {
         if (j >= maxTeams) j = 0;
         const teamUser = getRandomUser(availableUsers);
+
         splitUsers[j] = [
           ...splitUsers[j],
-          { user: teamUser.user, role: BoardUserRoles.MEMBER, votesCount: 0 },
+          {
+            user: teamUser.user,
+            role: BoardUserRoles.MEMBER,
+            votesCount: 0,
+            isNewJoiner: teamUser.isNewJoiner,
+            _id: teamUser._id,
+          },
         ];
         return ++j;
       }, 0);

--- a/frontend/src/hooks/useCreateBoard.tsx
+++ b/frontend/src/hooks/useCreateBoard.tsx
@@ -77,7 +77,7 @@ const useCreateBoard = (team: Team) => {
   const sortUsersListByOldestCreatedDate = (users: TeamUser[]) =>
     users
       .map((user) => {
-        user.userCreated = user.user.userAzureCreatedAt || user.user.joinedAt;
+        user.userCreated = user.user.providerAccountCreatedAt || user.user.joinedAt;
         return user;
       })
       .sort((a, b) => Number(b.userCreated) - Number(a.userCreated));

--- a/frontend/src/hooks/useCreateBoard.tsx
+++ b/frontend/src/hooks/useCreateBoard.tsx
@@ -55,13 +55,13 @@ const useCreateBoard = (team: Team) => {
       if (splitUsers && team.users.length >= MIN_MEMBERS) {
         new Array(maxTeams).fill(0).forEach((_, i) => {
           const newBoard = generateSubBoard(i + 1);
-          const teamUsersWotIsNEwJoiner = splitUsers[i].filter((user) => !user.isNewJoiner);
+          const teamUsersWotIsNewJoiner = splitUsers[i].filter((user) => !user.isNewJoiner);
 
-          teamUsersWotIsNEwJoiner[Math.floor(Math.random() * teamUsersWotIsNEwJoiner.length)].role =
+          teamUsersWotIsNewJoiner[Math.floor(Math.random() * teamUsersWotIsNewJoiner.length)].role =
             BoardUserRoles.RESPONSIBLE;
 
           const result = splitUsers[i].map(
-            (user) => teamUsersWotIsNEwJoiner.find((member) => member._id === user._id) || user,
+            (user) => teamUsersWotIsNewJoiner.find((member) => member._id === user._id) || user,
           ) as BoardUserToAdd[];
 
           newBoard.users = result;

--- a/frontend/src/hooks/useCreateBoard.tsx
+++ b/frontend/src/hooks/useCreateBoard.tsx
@@ -57,16 +57,11 @@ const useCreateBoard = (team: Team) => {
           const newBoard = generateSubBoard(i + 1);
           const teamUsersWotIsNEwJoiner = splitUsers[i].filter((user) => !user.isNewJoiner);
 
-          splitUsers[i][Math.floor(Math.random() * splitUsers[i].length)].role =
-            BoardUserRoles.RESPONSIBLE;
-
           teamUsersWotIsNEwJoiner[Math.floor(Math.random() * teamUsersWotIsNEwJoiner.length)].role =
             BoardUserRoles.RESPONSIBLE;
 
-          const result = splitUsers[i].map((user) =>
-            teamUsersWotIsNEwJoiner.find((member) => member._id === user._id)
-              ? teamUsersWotIsNEwJoiner.find((member) => member._id === user._id)
-              : user,
+          const result = splitUsers[i].map(
+            (user) => teamUsersWotIsNEwJoiner.find((member) => member._id === user._id) || user,
           ) as BoardUserToAdd[];
 
           newBoard.users = result;

--- a/frontend/src/pages/api/auth/[...nextauth].tsx
+++ b/frontend/src/pages/api/auth/[...nextauth].tsx
@@ -91,7 +91,7 @@ export default NextAuth({
           email,
           _id,
           isSAdmin,
-          userAzureCreatedAt,
+          providerAccountCreatedAt,
         } = data;
         user.firstName = firstName;
         user.lastName = lastName;
@@ -101,7 +101,7 @@ export default NextAuth({
         user.strategy = 'azure';
         user.id = _id;
         user.isSAdmin = isSAdmin;
-        user.userAzureCreatedAt = userAzureCreatedAt;
+        user.providerAccountCreatedAt = providerAccountCreatedAt;
       }
 
       return true;

--- a/frontend/src/pages/api/auth/[...nextauth].tsx
+++ b/frontend/src/pages/api/auth/[...nextauth].tsx
@@ -83,14 +83,13 @@ export default NextAuth({
 
         if (!data) return false;
 
-
         const {
           firstName,
           lastName,
           accessToken,
           refreshToken,
           email,
-          id,
+          _id,
           isSAdmin,
           userAzureCreatedAt,
         } = data;

--- a/frontend/src/pages/api/auth/[...nextauth].tsx
+++ b/frontend/src/pages/api/auth/[...nextauth].tsx
@@ -82,7 +82,18 @@ export default NextAuth({
         const data = await createOrLoginUserAzure(azureAccessToken ?? '');
 
         if (!data) return false;
-        const { firstName, lastName, accessToken, refreshToken, email, _id, isSAdmin } = data;
+
+
+        const {
+          firstName,
+          lastName,
+          accessToken,
+          refreshToken,
+          email,
+          id,
+          isSAdmin,
+          userAzureCreatedAt,
+        } = data;
         user.firstName = firstName;
         user.lastName = lastName;
         user.accessToken = accessToken;
@@ -91,6 +102,7 @@ export default NextAuth({
         user.strategy = 'azure';
         user.id = _id;
         user.isSAdmin = isSAdmin;
+        user.userAzureCreatedAt = userAzureCreatedAt || undefined;
       }
 
       return true;

--- a/frontend/src/pages/api/auth/[...nextauth].tsx
+++ b/frontend/src/pages/api/auth/[...nextauth].tsx
@@ -101,7 +101,7 @@ export default NextAuth({
         user.strategy = 'azure';
         user.id = _id;
         user.isSAdmin = isSAdmin;
-        user.userAzureCreatedAt = userAzureCreatedAt || undefined;
+        user.userAzureCreatedAt = userAzureCreatedAt;
       }
 
       return true;

--- a/frontend/src/pages/teams/new.tsx
+++ b/frontend/src/pages/teams/new.tsx
@@ -44,7 +44,7 @@ const NewTeam: NextPage = () => {
         listMembers.push({
           user,
           role: TeamUserRoles.ADMIN,
-          isNewJoiner: verifyIfIsNewJoiner(user.providerAccountCreatedAt, user.joinedAt),
+          isNewJoiner: verifyIfIsNewJoiner(user.joinedAt, user.providerAccountCreatedAt),
         });
       }
     });

--- a/frontend/src/pages/teams/new.tsx
+++ b/frontend/src/pages/teams/new.tsx
@@ -12,6 +12,7 @@ import { toastState } from '@/store/toast/atom/toast.atom';
 import { TeamUser } from '@/types/team/team.user';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 import { ToastStateEnum } from '@/utils/enums/toast-types';
+import { verifyIfIsNewJoiner } from '@/utils/verifyIfIsNewJoiner';
 
 const NewTeam: NextPage = () => {
   const { data: session } = useSession({ required: true });
@@ -43,7 +44,7 @@ const NewTeam: NextPage = () => {
         listMembers.push({
           user,
           role: TeamUserRoles.ADMIN,
-          isNewJoiner: false,
+          isNewJoiner: verifyIfIsNewJoiner(user.userAzureCreatedAt, user.joinedAt),
         });
       }
     });

--- a/frontend/src/pages/teams/new.tsx
+++ b/frontend/src/pages/teams/new.tsx
@@ -44,7 +44,7 @@ const NewTeam: NextPage = () => {
         listMembers.push({
           user,
           role: TeamUserRoles.ADMIN,
-          isNewJoiner: verifyIfIsNewJoiner(user.userAzureCreatedAt, user.joinedAt),
+          isNewJoiner: verifyIfIsNewJoiner(user.providerAccountCreatedAt, user.joinedAt),
         });
       }
     });

--- a/frontend/src/types/board/board.user.ts
+++ b/frontend/src/types/board/board.user.ts
@@ -21,7 +21,7 @@ export interface BoardUserToAdd {
   role: BoardUserRoles;
   votesCount: number;
   isNewJoiner?: boolean;
-  _id: string;
+  _id?: string;
 }
 
 export interface BoardUserDto {

--- a/frontend/src/types/board/board.user.ts
+++ b/frontend/src/types/board/board.user.ts
@@ -20,6 +20,8 @@ export interface BoardUserToAdd {
   user: User;
   role: BoardUserRoles;
   votesCount: number;
+  isNewJoiner?: boolean;
+  _id: string;
 }
 
 export interface BoardUserDto {

--- a/frontend/src/types/next-auth.d.ts
+++ b/frontend/src/types/next-auth.d.ts
@@ -25,7 +25,7 @@ declare module 'next-auth' {
     firstName: string;
     lastName: string;
     isSAdmin: boolean;
-    userAzureCreatedAt?: Date;
+    providerAccountCreatedAt?: Date;
   }
 }
 

--- a/frontend/src/types/next-auth.d.ts
+++ b/frontend/src/types/next-auth.d.ts
@@ -25,7 +25,7 @@ declare module 'next-auth' {
     firstName: string;
     lastName: string;
     isSAdmin: boolean;
-    providerAccountCreatedAt?: Date;
+    providerAccountCreatedAt?: string;
   }
 }
 

--- a/frontend/src/types/next-auth.d.ts
+++ b/frontend/src/types/next-auth.d.ts
@@ -25,6 +25,7 @@ declare module 'next-auth' {
     firstName: string;
     lastName: string;
     isSAdmin: boolean;
+    userAzureCreatedAt?: Date;
   }
 }
 

--- a/frontend/src/types/team/team.user.ts
+++ b/frontend/src/types/team/team.user.ts
@@ -7,6 +7,7 @@ export interface TeamUser {
   isNewJoiner: boolean;
   _id?: string;
   team?: string;
+  userCreated?: Date | string;
 }
 
 export interface CreateTeamUser {

--- a/frontend/src/types/team/team.user.ts
+++ b/frontend/src/types/team/team.user.ts
@@ -5,7 +5,7 @@ export interface TeamUser {
   user: User;
   role: TeamUserRoles;
   isNewJoiner: boolean;
-  _id?: string;
+  _id: string;
   team?: string;
 }
 

--- a/frontend/src/types/team/team.user.ts
+++ b/frontend/src/types/team/team.user.ts
@@ -5,7 +5,7 @@ export interface TeamUser {
   user: User;
   role: TeamUserRoles;
   isNewJoiner: boolean;
-  _id: string;
+  _id?: string;
   team?: string;
 }
 

--- a/frontend/src/types/team/userList.ts
+++ b/frontend/src/types/team/userList.ts
@@ -6,5 +6,5 @@ export interface UserList {
   isSAdmin: boolean;
   joinedAt: string;
   isChecked: boolean;
-  providerAccountCreatedAt?: Date;
+  providerAccountCreatedAt?: string;
 }

--- a/frontend/src/types/team/userList.ts
+++ b/frontend/src/types/team/userList.ts
@@ -6,5 +6,5 @@ export interface UserList {
   isSAdmin: boolean;
   joinedAt: string;
   isChecked: boolean;
-  userAzureCreatedAt?: Date;
+  providerAccountCreatedAt?: Date;
 }

--- a/frontend/src/types/team/userList.ts
+++ b/frontend/src/types/team/userList.ts
@@ -6,4 +6,5 @@ export interface UserList {
   isSAdmin: boolean;
   joinedAt: string;
   isChecked: boolean;
+  userAzureCreatedAt?: Date;
 }

--- a/frontend/src/types/user/create-login.user.ts
+++ b/frontend/src/types/user/create-login.user.ts
@@ -9,5 +9,5 @@ export interface CreateOrLogin {
   firstName: string;
   lastName: string;
   isSAdmin: boolean;
-  userAzureCreatedAt?: string;
+  userAzureCreatedAt?: Date;
 }

--- a/frontend/src/types/user/create-login.user.ts
+++ b/frontend/src/types/user/create-login.user.ts
@@ -9,5 +9,5 @@ export interface CreateOrLogin {
   firstName: string;
   lastName: string;
   isSAdmin: boolean;
-  providerAccountCreatedAt?: Date;
+  providerAccountCreatedAt?: string;
 }

--- a/frontend/src/types/user/create-login.user.ts
+++ b/frontend/src/types/user/create-login.user.ts
@@ -9,5 +9,5 @@ export interface CreateOrLogin {
   firstName: string;
   lastName: string;
   isSAdmin: boolean;
-  userAzureCreatedAt?: Date;
+  userAzureCreatedAt?: string;
 }

--- a/frontend/src/types/user/create-login.user.ts
+++ b/frontend/src/types/user/create-login.user.ts
@@ -9,5 +9,5 @@ export interface CreateOrLogin {
   firstName: string;
   lastName: string;
   isSAdmin: boolean;
-  userAzureCreatedAt?: Date;
+  providerAccountCreatedAt?: Date;
 }

--- a/frontend/src/types/user/create-login.user.ts
+++ b/frontend/src/types/user/create-login.user.ts
@@ -9,4 +9,5 @@ export interface CreateOrLogin {
   firstName: string;
   lastName: string;
   isSAdmin: boolean;
+  userAzureCreatedAt?: Date;
 }

--- a/frontend/src/types/user/user.ts
+++ b/frontend/src/types/user/user.ts
@@ -15,6 +15,7 @@ export interface User {
   refreshToken?: Token;
   isSAdmin: boolean;
   joinedAt: string;
+  userAzureCreatedAt?: Date;
 }
 
 export interface UseUserType {

--- a/frontend/src/types/user/user.ts
+++ b/frontend/src/types/user/user.ts
@@ -15,7 +15,7 @@ export interface User {
   refreshToken?: Token;
   isSAdmin: boolean;
   joinedAt: string;
-  providerAccountCreatedAt?: Date;
+  providerAccountCreatedAt?: string;
 }
 
 export interface UseUserType {

--- a/frontend/src/types/user/user.ts
+++ b/frontend/src/types/user/user.ts
@@ -15,7 +15,7 @@ export interface User {
   refreshToken?: Token;
   isSAdmin: boolean;
   joinedAt: string;
-  userAzureCreatedAt?: Date;
+  providerAccountCreatedAt?: Date;
 }
 
 export interface UseUserType {

--- a/frontend/src/types/user/user.ts
+++ b/frontend/src/types/user/user.ts
@@ -15,7 +15,7 @@ export interface User {
   refreshToken?: Token;
   isSAdmin: boolean;
   joinedAt: string;
-  userAzureCreatedAt?: string;
+  userAzureCreatedAt?: Date;
 }
 
 export interface UseUserType {

--- a/frontend/src/types/user/user.ts
+++ b/frontend/src/types/user/user.ts
@@ -15,7 +15,7 @@ export interface User {
   refreshToken?: Token;
   isSAdmin: boolean;
   joinedAt: string;
-  userAzureCreatedAt?: Date;
+  userAzureCreatedAt?: string;
 }
 
 export interface UseUserType {

--- a/frontend/src/utils/verifyIfIsNewJoiner.ts
+++ b/frontend/src/utils/verifyIfIsNewJoiner.ts
@@ -1,16 +1,9 @@
-import dayjs from 'dayjs';
+import { addMonths, isAfter, parseISO } from 'date-fns';
 
-export const verifyIfIsNewJoiner = (
-  providerAccountCreatedAt: Date | undefined,
-  joinedAt: string,
-) => {
-  const currentDate = dayjs();
+export const verifyIfIsNewJoiner = (joinedAt: string, providerAccountCreatedAt?: string) => {
+  const dateToCompare = parseISO(providerAccountCreatedAt || joinedAt);
 
-  const dateToCompare = providerAccountCreatedAt
-    ? dayjs(providerAccountCreatedAt)
-    : dayjs(joinedAt);
+  const maxDateToBeNewJoiner = addMonths(dateToCompare, 2);
 
-  const maxDateToBeNewJoiner = dateToCompare.add(3, 'month');
-
-  return maxDateToBeNewJoiner.isAfter(currentDate);
+  return isAfter(maxDateToBeNewJoiner, new Date());
 };

--- a/frontend/src/utils/verifyIfIsNewJoiner.ts
+++ b/frontend/src/utils/verifyIfIsNewJoiner.ts
@@ -1,0 +1,11 @@
+import dayjs from 'dayjs';
+
+export const verifyIfIsNewJoiner = (userAzureCreatedAt: Date | undefined, joinedAt: string) => {
+  const currentDate = dayjs();
+
+  const dateToCompare = userAzureCreatedAt ? dayjs(userAzureCreatedAt) : dayjs(joinedAt);
+
+  const maxDateToBeNewJoiner = dateToCompare.add(2, 'month');
+
+  return currentDate.isBefore(maxDateToBeNewJoiner) || currentDate.isSame(maxDateToBeNewJoiner);
+};

--- a/frontend/src/utils/verifyIfIsNewJoiner.ts
+++ b/frontend/src/utils/verifyIfIsNewJoiner.ts
@@ -1,11 +1,16 @@
 import dayjs from 'dayjs';
 
-export const verifyIfIsNewJoiner = (userAzureCreatedAt: Date | undefined, joinedAt: string) => {
+export const verifyIfIsNewJoiner = (
+  providerAccountCreatedAt: Date | undefined,
+  joinedAt: string,
+) => {
   const currentDate = dayjs();
 
-  const dateToCompare = userAzureCreatedAt ? dayjs(userAzureCreatedAt) : dayjs(joinedAt);
+  const dateToCompare = providerAccountCreatedAt
+    ? dayjs(providerAccountCreatedAt)
+    : dayjs(joinedAt);
 
   const maxDateToBeNewJoiner = dateToCompare.add(3, 'month');
 
-  return currentDate.isBefore(maxDateToBeNewJoiner) || currentDate.isSame(maxDateToBeNewJoiner);
+  return maxDateToBeNewJoiner.isAfter(currentDate);
 };

--- a/frontend/src/utils/verifyIfIsNewJoiner.ts
+++ b/frontend/src/utils/verifyIfIsNewJoiner.ts
@@ -5,7 +5,7 @@ export const verifyIfIsNewJoiner = (userAzureCreatedAt: Date | undefined, joined
 
   const dateToCompare = userAzureCreatedAt ? dayjs(userAzureCreatedAt) : dayjs(joinedAt);
 
-  const maxDateToBeNewJoiner = dateToCompare.add(2, 'month');
+  const maxDateToBeNewJoiner = dateToCompare.add(3, 'month');
 
   return currentDate.isBefore(maxDateToBeNewJoiner) || currentDate.isSame(maxDateToBeNewJoiner);
 };


### PR DESCRIPTION


Relates to #636 


## Proposed Changes

  - Change the logic of creating the teams of the subboards.
  - If there aren't enough members who can be responsible for a subboard, the oldest new joiner user will be chosen
  - Everytime a board is created, a verification function is executed, to check if the new joiners are still new joiners, updating accordingly.




This pull request closes #636