### PR TITLE
feat: users lazy loading backend

### DIFF
--- a/backend/src/modules/teams/interfaces/services/get.team.service.interface.ts
+++ b/backend/src/modules/teams/interfaces/services/get.team.service.interface.ts
@@ -3,6 +3,7 @@ import { TeamQueryParams } from 'src/libs/dto/param/team.query.params';
 import TeamUser from '../../entities/team.user.schema';
 import Team from '../../entities/teams.schema';
 import { UserWithTeams } from '../../../users/interfaces/type-user-with-teams';
+import User from 'src/modules/users/entities/user.schema';
 
 export interface GetTeamServiceInterface {
 	countTeams(userId: string): Promise<number>;
@@ -19,5 +20,5 @@ export interface GetTeamServiceInterface {
 
 	getAllTeams(): Promise<LeanDocument<Team>[]>;
 
-	getUsersOnlyWithTeams(): Promise<UserWithTeams[]>;
+	getUsersOnlyWithTeams(users: User[]): Promise<LeanDocument<UserWithTeams>[]>;
 }

--- a/backend/src/modules/teams/repositories/team-user.repository.interface.ts
+++ b/backend/src/modules/teams/repositories/team-user.repository.interface.ts
@@ -1,4 +1,5 @@
 import { BaseInterfaceRepository } from 'src/libs/repositories/interfaces/base.repository.interface';
+import User from 'src/modules/users/entities/user.schema';
 import { UserWithTeams } from 'src/modules/users/interfaces/type-user-with-teams';
 import TeamUserDto from '../dto/team.user.dto';
 import TeamUser from '../entities/team.user.schema';
@@ -6,7 +7,7 @@ import TeamUser from '../entities/team.user.schema';
 export interface TeamUserRepositoryInterface extends BaseInterfaceRepository<TeamUser> {
 	countTeamsOfUser(userId: string): Promise<number>;
 	getAllTeamsOfUser(userId: string): Promise<TeamUser[]>;
-	getUsersOnlyWithTeams(): Promise<UserWithTeams[]>;
+	getUsersOnlyWithTeams(users: User[]): Promise<UserWithTeams[]>;
 	getUsersOfTeam(teamId: string);
 	updateTeamUser(teamData: TeamUserDto): Promise<TeamUser | null>;
 }

--- a/backend/src/modules/teams/repositories/team-user.repository.ts
+++ b/backend/src/modules/teams/repositories/team-user.repository.ts
@@ -53,8 +53,7 @@ export class TeamUserRepository
 						from: 'users',
 						localField: 'user',
 						foreignField: '_id',
-						as: 'user',
-						pipeline: [{ $sort: { firstName: 1 } }]
+						as: 'user'
 					}
 				},
 				{
@@ -80,7 +79,6 @@ export class TeamUserRepository
 				{
 					$set: { userWithTeam: '$_id' }
 				},
-
 				{
 					$unset: [
 						'_id',

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -4,6 +4,7 @@ import Team from '../entities/teams.schema';
 import { TYPES } from '../interfaces/types';
 import { TeamRepositoryInterface } from '../repositories/team.repository.interface';
 import { TeamUserRepositoryInterface } from '../repositories/team-user.repository.interface';
+import User from 'src/modules/users/entities/user.schema';
 
 @Injectable()
 export default class GetTeamService implements GetTeamServiceInterface {
@@ -38,8 +39,8 @@ export default class GetTeamService implements GetTeamServiceInterface {
 		});
 	}
 
-	getUsersOnlyWithTeams() {
-		return this.teamUserRepository.getUsersOnlyWithTeams();
+	getUsersOnlyWithTeams(users: User[]) {
+		return this.teamUserRepository.getUsersOnlyWithTeams(users);
 	}
 
 	getTeamUser(userId: string, teamId: string) {

--- a/backend/src/modules/users/applications/get.user.application.ts
+++ b/backend/src/modules/users/applications/get.user.application.ts
@@ -22,7 +22,11 @@ export class GetUserApplicationImpl implements GetUserApplication {
 		return this.getUserService.getAllUsers();
 	}
 
-	getUsersOnlyWithTeams() {
-		return this.getUserService.getAllUsersWithTeams();
+	getAllUsersWithPagination(page: number, size: number) {
+		return this.getUserService.getAllUsersWithPagination(page, size);
+	}
+
+	getAllUsersWithTeams(page?: number, size?: number) {
+		return this.getUserService.getAllUsersWithTeams(page, size);
 	}
 }

--- a/backend/src/modules/users/controller/users.controller.ts
+++ b/backend/src/modules/users/controller/users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Inject, Put, Req, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Inject, Put, Query, Req, UseGuards } from '@nestjs/common';
 import {
 	ApiBadRequestResponse,
 	ApiBearerAuth,
@@ -26,6 +26,7 @@ import { ForbiddenResponse } from '../../../libs/swagger/errors/forbidden.swagge
 import { NotFoundResponse } from '../../../libs/swagger/errors/not-found.swagger';
 import { UpdateSuperAdminSwagger } from '../swagger/update.superadmin.swagger';
 import RequestWithUser from 'src/libs/interfaces/requestWithUser.interface';
+import { PaginationParams } from 'src/libs/dto/param/pagination.params';
 
 @ApiBearerAuth('access-token')
 @ApiTags('Users')
@@ -77,8 +78,8 @@ export default class UsersController {
 		type: InternalServerErrorResponse
 	})
 	@Get('teams')
-	getAllUsersWithTeams() {
-		return this.getUserApp.getUsersOnlyWithTeams();
+	getAllUsersWithTeams(@Query() { page, size }: PaginationParams) {
+		return this.getUserApp.getAllUsersWithTeams(page, size);
 	}
 
 	@ApiOperation({ summary: 'Update user is super admin' })

--- a/backend/src/modules/users/interfaces/applications/get.user.application.interface.ts
+++ b/backend/src/modules/users/interfaces/applications/get.user.application.interface.ts
@@ -11,5 +11,8 @@ export interface GetUserApplication {
 
 	getAllUsersWithPagination(page: number, size: number): Promise<LeanDocument<UserDocument>[]>;
 
-	getAllUsersWithTeams(page?: number, size?: number): Promise<LeanDocument<UserWithTeams>[]>;
+	getAllUsersWithTeams(
+		page?: number,
+		size?: number
+	): Promise<{ userWithTeams: LeanDocument<UserWithTeams>[]; hasNextPage: boolean; page: number }>;
 }

--- a/backend/src/modules/users/interfaces/applications/get.user.application.interface.ts
+++ b/backend/src/modules/users/interfaces/applications/get.user.application.interface.ts
@@ -9,5 +9,7 @@ export interface GetUserApplication {
 
 	getAllUsers(): Promise<LeanDocument<UserDocument>[]>;
 
-	getUsersOnlyWithTeams(): Promise<LeanDocument<UserWithTeams>[]>;
+	getAllUsersWithPagination(page: number, size: number): Promise<LeanDocument<UserDocument>[]>;
+
+	getAllUsersWithTeams(page?: number, size?: number): Promise<LeanDocument<UserWithTeams>[]>;
 }

--- a/backend/src/modules/users/interfaces/services/get.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/services/get.user.service.interface.ts
@@ -16,5 +16,7 @@ export interface GetUserService {
 
 	getAllUsers(): Promise<LeanDocument<UserDocument>[]>;
 
-	getAllUsersWithTeams(): Promise<LeanDocument<UserWithTeams>[]>;
+	getAllUsersWithPagination(page: number, size: number): Promise<LeanDocument<UserDocument>[]>;
+
+	getAllUsersWithTeams(page?: number, size?: number): Promise<LeanDocument<UserWithTeams>[]>;
 }

--- a/backend/src/modules/users/interfaces/services/get.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/services/get.user.service.interface.ts
@@ -18,5 +18,8 @@ export interface GetUserService {
 
 	getAllUsersWithPagination(page: number, size: number): Promise<LeanDocument<UserDocument>[]>;
 
-	getAllUsersWithTeams(page?: number, size?: number): Promise<LeanDocument<UserWithTeams>[]>;
+	getAllUsersWithTeams(
+		page?: number,
+		size?: number
+	): Promise<{ userWithTeams: LeanDocument<UserWithTeams>[]; hasNextPage: boolean; page: number }>;
 }

--- a/backend/src/modules/users/repository/user.repository.interface.ts
+++ b/backend/src/modules/users/repository/user.repository.interface.ts
@@ -6,4 +6,5 @@ export interface UserRepositoryInterface extends BaseInterfaceRepository<User> {
 	updateUserWithRefreshToken(refreshToken: string, userId: string): Promise<User>;
 	updateUserPassword(email: string, password: string): Promise<User>;
 	updateSuperAdmin(userId: string, isSAdmin: boolean): Promise<User>;
+	getAllWithPagination(page: number, size: number): Promise<User[]>;
 }

--- a/backend/src/modules/users/repository/user.repository.ts
+++ b/backend/src/modules/users/repository/user.repository.ts
@@ -42,7 +42,7 @@ export class UserRepository
 			.find()
 			.skip(page * size)
 			.limit(size)
-			.sort({ firstName: 1 })
+			.sort({ firstName: 1, lastName: 1 })
 			.exec();
 	}
 }

--- a/backend/src/modules/users/repository/user.repository.ts
+++ b/backend/src/modules/users/repository/user.repository.ts
@@ -36,4 +36,12 @@ export class UserRepository
 	updateSuperAdmin(userId: string, isSAdmin: boolean) {
 		return this.findOneByFieldAndUpdate({ _id: userId }, { $set: { isSAdmin } }, { new: true });
 	}
+
+	getAllWithPagination(page: number, size: number) {
+		return this.model
+			.find()
+			.skip(page * size)
+			.limit(size)
+			.exec();
+	}
 }

--- a/backend/src/modules/users/repository/user.repository.ts
+++ b/backend/src/modules/users/repository/user.repository.ts
@@ -42,6 +42,7 @@ export class UserRepository
 			.find()
 			.skip(page * size)
 			.limit(size)
+			.sort({ firstName: 1 })
 			.exec();
 	}
 }

--- a/backend/src/modules/users/services/get.user.service.ts
+++ b/backend/src/modules/users/services/get.user.service.ts
@@ -42,15 +42,22 @@ export default class GetUserServiceImpl implements GetUserService {
 		return this.userRepository.findAll({ password: 0, currentHashedRefreshToken: 0 });
 	}
 
-	async getAllUsersWithTeams() {
-		const users = await this.getAllUsers();
+	getAllUsersWithPagination(page?: number, size?: number) {
+		return this.userRepository.getAllWithPagination(page, size);
+	}
+
+	async getAllUsersWithTeams(page = 0, size = 10) {
+		const users = await this.getAllUsersWithPagination(page, size);
 		const mappedUsers: UserWithTeams[] = users.map((userFound) => {
 			return {
 				user: userFound,
 				teams: []
 			};
 		});
-		const usersOnlyWithTeams = await this.getTeamService.getUsersOnlyWithTeams();
+		const usersOnlyWithTeams = await this.getTeamService.getUsersOnlyWithTeams(users);
+
+		//return usersOnlyWithTeams;
+
 		const ids = new Set(usersOnlyWithTeams.map((userWithTeams) => String(userWithTeams.user._id)));
 
 		return [

--- a/backend/src/modules/users/services/get.user.service.ts
+++ b/backend/src/modules/users/services/get.user.service.ts
@@ -74,9 +74,9 @@ export default class GetUserServiceImpl implements GetUserService {
 		results.userWithTeams.sort((a, b) => {
 			if (a.user.firstName === b.user.firstName) {
 				return a.user.lastName < b.user.lastName ? -1 : 1;
-			} else {
-				return a.user.firstName < b.user.firstName ? -1 : 1;
 			}
+
+			return a.user.firstName < b.user.firstName ? -1 : 1;
 		});
 
 		return results;

--- a/backend/src/modules/users/services/get.user.service.ts
+++ b/backend/src/modules/users/services/get.user.service.ts
@@ -46,23 +46,39 @@ export default class GetUserServiceImpl implements GetUserService {
 		return this.userRepository.getAllWithPagination(page, size);
 	}
 
-	async getAllUsersWithTeams(page = 0, size = 10) {
+	async getAllUsersWithTeams(page = 0, size = 15) {
 		const users = await this.getAllUsersWithPagination(page, size);
+
+		const count = await this.userRepository.countDocuments();
+		const hasNextPage = page + 1 < Math.ceil(count / size);
+
 		const mappedUsers: UserWithTeams[] = users.map((userFound) => {
 			return {
 				user: userFound,
-				teams: []
+				teamsNames: []
 			};
 		});
 		const usersOnlyWithTeams = await this.getTeamService.getUsersOnlyWithTeams(users);
 
-		//return usersOnlyWithTeams;
-
 		const ids = new Set(usersOnlyWithTeams.map((userWithTeams) => String(userWithTeams.user._id)));
 
-		return [
-			...usersOnlyWithTeams,
-			...mappedUsers.filter((user) => !ids.has(String(user.user._id)))
-		];
+		const results = {
+			userWithTeams: [
+				...usersOnlyWithTeams,
+				...mappedUsers.filter((user) => !ids.has(String(user.user._id)))
+			],
+			hasNextPage,
+			page
+		};
+
+		results.userWithTeams.sort((a, b) => {
+			if (a.user.firstName === b.user.firstName) {
+				return a.user.lastName < b.user.lastName ? -1 : 1;
+			} else {
+				return a.user.firstName < b.user.firstName ? -1 : 1;
+			}
+		});
+
+		return results;
 	}
 }


### PR DESCRIPTION
#594 


Relates to #602 

## Screenshots (if visual changes)

![image](https://user-images.githubusercontent.com/118206043/207667457-43958fbf-48e2-42d5-9b95-a14add05fb87.png)

![image](https://user-images.githubusercontent.com/118206043/207667539-0fe9dfdf-039a-406f-97b8-8e2e00b47329.png)


## Proposed Changes

-A lazy loading strategy should be implemented to avoid fetching all the platform users at the same time. So the user can fetch, for example, 15 at a time and more 15 when the scroll reaches its end.


Mention people who discussed this issue previously
@GuiSanto 



This pull request closes #602 