### PR TITLE
feat: change team on create board

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,6 +20,7 @@
 				"@radix-ui/react-hover-card": "^0.1.5",
 				"@radix-ui/react-label": "^0.1.5",
 				"@radix-ui/react-popover": "^0.1.6",
+				"@radix-ui/react-select": "^1.1.2",
 				"@radix-ui/react-separator": "^0.1.4",
 				"@radix-ui/react-switch": "^0.1.5",
 				"@radix-ui/react-tabs": "^0.1.5",
@@ -1817,6 +1818,14 @@
 			"resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-0.1.8.tgz",
 			"integrity": "sha512-jwRMXYwC0hUo0mv6wGpuw254Pd9p/R6Td5xsRpOmaWkUHlooNWqVcadgyzlRumMq3xfOTXwJReU0Jv+EIy4Jbw=="
 		},
+		"node_modules/@radix-ui/number": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.0.tgz",
+			"integrity": "sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
 		"node_modules/@radix-ui/popper": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@radix-ui/popper/-/popper-0.1.0.tgz",
@@ -1998,6 +2007,17 @@
 			"peerDependencies": {
 				"react": "^16.8 || ^17.0",
 				"react-dom": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-direction": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
+			"integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
 			}
 		},
 		"node_modules/@radix-ui/react-dismissable-layer": {
@@ -2239,6 +2259,247 @@
 			},
 			"peerDependencies": {
 				"react": "^16.8 || ^17.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-1.1.2.tgz",
+			"integrity": "sha512-pQmfz7T6oR5m27E3NgKOo6DLs5U1qMZaUcfTENXZnNPeyyRN8pEb6Z+xXE6zomP5sg9pgLOtir4R2Q3f2kkF9w==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/number": "1.0.0",
+				"@radix-ui/primitive": "1.0.0",
+				"@radix-ui/react-collection": "1.0.1",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-context": "1.0.0",
+				"@radix-ui/react-direction": "1.0.0",
+				"@radix-ui/react-dismissable-layer": "1.0.2",
+				"@radix-ui/react-focus-guards": "1.0.0",
+				"@radix-ui/react-focus-scope": "1.0.1",
+				"@radix-ui/react-id": "1.0.0",
+				"@radix-ui/react-portal": "1.0.1",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-slot": "1.0.1",
+				"@radix-ui/react-use-callback-ref": "1.0.0",
+				"@radix-ui/react-use-controllable-state": "1.0.0",
+				"@radix-ui/react-use-layout-effect": "1.0.0",
+				"@radix-ui/react-use-previous": "1.0.0",
+				"@radix-ui/react-visually-hidden": "1.0.1",
+				"aria-hidden": "^1.1.1",
+				"react-remove-scroll": "2.5.5"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/primitive": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+			"integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-collection": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.1.tgz",
+			"integrity": "sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-context": "1.0.0",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-slot": "1.0.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-compose-refs": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+			"integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-context": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+			"integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-dismissable-layer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.2.tgz",
+			"integrity": "sha512-WjJzMrTWROozDqLB0uRWYvj4UuXsM/2L19EmQ3Au+IJWqwvwq9Bwd+P8ivo0Deg9JDPArR1I6MbWNi1CmXsskg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/primitive": "1.0.0",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-use-callback-ref": "1.0.0",
+				"@radix-ui/react-use-escape-keydown": "1.0.2"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-focus-guards": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz",
+			"integrity": "sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-focus-scope": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.1.tgz",
+			"integrity": "sha512-Ej2MQTit8IWJiS2uuujGUmxXjF/y5xZptIIQnyd2JHLwtV0R2j9NRVoRj/1j/gJ7e3REdaBw4Hjf4a1ImhkZcQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-use-callback-ref": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-id": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+			"integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-layout-effect": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-portal": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.1.tgz",
+			"integrity": "sha512-NY2vUWI5WENgAT1nfC6JS7RU5xRYBfjZVLq0HmgEN1Ezy3rk/UruMV4+Rd0F40PEaFC5SrLS1ixYvcYIQrb4Ig==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-primitive": "1.0.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-primitive": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz",
+			"integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-slot": "1.0.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-slot": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+			"integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-compose-refs": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-callback-ref": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+			"integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-controllable-state": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+			"integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-callback-ref": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-escape-keydown": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.2.tgz",
+			"integrity": "sha512-DXGim3x74WgUv+iMNCF+cAo8xUHHeqvjx8zs7trKf+FkQKPQXLk2sX7Gx1ysH7Q76xCpZuxIJE7HLPxRE+Q+GA==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-use-callback-ref": "1.0.0"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-layout-effect": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+			"integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-use-previous": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.0.tgz",
+			"integrity": "sha512-RG2K8z/K7InnOKpq6YLDmT49HGjNmrK+fr82UCVKT2sW0GYfVnYp4wZWBooT/EYfQ5faA9uIjvsuMMhH61rheg==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0"
+			}
+		},
+		"node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-visually-hidden": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.1.tgz",
+			"integrity": "sha512-K1hJcCMfWfiYUibRqf3V8r5Drpyf7rh44jnrwAbdvI5iCCijilBBeyQv9SKidYNZIopMdCyR9FnIjkHxHN0FcQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/react-primitive": "1.0.1"
+			},
+			"peerDependencies": {
+				"react": "^16.8 || ^17.0 || ^18.0",
+				"react-dom": "^16.8 || ^17.0 || ^18.0"
 			}
 		},
 		"node_modules/@radix-ui/react-separator": {
@@ -13751,6 +14012,14 @@
 			"resolved": "https://registry.npmjs.org/@radix-ui/colors/-/colors-0.1.8.tgz",
 			"integrity": "sha512-jwRMXYwC0hUo0mv6wGpuw254Pd9p/R6Td5xsRpOmaWkUHlooNWqVcadgyzlRumMq3xfOTXwJReU0Jv+EIy4Jbw=="
 		},
+		"@radix-ui/number": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.0.0.tgz",
+			"integrity": "sha512-Ofwh/1HX69ZfJRiRBMTy7rgjAzHmwe4kW9C9Y99HTRUcYLUuVT0KESFj15rPjRgKJs20GPq8Bm5aEDJ8DuA3vA==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
+			}
+		},
 		"@radix-ui/popper": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/@radix-ui/popper/-/popper-0.1.0.tgz",
@@ -13900,6 +14169,14 @@
 				"@radix-ui/react-use-controllable-state": "0.1.0",
 				"aria-hidden": "^1.1.1",
 				"react-remove-scroll": "^2.4.0"
+			}
+		},
+		"@radix-ui/react-direction": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.0.tgz",
+			"integrity": "sha512-2HV05lGUgYcA6xgLQ4BKPDmtL+QbIZYH5fCOTAOOcJ5O0QbWS3i9lKaurLzliYUDhORI2Qr3pyjhJh44lKA3rQ==",
+			"requires": {
+				"@babel/runtime": "^7.13.10"
 			}
 		},
 		"@radix-ui/react-dismissable-layer": {
@@ -14094,6 +14371,191 @@
 				"@radix-ui/react-primitive": "0.1.4",
 				"@radix-ui/react-use-callback-ref": "0.1.0",
 				"@radix-ui/react-use-controllable-state": "0.1.0"
+			}
+		},
+		"@radix-ui/react-select": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-1.1.2.tgz",
+			"integrity": "sha512-pQmfz7T6oR5m27E3NgKOo6DLs5U1qMZaUcfTENXZnNPeyyRN8pEb6Z+xXE6zomP5sg9pgLOtir4R2Q3f2kkF9w==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@radix-ui/number": "1.0.0",
+				"@radix-ui/primitive": "1.0.0",
+				"@radix-ui/react-collection": "1.0.1",
+				"@radix-ui/react-compose-refs": "1.0.0",
+				"@radix-ui/react-context": "1.0.0",
+				"@radix-ui/react-direction": "1.0.0",
+				"@radix-ui/react-dismissable-layer": "1.0.2",
+				"@radix-ui/react-focus-guards": "1.0.0",
+				"@radix-ui/react-focus-scope": "1.0.1",
+				"@radix-ui/react-id": "1.0.0",
+				"@radix-ui/react-portal": "1.0.1",
+				"@radix-ui/react-primitive": "1.0.1",
+				"@radix-ui/react-slot": "1.0.1",
+				"@radix-ui/react-use-callback-ref": "1.0.0",
+				"@radix-ui/react-use-controllable-state": "1.0.0",
+				"@radix-ui/react-use-layout-effect": "1.0.0",
+				"@radix-ui/react-use-previous": "1.0.0",
+				"@radix-ui/react-visually-hidden": "1.0.1",
+				"aria-hidden": "^1.1.1",
+				"react-remove-scroll": "2.5.5"
+			},
+			"dependencies": {
+				"@radix-ui/primitive": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.0.tgz",
+					"integrity": "sha512-3e7rn8FDMin4CgeL7Z/49smCA3rFYY3Ha2rUQ7HRWFadS5iCRw08ZgVT1LaNTCNqgvrUiyczLflrVrF0SRQtNA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@radix-ui/react-collection": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.1.tgz",
+					"integrity": "sha512-uuiFbs+YCKjn3X1DTSx9G7BHApu4GHbi3kgiwsnFUbOKCrwejAJv4eE4Vc8C0Oaxt9T0aV4ox0WCOdx+39Xo+g==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-compose-refs": "1.0.0",
+						"@radix-ui/react-context": "1.0.0",
+						"@radix-ui/react-primitive": "1.0.1",
+						"@radix-ui/react-slot": "1.0.1"
+					}
+				},
+				"@radix-ui/react-compose-refs": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.0.tgz",
+					"integrity": "sha512-0KaSv6sx787/hK3eF53iOkiSLwAGlFMx5lotrqD2pTjB18KbybKoEIgkNZTKC60YECDQTKGTRcDBILwZVqVKvA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@radix-ui/react-context": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.0.tgz",
+					"integrity": "sha512-1pVM9RfOQ+n/N5PJK33kRSKsr1glNxomxONs5c49MliinBY6Yw2Q995qfBUUo0/Mbg05B/sGA0gkgPI7kmSHBg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@radix-ui/react-dismissable-layer": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.2.tgz",
+					"integrity": "sha512-WjJzMrTWROozDqLB0uRWYvj4UuXsM/2L19EmQ3Au+IJWqwvwq9Bwd+P8ivo0Deg9JDPArR1I6MbWNi1CmXsskg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/primitive": "1.0.0",
+						"@radix-ui/react-compose-refs": "1.0.0",
+						"@radix-ui/react-primitive": "1.0.1",
+						"@radix-ui/react-use-callback-ref": "1.0.0",
+						"@radix-ui/react-use-escape-keydown": "1.0.2"
+					}
+				},
+				"@radix-ui/react-focus-guards": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.0.tgz",
+					"integrity": "sha512-UagjDk4ijOAnGu4WMUPj9ahi7/zJJqNZ9ZAiGPp7waUWJO0O1aWXi/udPphI0IUjvrhBsZJGSN66dR2dsueLWQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@radix-ui/react-focus-scope": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.1.tgz",
+					"integrity": "sha512-Ej2MQTit8IWJiS2uuujGUmxXjF/y5xZptIIQnyd2JHLwtV0R2j9NRVoRj/1j/gJ7e3REdaBw4Hjf4a1ImhkZcQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-compose-refs": "1.0.0",
+						"@radix-ui/react-primitive": "1.0.1",
+						"@radix-ui/react-use-callback-ref": "1.0.0"
+					}
+				},
+				"@radix-ui/react-id": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.0.tgz",
+					"integrity": "sha512-Q6iAB/U7Tq3NTolBBQbHTgclPmGWE3OlktGGqrClPozSw4vkQ1DfQAOtzgRPecKsMdJINE05iaoDUG8tRzCBjw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-use-layout-effect": "1.0.0"
+					}
+				},
+				"@radix-ui/react-portal": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.1.tgz",
+					"integrity": "sha512-NY2vUWI5WENgAT1nfC6JS7RU5xRYBfjZVLq0HmgEN1Ezy3rk/UruMV4+Rd0F40PEaFC5SrLS1ixYvcYIQrb4Ig==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-primitive": "1.0.1"
+					}
+				},
+				"@radix-ui/react-primitive": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.1.tgz",
+					"integrity": "sha512-fHbmislWVkZaIdeF6GZxF0A/NH/3BjrGIYj+Ae6eTmTCr7EB0RQAAVEiqsXK6p3/JcRqVSBQoceZroj30Jj3XA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-slot": "1.0.1"
+					}
+				},
+				"@radix-ui/react-slot": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.1.tgz",
+					"integrity": "sha512-avutXAFL1ehGvAXtPquu0YK5oz6ctS474iM3vNGQIkswrVhdrS52e3uoMQBzZhNRAIE0jBnUyXWNmSjGHhCFcw==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-compose-refs": "1.0.0"
+					}
+				},
+				"@radix-ui/react-use-callback-ref": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.0.tgz",
+					"integrity": "sha512-GZtyzoHz95Rhs6S63D2t/eqvdFCm7I+yHMLVQheKM7nBD8mbZIt+ct1jz4536MDnaOGKIxynJ8eHTkVGVVkoTg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@radix-ui/react-use-controllable-state": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.0.tgz",
+					"integrity": "sha512-FohDoZvk3mEXh9AWAVyRTYR4Sq7/gavuofglmiXB2g1aKyboUD4YtgWxKj8O5n+Uak52gXQ4wKz5IFST4vtJHg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-use-callback-ref": "1.0.0"
+					}
+				},
+				"@radix-ui/react-use-escape-keydown": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.2.tgz",
+					"integrity": "sha512-DXGim3x74WgUv+iMNCF+cAo8xUHHeqvjx8zs7trKf+FkQKPQXLk2sX7Gx1ysH7Q76xCpZuxIJE7HLPxRE+Q+GA==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-use-callback-ref": "1.0.0"
+					}
+				},
+				"@radix-ui/react-use-layout-effect": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.0.tgz",
+					"integrity": "sha512-6Tpkq+R6LOlmQb1R5NNETLG0B4YP0wc+klfXafpUCj6JGyaUc8il7/kUZ7m59rGbXGczE9Bs+iz2qloqsZBduQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@radix-ui/react-use-previous": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.0.0.tgz",
+					"integrity": "sha512-RG2K8z/K7InnOKpq6YLDmT49HGjNmrK+fr82UCVKT2sW0GYfVnYp4wZWBooT/EYfQ5faA9uIjvsuMMhH61rheg==",
+					"requires": {
+						"@babel/runtime": "^7.13.10"
+					}
+				},
+				"@radix-ui/react-visually-hidden": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.0.1.tgz",
+					"integrity": "sha512-K1hJcCMfWfiYUibRqf3V8r5Drpyf7rh44jnrwAbdvI5iCCijilBBeyQv9SKidYNZIopMdCyR9FnIjkHxHN0FcQ==",
+					"requires": {
+						"@babel/runtime": "^7.13.10",
+						"@radix-ui/react-primitive": "1.0.1"
+					}
+				}
 			}
 		},
 		"@radix-ui/react-separator": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
 		"@radix-ui/react-hover-card": "^0.1.5",
 		"@radix-ui/react-label": "^0.1.5",
 		"@radix-ui/react-popover": "^0.1.6",
+		"@radix-ui/react-select": "^1.1.2",
 		"@radix-ui/react-separator": "^0.1.4",
 		"@radix-ui/react-switch": "^0.1.5",
 		"@radix-ui/react-tabs": "^0.1.5",

--- a/frontend/src/components/CreateBoard/SettingsTabs.tsx
+++ b/frontend/src/components/CreateBoard/SettingsTabs.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useRecoilValue } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { styled } from '@/styles/stitches/stitches.config';
 
@@ -8,6 +8,8 @@ import Flex from '@/components/Primitives/Flex';
 import Separator from '@/components/Primitives/Separator';
 import Text from '@/components/Primitives/Text';
 import { createBoardError } from '@/store/createBoard/atoms/create-board.atom';
+import { ToastStateEnum } from '@/utils/enums/toast-types';
+import { toastState } from '@/store/toast/atom/toast.atom';
 import BoardConfigurations from './Configurations/BoardConfigurations';
 import TeamSubTeamsConfigurations from './SubTeamsTab/TeamSubTeamsConfigurations';
 
@@ -35,6 +37,7 @@ const Settings = () => {
    * Recoil Atoms
    */
   const haveError = useRecoilValue(createBoardError);
+  const setToastState = useSetRecoilState(toastState);
 
   const {
     formState: { errors },
@@ -44,7 +47,15 @@ const Settings = () => {
     if (errors.maxVotes) {
       setCurrentTab(2);
     }
-  }, [errors.maxVotes]);
+
+    if (errors.team && currentTab === 2) {
+      setToastState({
+        open: true,
+        content: 'Please choose a team in the "Team/-Sub-teams configuration" tab',
+        type: ToastStateEnum.ERROR,
+      });
+    }
+  }, [currentTab, errors.maxVotes, errors.team, setToastState]);
 
   return (
     <Flex direction="column">

--- a/frontend/src/components/CreateBoard/SubTeamsTab/MainBoardCard.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/MainBoardCard.tsx
@@ -1,13 +1,10 @@
 import React, { useEffect } from 'react';
 import { SetterOrUpdater, useRecoilState } from 'recoil';
-
 import { styled } from '@/styles/stitches/stitches.config';
-
 import CardAvatars from '@/components/CardBoard/CardAvatars';
 import Icon from '@/components/icons/Icon';
 import Box from '@/components/Primitives/Box';
 import Checkbox from '@/components/Primitives/Checkbox';
-import Flex from '@/components/Primitives/Flex';
 import Separator from '@/components/Primitives/Separator';
 import Text from '@/components/Primitives/Text';
 import Tooltip from '@/components/Primitives/Tooltip';
@@ -16,17 +13,11 @@ import { CreateBoardData, createBoardError } from '@/store/createBoard/atoms/cre
 import { BoardToAdd } from '@/types/board/board';
 import { Team } from '@/types/team/team';
 import { BoardUserRoles } from '@/utils/enums/board.user.roles';
+import Flex from '@/components/Primitives/Flex';
 import { TeamUserRoles } from '../../../utils/enums/team.user.roles';
 import SubCardBoard from './SubCardBoard';
 
-const MainContainer = styled(Flex, Box, {
-  backgroundColor: 'white',
-  height: '$76',
-  width: '100%',
-  borderRadius: '$12',
-  px: '$24',
-  py: '$22',
-});
+const MainContainer = styled(Flex, Box, {});
 
 interface SubBoardListProp {
   dividedBoards: BoardToAdd[];
@@ -103,7 +94,19 @@ const MainBoardCard = React.memo(({ team, timesOpen }: MainBoardCardInterface) =
 
   return (
     <Flex css={{ width: '100%', height: '100%' }} direction="column" gap="8">
-      <MainContainer align="center" elevation="1" justify="between">
+      <MainContainer
+        align="center"
+        elevation="1"
+        justify="between"
+        css={{
+          backgroundColor: 'white',
+          height: '$76',
+          width: '100%',
+          borderRadius: '$12',
+          px: '$24',
+          py: '$22',
+        }}
+      >
         <Flex>
           <Flex align="center" gap="8">
             <Tooltip content="It’s a main board. All sub-team boards got merged into this main board.">

--- a/frontend/src/components/CreateBoard/SubTeamsTab/MainBoardCard.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/MainBoardCard.tsx
@@ -99,7 +99,7 @@ const MainBoardCard = React.memo(({ team, timesOpen }: MainBoardCardInterface) =
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [team]);
 
   return (
     <Flex css={{ width: '100%', height: '100%' }} direction="column" gap="8">

--- a/frontend/src/components/CreateBoard/SubTeamsTab/SelectTeam/index.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/SelectTeam/index.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import {
+  Select,
+  SelectContent,
+  SelectIcon,
+  SelectItemText,
+  SelectPortal,
+  SelectTrigger,
+  SelectValue,
+  SelectViewport,
+  StyledItem,
+  StyledItemIndicator,
+} from '@/components/Primitives/Select';
+import Icon from '@/components/icons/Icon';
+import Text from '@/components/Primitives/Text';
+import { teamsOfUser } from '@/store/team/atom/team.atom';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { createBoardTeam } from '@/store/createBoard/atoms/create-board.atom';
+import { StyledBox } from './styles';
+
+export const SelectTeam = () => {
+  const [selectedTeam, setSelectedTeam] = useRecoilState(createBoardTeam);
+
+  const teams = useRecoilValue(teamsOfUser);
+
+  const handleTeamChange = (value: string) => {
+    const foundTeam = teams.find((team) => team._id === value);
+
+    setSelectedTeam(foundTeam);
+  };
+
+  return (
+    <StyledBox
+      css={{ width: '100%', py: '$12', pl: '$17', pr: '$16' }}
+      direction="column"
+      elevation="1"
+    >
+      {selectedTeam && (
+        <Text color="primary300" size="xs">
+          Select Team
+        </Text>
+      )}
+      <Select onValueChange={handleTeamChange}>
+        <SelectTrigger aria-label="Food">
+          <SelectValue placeholder="Select Team" />
+          <SelectIcon>
+            <Icon
+              name="arrow-down"
+              css={{
+                width: '$20',
+                height: '$20',
+              }}
+            />
+          </SelectIcon>
+        </SelectTrigger>
+        <SelectPortal>
+          <SelectContent>
+            <SelectViewport>
+              {teams.map((team) => (
+                <StyledItem value={team._id} key={team._id}>
+                  <SelectItemText>{team.name}</SelectItemText>
+                  <StyledItemIndicator>
+                    <Icon
+                      name="check"
+                      css={{
+                        width: '$20',
+                        height: '$20',
+                      }}
+                    />
+                  </StyledItemIndicator>
+                </StyledItem>
+              ))}
+            </SelectViewport>
+          </SelectContent>
+        </SelectPortal>
+      </Select>
+    </StyledBox>
+  );
+};
+
+export default SelectTeam;

--- a/frontend/src/components/CreateBoard/SubTeamsTab/SelectTeam/index.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/SelectTeam/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import {
   Select,
   SelectContent,
@@ -18,77 +18,144 @@ import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { createBoardError, createBoardTeam } from '@/store/createBoard/atoms/create-board.atom';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 import { MIN_MEMBERS } from '@/utils/constants';
-import { StyledBox } from './styles';
+import { useSession } from 'next-auth/react';
+import { useFormContext } from 'react-hook-form';
+import isEmpty from '@/utils/isEmpty';
+import Flex from '@/components/Primitives/Flex';
+import { HelperTextWrapper, StyledBox } from './styles';
 
-export const SelectTeam = () => {
+const SelectTeam = () => {
+  const { data: session } = useSession({ required: true });
+
+  const {
+    setValue,
+    getValues,
+    clearErrors,
+    formState: { errors },
+  } = useFormContext();
+
+  /**
+   * Recoil Atoms and Hooks
+   */
   const [selectedTeam, setSelectedTeam] = useRecoilState(createBoardTeam);
   const setHaveError = useSetRecoilState(createBoardError);
-
   const teams = useRecoilValue(teamsOfUser);
 
+  const message = errors.team?.message;
+  const teamValueOnForm = getValues().team;
+  const isValueEmpty = isEmpty(teamValueOnForm);
+
+  const currentState = useMemo(() => {
+    if (message) return 'error';
+    if (isValueEmpty) return 'default';
+    if (!message && !isValueEmpty) return 'valid';
+    return undefined;
+  }, [message, isValueEmpty]);
+
+  const isHelperEmpty = isEmpty(message);
+
   const handleTeamChange = (value: string) => {
+    clearErrors();
     const foundTeam = teams.find((team) => team._id === value);
+
+    setValue('team', foundTeam?._id);
 
     setSelectedTeam(foundTeam);
   };
 
   useEffect(() => {
     if (selectedTeam) {
-      setHaveError(
-        !!(
-          selectedTeam.users?.filter((user) => user.role !== TeamUserRoles.STAKEHOLDER).length <
-          MIN_MEMBERS
-        ),
+      const haveMinMembers = !!(
+        selectedTeam.users?.filter((user) => user.role !== TeamUserRoles.STAKEHOLDER).length >=
+        MIN_MEMBERS
       );
+
+      const isAdminOrStakeholder = selectedTeam
+        ? !!selectedTeam.users.find(
+            (teamUser) =>
+              teamUser.user._id === session?.user.id &&
+              [TeamUserRoles.ADMIN, TeamUserRoles.STAKEHOLDER].includes(teamUser.role),
+          ) || session?.user.isSAdmin
+        : false;
+
+      setHaveError(!isAdminOrStakeholder || !haveMinMembers);
     }
-  }, [selectedTeam, setHaveError]);
+  }, [selectedTeam, session?.user.id, session?.user.isSAdmin, setHaveError]);
 
   return (
-    <StyledBox
-      css={{ width: '100%', py: '$12', pl: '$17', pr: '$16' }}
-      direction="column"
-      elevation="1"
-    >
-      {selectedTeam && (
-        <Text color="primary300" size="xs">
-          Select Team
-        </Text>
-      )}
-      <Select onValueChange={handleTeamChange}>
-        <SelectTrigger aria-label="Food">
-          <SelectValue placeholder="Select Team" />
-          <SelectIcon>
-            <Icon
-              name="arrow-down"
+    <Flex direction="column" css={{ width: '100%' }}>
+      <StyledBox
+        css={{
+          width: '100%',
+          py: '$12',
+          pl: '$17',
+          pr: '$16',
+          height: '$64',
+          borderRadius: '$4',
+          backgroundColor: 'white',
+          border: currentState === 'error' ? '1px solid $dangerBase' : '1px solid $primary200',
+        }}
+        direction="column"
+        elevation="1"
+      >
+        {selectedTeam && (
+          <Text color="primary300" size="xs">
+            Select Team
+          </Text>
+        )}
+        <Select onValueChange={handleTeamChange}>
+          <SelectTrigger aria-label="Teams">
+            <SelectValue placeholder="Select Team" />
+            <SelectIcon>
+              <Icon
+                name="arrow-down"
+                css={{
+                  width: '$20',
+                  height: '$20',
+                }}
+              />
+            </SelectIcon>
+          </SelectTrigger>
+          <SelectPortal>
+            <SelectContent>
+              <SelectViewport>
+                {teams.map((team) => (
+                  <StyledItem value={team._id} key={team._id}>
+                    <SelectItemText>
+                      {team.name} <Text color="primary300">({team.users.length} members)</Text>
+                    </SelectItemText>
+                    <StyledItemIndicator>
+                      <Icon
+                        name="check"
+                        css={{
+                          width: '$20',
+                          height: '$20',
+                        }}
+                      />
+                    </StyledItemIndicator>
+                  </StyledItem>
+                ))}
+              </SelectViewport>
+            </SelectContent>
+          </SelectPortal>
+        </Select>
+      </StyledBox>
+      <Flex justify={!isHelperEmpty ? 'between' : 'end'}>
+        {!isHelperEmpty && (
+          <HelperTextWrapper css={{ mt: '$8' }} gap="4">
+            {currentState === 'error' && <Icon css={{ width: '$24', height: '$24' }} name="info" />}
+            <Text
+              hint
               css={{
-                width: '$20',
-                height: '$20',
+                color: currentState === 'error' ? '$dangerBase' : '$primary300',
               }}
-            />
-          </SelectIcon>
-        </SelectTrigger>
-        <SelectPortal>
-          <SelectContent>
-            <SelectViewport>
-              {teams.map((team) => (
-                <StyledItem value={team._id} key={team._id}>
-                  <SelectItemText>{team.name}</SelectItemText>
-                  <StyledItemIndicator>
-                    <Icon
-                      name="check"
-                      css={{
-                        width: '$20',
-                        height: '$20',
-                      }}
-                    />
-                  </StyledItemIndicator>
-                </StyledItem>
-              ))}
-            </SelectViewport>
-          </SelectContent>
-        </SelectPortal>
-      </Select>
-    </StyledBox>
+            >
+              {message}
+            </Text>
+          </HelperTextWrapper>
+        )}
+      </Flex>
+    </Flex>
   );
 };
 

--- a/frontend/src/components/CreateBoard/SubTeamsTab/SelectTeam/index.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/SelectTeam/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import {
   Select,
   SelectContent,
@@ -14,12 +14,15 @@ import {
 import Icon from '@/components/icons/Icon';
 import Text from '@/components/Primitives/Text';
 import { teamsOfUser } from '@/store/team/atom/team.atom';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { createBoardTeam } from '@/store/createBoard/atoms/create-board.atom';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { createBoardError, createBoardTeam } from '@/store/createBoard/atoms/create-board.atom';
+import { TeamUserRoles } from '@/utils/enums/team.user.roles';
+import { MIN_MEMBERS } from '@/utils/constants';
 import { StyledBox } from './styles';
 
 export const SelectTeam = () => {
   const [selectedTeam, setSelectedTeam] = useRecoilState(createBoardTeam);
+  const setHaveError = useSetRecoilState(createBoardError);
 
   const teams = useRecoilValue(teamsOfUser);
 
@@ -28,6 +31,17 @@ export const SelectTeam = () => {
 
     setSelectedTeam(foundTeam);
   };
+
+  useEffect(() => {
+    if (selectedTeam) {
+      setHaveError(
+        !!(
+          selectedTeam.users?.filter((user) => user.role !== TeamUserRoles.STAKEHOLDER).length <
+          MIN_MEMBERS
+        ),
+      );
+    }
+  }, [selectedTeam, setHaveError]);
 
   return (
     <StyledBox

--- a/frontend/src/components/CreateBoard/SubTeamsTab/SelectTeam/styles.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/SelectTeam/styles.tsx
@@ -1,0 +1,5 @@
+import Box from '@/components/Primitives/Box';
+import Flex from '@/components/Primitives/Flex';
+import { styled } from '@/styles/stitches/stitches.config';
+
+export const StyledBox = styled(Flex, Box, { borderRadius: '$12', backgroundColor: 'white' });

--- a/frontend/src/components/CreateBoard/SubTeamsTab/SelectTeam/styles.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/SelectTeam/styles.tsx
@@ -2,4 +2,14 @@ import Box from '@/components/Primitives/Box';
 import Flex from '@/components/Primitives/Flex';
 import { styled } from '@/styles/stitches/stitches.config';
 
-export const StyledBox = styled(Flex, Box, { borderRadius: '$12', backgroundColor: 'white' });
+export const StyledBox = styled(Flex, Box, {});
+
+export const HelperTextWrapper = styled(Flex, {
+  '& svg': {
+    flex: '0 0 16px',
+    height: '$16 ',
+    width: '$16 ',
+    color: '$dangerBase',
+  },
+  '& *:not(svg)': { flex: '1 1 auto' },
+});

--- a/frontend/src/components/CreateBoard/SubTeamsTab/TeamSubTeamsConfigurations.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/TeamSubTeamsConfigurations.tsx
@@ -27,7 +27,7 @@ import QuickEditSubTeams from './QuickEditSubTeams';
 import SelectTeam from './SelectTeam';
 import FakeMainBoardCard from '../fake/FakeSettingsTabs/partials/MainBoardCard';
 
-const StyledBox = styled(Flex, Box, { borderRadius: '$12', backgroundColor: 'white' });
+const StyledBox = styled(Flex, Box, {});
 
 type TeamSubTeamsInterface = {
   timesOpen: number;
@@ -53,13 +53,6 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
     const isTeamsValid = Array.isArray(teams) && teams.length > 0;
 
     if (isTeamsValid && selectedTeam) {
-      // setHaveError(
-      //   !!(
-      //     selectedTeam?.users?.filter((user) => user.role !== TeamUserRoles.STAKEHOLDER).length <
-      //     MIN_MEMBERS
-      //   ),
-      // );
-
       const isStakeholder = (userTeam: TeamUser): boolean =>
         userTeam.role === TeamUserRoles.STAKEHOLDER;
       const getStakeholder = ({ user }: TeamUser): User => user;
@@ -104,6 +97,7 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
               borderRadius: '$4',
               border: '1px solid $primary200',
               background: '$background',
+              height: '$64',
             }}
             direction="column"
             elevation="1"
@@ -116,7 +110,16 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
           </StyledBox>
         ) : (
           <StyledBox
-            css={{ width: '100%', py: '$12', pl: '$17', pr: '$16' }}
+            css={{
+              width: '100%',
+              py: '$12',
+              pl: '$17',
+              pr: '$16',
+              borderRadius: '$4',
+              border: '1px solid $primary200',
+              background: 'white',
+              height: '$64',
+            }}
             direction="column"
             elevation="1"
             gap="2"
@@ -137,7 +140,7 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
           </StyledBox>
         )}
       </Flex>
-      {selectedTeam && (
+      {selectedTeam ? (
         <>
           <Flex justify="end">
             <QuickEditSubTeams team={selectedTeam} />
@@ -148,6 +151,10 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
             <MainBoardCard team={selectedTeam} timesOpen={timesOpen} />
           )}
         </>
+      ) : (
+        <Flex css={{ mt: '$36' }}>
+          <FakeMainBoardCard />
+        </Flex>
       )}
     </Flex>
   );

--- a/frontend/src/components/CreateBoard/SubTeamsTab/TeamSubTeamsConfigurations.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/TeamSubTeamsConfigurations.tsx
@@ -1,15 +1,13 @@
 import React, { useEffect, useState } from 'react';
-import { useQuery } from 'react-query';
+
 import { useRecoilState, useSetRecoilState } from 'recoil';
 
 import { styled } from '@/styles/stitches/stitches.config';
 
-import { getAllTeams } from '@/api/teamService';
-import Icon from '@/components/icons/Icon';
 import Box from '@/components/Primitives/Box';
 import Flex from '@/components/Primitives/Flex';
 import Text from '@/components/Primitives/Text';
-import Tooltip from '@/components/Primitives/Tooltip';
+
 import {
   CreateBoardData,
   createBoardDataState,
@@ -19,8 +17,11 @@ import { Team } from '@/types/team/team';
 import { TeamUser } from '@/types/team/team.user';
 import { User } from '@/types/user/user';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
+import useTeam from '@/hooks/useTeam';
 import MainBoardCard from './MainBoardCard';
 import QuickEditSubTeams from './QuickEditSubTeams';
+// eslint-disable-next-line import/no-named-as-default
+import SelectTeam from './SelectTeam';
 
 const StyledBox = styled(Flex, Box, { borderRadius: '$12', backgroundColor: 'white' });
 
@@ -36,10 +37,9 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
   const [stakeholders, setStakeholders] = useState<User[]>([]);
   const [team, setTeam] = useState<Team | null>(null);
 
-  const { data: teams } = useQuery(['teams'], () => getAllTeams(), {
-    suspense: false,
-    refetchOnWindowFocus: false,
-  });
+  const {
+    fetchTeamsOfUser: { data: teams },
+  } = useTeam({ autoFetchTeam: false });
 
   const setBoardData = useSetRecoilState<CreateBoardData>(createBoardDataState);
   const [haveError, setHaveError] = useRecoilState(createBoardError);
@@ -91,34 +91,8 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
   return (
     <Flex css={{ mt: '$32' }} direction="column">
       <Flex css={{ width: '100%' }} gap="22" justify="between">
-        <StyledBox
-          css={{ width: '100%', py: '$12', pl: '$17', pr: '$16' }}
-          direction="column"
-          elevation="1"
-          gap="2"
-        >
-          <Text color="primary300" size="xs">
-            Team
-          </Text>
-          <Flex align="center" gap="8">
-            <Text size="md">{haveError || !team ? '' : team?.name}</Text>
-            <Text color="primary300" size="md">
-              ({haveError || !team ? '--' : team?.users.length} members)
-            </Text>
-            <Tooltip content="All active members on the platform">
-              <div>
-                <Icon
-                  name="info"
-                  css={{
-                    width: '$14',
-                    height: '$14',
-                    color: '$primary400',
-                  }}
-                />
-              </div>
-            </Tooltip>
-          </Flex>
-        </StyledBox>
+        <SelectTeam />
+
         <StyledBox
           css={{ width: '100%', py: '$12', pl: '$17', pr: '$16' }}
           direction="column"

--- a/frontend/src/components/CreateBoard/SubTeamsTab/TeamSubTeamsConfigurations.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/TeamSubTeamsConfigurations.tsx
@@ -1,33 +1,39 @@
-import React, { useEffect, useState } from 'react';
-
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
-
+import React, { ReactNode, useEffect, useState } from 'react';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { styled } from '@/styles/stitches/stitches.config';
-
 import Box from '@/components/Primitives/Box';
 import Flex from '@/components/Primitives/Flex';
 import Text from '@/components/Primitives/Text';
-
-import {
-  CreateBoardData,
-  createBoardDataState,
-  createBoardError,
-  createBoardTeam,
-} from '@/store/createBoard/atoms/create-board.atom';
-
+import { createBoardError, createBoardTeam } from '@/store/createBoard/atoms/create-board.atom';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 import useTeam from '@/hooks/useTeam';
 import { TeamUser } from '@/types/team/team.user';
-
 import { User } from '@/types/user/user';
-
 import MainBoardCard from './MainBoardCard';
 import QuickEditSubTeams from './QuickEditSubTeams';
-// eslint-disable-next-line import/no-named-as-default
 import SelectTeam from './SelectTeam';
 import FakeMainBoardCard from '../fake/FakeSettingsTabs/partials/MainBoardCard';
 
-const StyledBox = styled(Flex, Box, {});
+const StyledBox = styled(Flex, Box, {
+  width: '100%',
+  py: '$12',
+  pl: '$17',
+  pr: '$16',
+  borderRadius: '$4',
+  border: '1px solid $primary200',
+  height: '$64',
+});
+
+type BoxContainerProps = {
+  children: ReactNode;
+  color: string;
+};
+
+const BoxContainer = ({ children, color }: BoxContainerProps) => (
+  <StyledBox direction="column" elevation="1" gap="2" css={{ background: color }}>
+    {children}
+  </StyledBox>
+);
 
 type TeamSubTeamsInterface = {
   timesOpen: number;
@@ -46,7 +52,6 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
     fetchTeamsOfUser: { data: teams },
   } = useTeam({ autoFetchTeam: false });
 
-  const setBoardData = useSetRecoilState<CreateBoardData>(createBoardDataState);
   const [haveError, setHaveError] = useRecoilState(createBoardError);
 
   useEffect(() => {
@@ -57,8 +62,6 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
         userTeam.role === TeamUserRoles.STAKEHOLDER;
       const getStakeholder = ({ user }: TeamUser): User => user;
       const stakeholdersFound = selectedTeam.users.filter(isStakeholder).map(getStakeholder);
-
-      setBoardData((prev) => ({ ...prev, board: { ...prev.board, team: selectedTeam._id } }));
 
       const stakeholdersNames = stakeholdersFound.map((stakeholderList) => ({
         ...stakeholderList,
@@ -72,7 +75,7 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
       }));
       setStakeholders(stakeholdersNames);
     }
-  }, [teams, setBoardData, selectedTeam, setHaveError]);
+  }, [teams, selectedTeam, setHaveError]);
 
   useEffect(() => {
     if (timesOpen < 2) {
@@ -88,42 +91,14 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
         <SelectTeam />
 
         {haveError ? (
-          <StyledBox
-            css={{
-              width: '100%',
-              py: '$12',
-              pl: '$17',
-              pr: '$16',
-              borderRadius: '$4',
-              border: '1px solid $primary200',
-              background: '$background',
-              height: '$64',
-            }}
-            direction="column"
-            elevation="1"
-            gap="2"
-          >
+          <BoxContainer color="$background">
             <Text color="primary300" size="xs">
               Stakeholders
             </Text>
             <Text css={{ wordBreak: 'break-word' }} size="md" />
-          </StyledBox>
+          </BoxContainer>
         ) : (
-          <StyledBox
-            css={{
-              width: '100%',
-              py: '$12',
-              pl: '$17',
-              pr: '$16',
-              borderRadius: '$4',
-              border: '1px solid $primary200',
-              background: 'white',
-              height: '$64',
-            }}
-            direction="column"
-            elevation="1"
-            gap="2"
-          >
+          <BoxContainer color="white">
             <Text color="primary300" size="xs">
               Stakeholders
             </Text>
@@ -137,7 +112,7 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
                     : `${value.firstName} ${value.lastName}`,
                 )}
             </Text>
-          </StyledBox>
+          </BoxContainer>
         )}
       </Flex>
       {selectedTeam ? (

--- a/frontend/src/components/CreateBoard/SubTeamsTab/TeamSubTeamsConfigurations.tsx
+++ b/frontend/src/components/CreateBoard/SubTeamsTab/TeamSubTeamsConfigurations.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { styled } from '@/styles/stitches/stitches.config';
 
@@ -11,11 +11,9 @@ import Text from '@/components/Primitives/Text';
 import {
   CreateBoardData,
   createBoardDataState,
-  createBoardError,
+  createBoardTeam,
 } from '@/store/createBoard/atoms/create-board.atom';
-import { Team } from '@/types/team/team';
-import { TeamUser } from '@/types/team/team.user';
-import { User } from '@/types/user/user';
+
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 import useTeam from '@/hooks/useTeam';
 import MainBoardCard from './MainBoardCard';
@@ -34,15 +32,17 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
   timesOpen,
   setTimesOpen,
 }) => {
-  const [stakeholders, setStakeholders] = useState<User[]>([]);
-  const [team, setTeam] = useState<Team | null>(null);
+  // const [stakeholders, setStakeholders] = useState<User[]>([]);
+
+  const selectedTeam = useRecoilValue(createBoardTeam);
+  console.log(selectedTeam);
 
   const {
     fetchTeamsOfUser: { data: teams },
   } = useTeam({ autoFetchTeam: false });
 
   const setBoardData = useSetRecoilState<CreateBoardData>(createBoardDataState);
-  const [haveError, setHaveError] = useRecoilState(createBoardError);
+  // const [haveError, setHaveError] = useRecoilState(createBoardError);
 
   const MIN_MEMBERS = 4;
 
@@ -51,34 +51,32 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
 
     if (
       isTeamsValid &&
-      teams[0].users?.filter((user) => user.role !== TeamUserRoles.STAKEHOLDER).length >=
+      selectedTeam &&
+      selectedTeam?.users?.filter((user) => user.role !== TeamUserRoles.STAKEHOLDER).length >=
         MIN_MEMBERS
     ) {
-      const selectedTeam = teams[0];
-
-      const isStakeholder = (userTeam: TeamUser): boolean =>
-        userTeam.role === TeamUserRoles.STAKEHOLDER;
-      const getStakeholder = ({ user }: TeamUser): User => user;
-      const stakeholdersFound = selectedTeam.users.filter(isStakeholder).map(getStakeholder);
+      // const isStakeholder = (userTeam: TeamUser): boolean =>
+      //   userTeam.role === TeamUserRoles.STAKEHOLDER;
+      // const getStakeholder = ({ user }: TeamUser): User => user;
+      // const stakeholdersFound = selectedTeam.users.filter(isStakeholder).map(getStakeholder);
 
       setBoardData((prev) => ({ ...prev, board: { ...prev.board, team: selectedTeam._id } }));
 
-      const stakeholdersNames = stakeholdersFound.map((stakeholderList) => ({
-        ...stakeholderList,
-        firstName: stakeholderList.firstName
-          .split(' ')
-          .concat(stakeholderList.lastName.split(' '))[0],
-        lastName: stakeholderList.firstName.split(' ').concat(stakeholderList.lastName.split(' '))[
-          stakeholderList.firstName.split(' ').concat(stakeholderList.lastName.split(' ')).length -
-            1
-        ],
-      }));
-      setStakeholders(stakeholdersNames);
-      setTeam(selectedTeam);
-    } else {
-      setHaveError(true);
-    }
-  }, [teams, setBoardData, setHaveError]);
+      // const stakeholdersNames = stakeholdersFound.map((stakeholderList) => ({
+      //   ...stakeholderList,
+      //   firstName: stakeholderList.firstName
+      //     .split(' ')
+      //     .concat(stakeholderList.lastName.split(' '))[0],
+      //   lastName: stakeholderList.firstName.split(' ').concat(stakeholderList.lastName.split(' '))[
+      //     stakeholderList.firstName.split(' ').concat(stakeholderList.lastName.split(' ')).length -
+      //       1
+      //   ],
+      // }));
+      // setStakeholders(stakeholdersNames);
+    } // else {
+    //   setHaveError(true);
+    // }
+  }, [teams, setBoardData, selectedTeam]);
 
   useEffect(() => {
     if (timesOpen < 2) {
@@ -102,7 +100,7 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
           <Text color="primary300" size="xs">
             Stakeholders
           </Text>
-          <Text css={{ wordBreak: 'break-word' }} size="md">
+          {/* <Text css={{ wordBreak: 'break-word' }} size="md">
             {!haveError &&
               stakeholders &&
               stakeholders.length > 0 &&
@@ -111,15 +109,15 @@ const TeamSubTeamsConfigurations: React.FC<TeamSubTeamsInterface> = ({
                   ? `${value.firstName} ${value.lastName}, `
                   : `${value.firstName} ${value.lastName}`,
               )}
-          </Text>
+          </Text> */}
         </StyledBox>
       </Flex>
-      {team && (
+      {selectedTeam && (
         <>
           <Flex justify="end">
-            <QuickEditSubTeams team={team} />
+            <QuickEditSubTeams team={selectedTeam} />
           </Flex>
-          <MainBoardCard team={team} timesOpen={timesOpen} />
+          <MainBoardCard team={selectedTeam} timesOpen={timesOpen} />
         </>
       )}
     </Flex>

--- a/frontend/src/components/CreateBoard/fake/FakeSettingsTabs/partials/MainBoardCard/index.tsx
+++ b/frontend/src/components/CreateBoard/fake/FakeSettingsTabs/partials/MainBoardCard/index.tsx
@@ -15,7 +15,7 @@ import { Container, MainContainer } from './styles';
 
 const FakeMainBoardCard = () => (
   <Flex css={{ width: '100%', height: '100%' }} direction="column" gap="8">
-    <MainContainer align="center" elevation="1" justify="between">
+    <MainContainer align="center" elevation="1" justify="between" css={{ opacity: '0.5' }}>
       <Flex>
         <Flex align="center" gap="8">
           <Tooltip content="It’s a main board. All sub-team boards got merged into this main board.">
@@ -111,6 +111,7 @@ const FakeMainBoardCard = () => (
             py: '$16',
             pl: '$32',
             pr: '$24',
+            opacity: '0.5',
           }}
         >
           <Flex align="center">
@@ -132,14 +133,8 @@ const FakeMainBoardCard = () => (
                   borderRadius: '$round',
                   border: '1px solid $colors$primary400',
                   ml: '$12',
-                  cursor: 'pointer',
 
                   transtion: 'all 0.2s ease-in-out',
-
-                  '&:hover': {
-                    backgroundColor: '$primary400',
-                    color: 'white',
-                  },
                 }}
               >
                 <Icon
@@ -185,6 +180,7 @@ const FakeMainBoardCard = () => (
             py: '$16',
             pl: '$32',
             pr: '$24',
+            opacity: '0.5',
           }}
         >
           <Flex align="center">
@@ -206,14 +202,8 @@ const FakeMainBoardCard = () => (
                   borderRadius: '$round',
                   border: '1px solid $colors$primary400',
                   ml: '$12',
-                  cursor: 'pointer',
 
                   transtion: 'all 0.2s ease-in-out',
-
-                  '&:hover': {
-                    backgroundColor: '$primary400',
-                    color: 'white',
-                  },
                 }}
               >
                 <Icon
@@ -245,7 +235,9 @@ const FakeMainBoardCard = () => (
         </Container>
       </Flex>
     </Flex>
-    <Checkbox id="slack" label="Create Slack group for each sub-team" size="16" />
+    <Tooltip color="primary100" content="First select a team">
+      <Checkbox id="slack" label="Create Slack group for each sub-team" size="16" disabled />
+    </Tooltip>
   </Flex>
 );
 

--- a/frontend/src/components/CreateBoard/fake/FakeSettingsTabs/partials/TeamTab/index.tsx
+++ b/frontend/src/components/CreateBoard/fake/FakeSettingsTabs/partials/TeamTab/index.tsx
@@ -3,41 +3,16 @@ import React from 'react';
 import Icon from '@/components/icons/Icon';
 import Flex from '@/components/Primitives/Flex';
 import Text from '@/components/Primitives/Text';
-import Tooltip from '@/components/Primitives/Tooltip';
+
+// eslint-disable-next-line import/no-named-as-default
+import SelectTeam from '@/components/CreateBoard/SubTeamsTab/SelectTeam';
 import FakeMainBoardCard from '../MainBoardCard';
 import { StyledBox } from './styles';
 
 const FakeTeamTab: React.FC = () => (
   <Flex css={{ mt: '$32' }} direction="column">
     <Flex css={{ width: '100%' }} gap="22" justify="between">
-      <StyledBox
-        css={{ width: '100%', py: '$12', pl: '$17', pr: '$16' }}
-        direction="column"
-        elevation="1"
-        gap="2"
-      >
-        <Text color="primary300" size="xs">
-          Team
-        </Text>
-        <Flex align="center" gap="8">
-          <Text size="md" />
-          <Text color="primary300" size="md">
-            (-- members)
-          </Text>
-          <Tooltip content="All active members on the platform">
-            <div>
-              <Icon
-                name="info"
-                css={{
-                  width: '$14',
-                  height: '$14',
-                  color: '$primary400',
-                }}
-              />
-            </div>
-          </Tooltip>
-        </Flex>
-      </StyledBox>
+      <SelectTeam />
       <StyledBox
         css={{ width: '100%', py: '$12', pl: '$17', pr: '$16' }}
         direction="column"
@@ -56,6 +31,7 @@ const FakeTeamTab: React.FC = () => (
         gap="8"
         justify="end"
         css={{
+          color: '$primary200',
           py: '$14',
           cursor: 'pointer',
           transition: 'text-decoration 0.2s ease-in-out',
@@ -71,15 +47,15 @@ const FakeTeamTab: React.FC = () => (
           css={{
             width: '$16',
             height: '$16',
+            color: '$primary200',
           }}
         />
-        <Text size="sm" weight="medium">
+        <Text size="sm" weight="medium" color="primary200">
           Quick edit sub-teams configurations
         </Text>
       </Flex>
     </Flex>
     <FakeMainBoardCard />
-    {/* <MainBoardCard team={team} stakeholders={stakeholders} /> */}
   </Flex>
 );
 

--- a/frontend/src/components/CreateBoard/fake/FakeSettingsTabs/partials/TeamTab/styles.tsx
+++ b/frontend/src/components/CreateBoard/fake/FakeSettingsTabs/partials/TeamTab/styles.tsx
@@ -3,6 +3,6 @@ import { styled } from '@/styles/stitches/stitches.config';
 import Box from '@/components/Primitives/Box';
 import Flex from '@/components/Primitives/Flex';
 
-const StyledBox = styled(Flex, Box, { borderRadius: '$12', backgroundColor: 'white' });
+const StyledBox = styled(Flex, Box, { borderRadius: '$4', border: '1px solid $primary200' });
 
 export { StyledBox };

--- a/frontend/src/components/Primitives/Checkbox.tsx
+++ b/frontend/src/components/Primitives/Checkbox.tsx
@@ -151,7 +151,12 @@ const Checkbox: React.FC<{
       </Flex>
       <Text
         as="label"
-        css={{ paddingLeft: '$8', width: '100%', cursor: 'pointer' }}
+        css={{
+          paddingLeft: '$8',
+          width: '100%',
+          cursor: 'pointer',
+          color: disabled ? '$primary200' : '$primaryBase',
+        }}
         htmlFor={id}
         size="sm"
       >

--- a/frontend/src/components/Primitives/Select.tsx
+++ b/frontend/src/components/Primitives/Select.tsx
@@ -16,19 +16,21 @@ export const SelectTrigger = styled(SelectPrimitive.SelectTrigger, {
   py: '$12',
   pl: '$17',
   pr: '$16',
+  cursor: 'pointer',
   '&[data-placeholder]': {
     fontSize: 13,
-    color: '$primary400',
+    color: '$primary300',
   },
 });
 
 export const SelectIcon = styled(SelectPrimitive.SelectIcon, {
-  color: '$primary400',
+  color: '$primary800',
 });
 
 export const SelectContent = styled(SelectPrimitive.Content, {
   overflow: 'hidden',
   backgroundColor: 'white',
+  boxShadow: '0px 4px 16px rgba(18, 25, 34, 0.05)',
 });
 
 export const SelectViewport = styled(SelectPrimitive.Viewport, {
@@ -38,15 +40,14 @@ export const SelectViewport = styled(SelectPrimitive.Viewport, {
 export const StyledItem = styled(SelectPrimitive.Item, {
   fontSize: 16,
   lineHeight: 1,
-  color: '$primary400',
+  color: '$primary800',
   borderRadius: 3,
   display: 'flex',
   alignItems: 'center',
-  height: 25,
+  height: 35,
   padding: '0 35px 0 25px',
   position: 'relative',
   userSelect: 'none',
-
   '&[data-disabled]': {
     color: mauve.mauve8,
     pointerEvents: 'none',
@@ -54,8 +55,9 @@ export const StyledItem = styled(SelectPrimitive.Item, {
 
   '&[data-highlighted]': {
     outline: 'none',
-    backgroundColor: '$primary400',
+    backgroundColor: '$primary800',
     color: 'white',
+    cursor: 'pointer',
   },
 });
 
@@ -77,7 +79,7 @@ export const StyledItemIndicator = styled(SelectPrimitive.ItemIndicator, {
 
 const StyledRootSelect = styled(SelectPrimitive.Root);
 const StyledSelectValue = styled(SelectPrimitive.Value, {
-  color: '$primary700',
+  color: '$primary800',
   fontSize: '16px',
 });
 const StyledSelectPortal = styled(SelectPrimitive.Portal);

--- a/frontend/src/components/Primitives/Select.tsx
+++ b/frontend/src/components/Primitives/Select.tsx
@@ -1,0 +1,91 @@
+import * as SelectPrimitive from '@radix-ui/react-select';
+import { styled } from '@stitches/react';
+import { mauve } from '@radix-ui/colors';
+
+export const SelectTrigger = styled(SelectPrimitive.SelectTrigger, {
+  all: 'unset',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  borderRadius: 4,
+  fontSize: '$16',
+  lineHeight: '$24',
+  backgroundColor: 'white',
+  color: '$primary800',
+  width: '100%',
+  py: '$12',
+  pl: '$17',
+  pr: '$16',
+  '&[data-placeholder]': {
+    fontSize: 13,
+    color: '$primary400',
+  },
+});
+
+export const SelectIcon = styled(SelectPrimitive.SelectIcon, {
+  color: '$primary400',
+});
+
+export const SelectContent = styled(SelectPrimitive.Content, {
+  overflow: 'hidden',
+  backgroundColor: 'white',
+});
+
+export const SelectViewport = styled(SelectPrimitive.Viewport, {
+  padding: 5,
+});
+
+export const StyledItem = styled(SelectPrimitive.Item, {
+  fontSize: 16,
+  lineHeight: 1,
+  color: '$primary400',
+  borderRadius: 3,
+  display: 'flex',
+  alignItems: 'center',
+  height: 25,
+  padding: '0 35px 0 25px',
+  position: 'relative',
+  userSelect: 'none',
+
+  '&[data-disabled]': {
+    color: mauve.mauve8,
+    pointerEvents: 'none',
+  },
+
+  '&[data-highlighted]': {
+    outline: 'none',
+    backgroundColor: '$primary400',
+    color: 'white',
+  },
+});
+
+export const SelectLabel = styled(SelectPrimitive.Label, {
+  padding: '0 25px',
+  fontSize: 12,
+  lineHeight: '25px',
+  color: mauve.mauve11,
+});
+
+export const StyledItemIndicator = styled(SelectPrimitive.ItemIndicator, {
+  position: 'absolute',
+  left: 0,
+  width: 25,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+const StyledRootSelect = styled(SelectPrimitive.Root);
+const StyledSelectValue = styled(SelectPrimitive.Value, {
+  color: '$primary700',
+  fontSize: '16px',
+});
+const StyledSelectPortal = styled(SelectPrimitive.Portal);
+const StyleSelectItemText = styled(SelectPrimitive.ItemText);
+const StyleSelectItemIndicator = styled(SelectPrimitive.ItemIndicator);
+
+export const Select = StyledRootSelect;
+export const SelectValue = StyledSelectValue;
+export const SelectPortal = StyledSelectPortal;
+export const SelectItemText = StyleSelectItemText;
+export const SelectItemIndicator = StyleSelectItemIndicator;

--- a/frontend/src/pages/boards/new.tsx
+++ b/frontend/src/pages/boards/new.tsx
@@ -45,7 +45,7 @@ const NewBoard: NextPage = () => {
   const { data: session } = useSession({ required: true });
 
   const [isBackButtonDisable, setBackButtonState] = useState(false);
-  const [isSaving, setIsSaving] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
 
   /**
    * Recoil Atoms and Hooks
@@ -101,6 +101,7 @@ const NewBoard: NextPage = () => {
    * Handle back to boards list page
    */
   const handleBack = useCallback(() => {
+    setIsLoading(true);
     resetBoardState();
     setSelectedTeam(undefined);
     setHaveError(false);
@@ -146,7 +147,7 @@ const NewBoard: NextPage = () => {
     }
 
     if (status === 'success') {
-      setIsSaving(true);
+      setIsLoading(true);
       setToastState({
         open: true,
         content: 'Board created with success!',
@@ -174,7 +175,7 @@ const NewBoard: NextPage = () => {
   return (
     <Suspense fallback={<LoadingPage />}>
       <QueryError>
-        <Container style={isSaving ? { opacity: 0.5 } : undefined}>
+        <Container style={isLoading ? { opacity: 0.5 } : undefined}>
           <PageHeader>
             <Text color="primary800" heading={3} weight="bold">
               Add new SPLIT board

--- a/frontend/src/pages/boards/new.tsx
+++ b/frontend/src/pages/boards/new.tsx
@@ -36,7 +36,7 @@ import {
 } from '@/store/createBoard/atoms/create-board.atom';
 import { toastState } from '@/store/toast/atom/toast.atom';
 import { CreateBoardDto } from '@/types/board/board';
-import { TeamUserRoles } from '@/utils/enums/team.user.roles';
+
 import { ToastStateEnum } from '@/utils/enums/toast-types';
 import useTeam from '@/hooks/useTeam';
 import { teamsOfUser } from '@/store/team/atom/team.atom';
@@ -137,16 +137,18 @@ const NewBoard: NextPage = () => {
   };
 
   useEffect(() => {
-    const isAdminOrStakeHolder = teams
-      ? !!teams[0].users.find(
-          (teamUser) =>
-            teamUser.user._id === session?.user.id &&
-            [TeamUserRoles.ADMIN, TeamUserRoles.STAKEHOLDER].includes(teamUser.role),
-        ) || session?.user.isSAdmin
-      : false;
+    const isAdminOrStakeHolder = false;
+    // const isAdminOrStakeHolder = teams
+    //   ? !!teams[0].users.find(
+    //       (teamUser) =>
+    //         teamUser.user._id === session?.user.id &&
+    //         [TeamUserRoles.ADMIN, TeamUserRoles.STAKEHOLDER].includes(teamUser.role),
+    //     ) || session?.user.isSAdmin
+    //   : false;
 
     if (!isAdminOrStakeHolder && !haveError) {
-      setHaveError(!isAdminOrStakeHolder);
+      // setHaveError(!isAdminOrStakeHolder);
+      setHaveError(false);
     }
 
     if (status === 'success') {

--- a/frontend/src/pages/teams/[teamId].tsx
+++ b/frontend/src/pages/teams/[teamId].tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useEffect } from 'react';
+import React, { Suspense } from 'react';
 import { dehydrate, QueryClient } from 'react-query';
 import { GetServerSideProps } from 'next';
 import { useSession } from 'next-auth/react';
@@ -15,7 +15,7 @@ import { Sidebar } from '@/components/Sidebar';
 import TeamHeader from '@/components/Teams/Team/Header';
 import TeamMembersList from '@/components/Teams/Team/ListCardMembers';
 import useTeam from '@/hooks/useTeam';
-import { membersListState, usersListState } from '@/store/team/atom/team.atom';
+import { membersListState } from '@/store/team/atom/team.atom';
 
 const Team = () => {
   // Session Details
@@ -28,16 +28,11 @@ const Team = () => {
   } = useTeam({ autoFetchTeam: false });
 
   // Recoil States
-  const setUsersListState = useSetRecoilState(usersListState);
   const setMembersListState = useSetRecoilState(membersListState);
 
-  useEffect(() => {
-    if (!data) {
-      return;
-    }
-
+  if (data) {
     setMembersListState(data.users);
-  }, [data, session?.user.id, setMembersListState, setUsersListState]);
+  }
 
   if (!session || !data) return null;
   return (

--- a/frontend/src/pages/teams/[teamId].tsx
+++ b/frontend/src/pages/teams/[teamId].tsx
@@ -1,4 +1,4 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect } from 'react';
 import { dehydrate, QueryClient } from 'react-query';
 import { GetServerSideProps } from 'next';
 import { useSession } from 'next-auth/react';
@@ -30,9 +30,11 @@ const Team = () => {
   // Recoil States
   const setMembersListState = useSetRecoilState(membersListState);
 
-  if (data) {
-    setMembersListState(data.users);
-  }
+  useEffect(() => {
+    if (data) {
+      setMembersListState(data.users);
+    }
+  }, [data, setMembersListState]);
 
   if (!session || !data) return null;
   return (

--- a/frontend/src/pages/teams/index.tsx
+++ b/frontend/src/pages/teams/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, Suspense } from 'react';
+import { ReactElement, Suspense, useEffect } from 'react';
 import { dehydrate, QueryClient } from 'react-query';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { getSession, useSession } from 'next-auth/react';
@@ -21,9 +21,11 @@ const Teams = () => {
     fetchTeamsOfUser: { data, isFetching },
   } = useTeam({ autoFetchTeam: false });
 
-  if (data) {
-    setTeamsList(data);
-  }
+  useEffect(() => {
+    if (data) {
+      setTeamsList(data);
+    }
+  }, []);
 
   if (!session || !data) return null;
 

--- a/frontend/src/pages/teams/index.tsx
+++ b/frontend/src/pages/teams/index.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, Suspense, useEffect } from 'react';
+import { ReactElement, Suspense } from 'react';
 import { dehydrate, QueryClient } from 'react-query';
 import { GetServerSideProps, GetServerSidePropsContext } from 'next';
 import { getSession, useSession } from 'next-auth/react';
@@ -21,10 +21,9 @@ const Teams = () => {
     fetchTeamsOfUser: { data, isFetching },
   } = useTeam({ autoFetchTeam: false });
 
-  useEffect(() => {
-    if (!data) return;
+  if (data) {
     setTeamsList(data);
-  }, [data, setTeamsList]);
+  }
 
   if (!session || !data) return null;
 

--- a/frontend/src/pages/teams/new.tsx
+++ b/frontend/src/pages/teams/new.tsx
@@ -13,7 +13,7 @@ import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 import { ToastStateEnum } from '@/utils/enums/toast-types';
 import QueryError from '@/components/Errors/QueryError';
 import LoadingPage from '@/components/loadings/LoadingPage';
-import { Suspense } from 'react';
+import { Suspense, useEffect } from 'react';
 
 const NewTeam: NextPage = () => {
   const { data: session } = useSession({ required: true });
@@ -35,26 +35,29 @@ const NewTeam: NextPage = () => {
   const setMembersListState = useSetRecoilState(membersListState);
 
   const listMembers: TeamUser[] | undefined = [];
-  if (data) {
-    data.forEach((user) => {
-      if (user._id === session?.user.id) {
-        listMembers.push({
-          user,
-          role: TeamUserRoles.ADMIN,
-          isNewJoiner: false,
-        });
-      }
-    });
 
-    const usersWithChecked = data.map((user) => ({
-      ...user,
-      isChecked: user._id === session?.user.id,
-    }));
+  useEffect(() => {
+    if (data) {
+      data.forEach((user) => {
+        if (user._id === session?.user.id) {
+          listMembers.push({
+            user,
+            role: TeamUserRoles.ADMIN,
+            isNewJoiner: false,
+          });
+        }
+      });
 
-    setUsersListState(usersWithChecked);
+      const usersWithChecked = data.map((user) => ({
+        ...user,
+        isChecked: user._id === session?.user.id,
+      }));
 
-    setMembersListState(listMembers);
-  }
+      setUsersListState(usersWithChecked);
+
+      setMembersListState(listMembers);
+    }
+  }, [data, listMembers, session?.user.id, setMembersListState, setUsersListState]);
 
   if (!session || !data) return null;
 

--- a/frontend/src/schema/schemaCreateBoardForm.ts
+++ b/frontend/src/schema/schemaCreateBoardForm.ts
@@ -10,7 +10,10 @@ const SchemaCreateBoard = Joi.object({
     'number.min': 'Please insert a number greater than zero.',
   }),
   slackEnable: Joi.boolean().required().messages({
-    'boolean.required': 'Please enterm the value for slack enable.',
+    'boolean.required': 'Please enter the value for slack enable.',
+  }),
+  team: Joi.string().required().messages({
+    'any.required': 'Please Select Team',
   }),
 });
 

--- a/frontend/src/schema/schemaCreateBoardForm.ts
+++ b/frontend/src/schema/schemaCreateBoardForm.ts
@@ -6,7 +6,7 @@ const SchemaCreateBoard = Joi.object({
     'string.empty': 'Please enter the board name',
     'string.max': 'Maximum of 30 characters',
   }),
-  maxVotes: Joi.number().min(1).optional().messages({
+  maxVotes: Joi.number().integer().min(1).optional().messages({
     'number.min': 'Please insert a number greater than zero.',
   }),
   slackEnable: Joi.boolean().required().messages({

--- a/frontend/src/store/createBoard/atoms/create-board.atom.tsx
+++ b/frontend/src/store/createBoard/atoms/create-board.atom.tsx
@@ -14,6 +14,16 @@ export const createBoardState = atom({
   default: false,
 });
 
+export const createBoardTeam = atom<Team | undefined>({
+  key: 'createBoardTeam',
+  default: {
+    _id: '',
+    name: '',
+    users: [],
+    boardsCount: 0,
+  },
+});
+
 export interface CreateBoardData {
   count: {
     teamsCount: number;

--- a/frontend/src/store/createBoard/atoms/create-board.atom.tsx
+++ b/frontend/src/store/createBoard/atoms/create-board.atom.tsx
@@ -16,12 +16,7 @@ export const createBoardState = atom({
 
 export const createBoardTeam = atom<Team | undefined>({
   key: 'createBoardTeam',
-  default: {
-    _id: '',
-    name: '',
-    users: [],
-    boardsCount: 0,
-  },
+  default: undefined,
 });
 
 export interface CreateBoardData {

--- a/frontend/src/store/team/atom/team.atom.tsx
+++ b/frontend/src/store/team/atom/team.atom.tsx
@@ -18,3 +18,8 @@ export const teamsListState = atom<Team[]>({
   key: 'teamsList',
   default: [],
 });
+
+export const teamsOfUser = atom<Team[]>({
+  key: 'teamsOfUser',
+  default: [],
+});

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -22,4 +22,6 @@ export const AUTH_SSO =
 
 export const REFRESH_TOKEN_ERROR = 'REFRESH_TOKEN_ERROR';
 
+export const MIN_MEMBERS = 4;
+
 // -------------------------------


### PR DESCRIPTION
Relates to #663 
Fixes #577 
Fixes #580 


## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/59372326/207110073-fdb68f31-33d6-4367-a850-91a6186319d3.png)


## Proposed Changes

  - Add a select with teams that the user is part of. If the user is super Admin, he can view all the teams.
  - When the user selects a team, it's validated if he is a team admin, a stakeholder or super admin, and if the team has the minimum number of members to form subteams. If one of this conditions fails, a message error is displayed and the user can select another team.
  - The joi schema validates if a team is selected. This prevents the user of creating a board without a team, if he clicks on the create button. 
  - Fix: Remove error message when the page is refreshed.
  - Fix: Cancel board create button bug fixed. The button is always accessible to the user. 
  - Fix: Max Votes input only accepts integers


This pull request closes #663 #577 #580 