### PR TITLE
feat: top layout for users edit page

### DIFF
--- a/frontend/src/components/Users/UserEdit/index.tsx
+++ b/frontend/src/components/Users/UserEdit/index.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+import ListOfCards from './partials/ListOfCards';
+
+const UsersEdit = () => <ListOfCards />;
+
+export default UsersEdit;

--- a/frontend/src/components/Users/UserEdit/partials/ListOfCards/index.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/ListOfCards/index.tsx
@@ -1,0 +1,13 @@
+import Flex from '@/components/Primitives/Flex';
+
+import React from 'react';
+
+const ListOfCards = React.memo(() => (
+  <>
+    <Flex css={{ mt: '$32' }} direction="column">
+      <Flex />
+    </Flex>
+  </>
+));
+
+export default ListOfCards;

--- a/frontend/src/components/Users/UserEdit/partials/UserHeader/index.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/UserHeader/index.tsx
@@ -17,12 +17,11 @@ const UserHeader = ({ title }: UserHeaderProps) => {
       title: 'Users',
       link: '/users',
     },
+    {
+      title,
+      isActive: true,
+    },
   ];
-
-  breadcrumbItems.push({
-    title,
-    isActive: true,
-  });
   return (
     <Flex align="center" justify="between" css={{ width: '100%' }}>
       <Flex direction="column">
@@ -34,11 +33,11 @@ const UserHeader = ({ title }: UserHeaderProps) => {
           <Text
             css={{
               ml: '$14',
-              background: '#E3FFF5',
+              background: '$primary1000',
               borderStyle: 'solid',
-              borderColor: '#3EC796',
+              borderColor: '$primary900',
               borderWidth: 'thin',
-              color: '#3EC796',
+              color: '$primary900',
               borderRadius: '$12',
               padding: '$8',
               height: '1.55rem',

--- a/frontend/src/components/Users/UserEdit/partials/UserHeader/index.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/UserHeader/index.tsx
@@ -1,0 +1,64 @@
+import Breadcrumb from '@/components/breadcrumb/Breadcrumb';
+import { AddNewBoardButton } from '@/components/layouts/DashboardLayout/styles';
+import Flex from '@/components/Primitives/Flex';
+import Text from '@/components/Primitives/Text';
+import { BreadcrumbType } from '@/types/board/Breadcrumb';
+import Icon from '@/components/icons/Icon';
+import { TitleSection } from './styles';
+
+type UserHeaderProps = {
+  title: string;
+};
+
+const UserHeader = ({ title }: UserHeaderProps) => {
+  // Set breadcrumbs
+  const breadcrumbItems: BreadcrumbType = [
+    {
+      title: 'Users',
+      link: '/users',
+    },
+  ];
+
+  breadcrumbItems.push({
+    title,
+    isActive: true,
+  });
+  return (
+    <Flex align="center" justify="between" css={{ width: '100%' }}>
+      <Flex direction="column">
+        <Flex align="center" css={{ pb: '$12' }}>
+          <Breadcrumb items={breadcrumbItems} />
+        </Flex>
+        <TitleSection>
+          <Text heading="1">{title}</Text>
+          <Text
+            css={{
+              ml: '$14',
+              background: '#E3FFF5',
+              borderStyle: 'solid',
+              borderColor: '#3EC796',
+              borderWidth: 'thin',
+              color: '#3EC796',
+              borderRadius: '$12',
+              padding: '$8',
+              height: '1.55rem',
+              lineHeight: '$8',
+            }}
+            size="sm"
+            weight="medium"
+          >
+            SUPER ADMIN
+          </Text>
+        </TitleSection>
+      </Flex>
+      <Flex justify="end" css={{ height: '$10 ' }}>
+        <AddNewBoardButton size="sm">
+          <Icon css={{ color: 'white' }} name="plus" />
+          Add user to new team
+        </AddNewBoardButton>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default UserHeader;

--- a/frontend/src/components/Users/UserEdit/partials/UserHeader/styles.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/UserHeader/styles.tsx
@@ -1,0 +1,23 @@
+import { styled } from '@/styles/stitches/stitches.config';
+
+const StyledHeader = styled('div', {
+  width: '100%',
+  maxHeight: '108px',
+
+  position: 'relative',
+
+  padding: '$24 $37',
+  borderBottomStyle: 'solid',
+  borderBottomWidth: 1,
+  borderBottomColor: '$primary100',
+
+  backgroundColor: '$surface',
+});
+
+const TitleSection = styled('section', {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '$10',
+});
+
+export { StyledHeader, TitleSection };

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -64,11 +64,28 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
           />
 
           <Flex align="center" css={{ width: '$147' }} gap="8">
-            <Link href={`/users/${userWithTeams.user._id}`}>
+            {loggedUserIsSAdmin ? (
+              <Link href={`/users/${userWithTeams.user._id}`}>
+                <Flex>
+                  <CardTitle firstName={firstName} lastName={lastName} />
+                </Flex>
+              </Link>
+            ) : (
               <Flex>
-                <CardTitle firstName={firstName} lastName={lastName} />
+                <Text
+                  css={{
+                    mr: '$2',
+                    fontWeight: '$bold',
+                    fontSize: '$14',
+                    letterSpacing: '$0-17',
+                    cursor: 'default',
+                  }}
+                  size="sm"
+                >
+                  {firstName} {lastName}
+                </Text>
               </Flex>
-            </Link>
+            )}
           </Flex>
 
           <Flex align="center" css={{ width: '$147' }}>
@@ -78,6 +95,18 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
           </Flex>
         </Flex>
 
+        {!loggedUserIsSAdmin && (
+          <Flex css={{ width: '100%' }} justify="end">
+            <Flex align="center" css={{ width: '$237' }} justify="end">
+              <SuperAdmin
+                userSAdmin={isSAdmin}
+                loggedUserSAdmin={loggedUserIsSAdmin}
+                userId={_id}
+                loggedUserId={userLoginId}
+              />
+            </Flex>
+          </Flex>
+        )}
         <Flex align="center" css={{ justifyContent: 'end', width: '$683' }} gap="8">
           <Flex align="center" css={{ ml: '$40', alignItems: 'center' }} gap="8">
             <Flex align="center" css={{ width: '$147' }}>
@@ -88,17 +117,19 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
               </Tooltip>
             </Flex>
           </Flex>
-          <Flex css={{ width: '40%' }} justify="end">
-            <Flex align="center" css={{ width: '$237' }} justify="start">
-              <SuperAdmin
-                userSAdmin={isSAdmin}
-                loggedUserSAdmin={loggedUserIsSAdmin}
-                userId={_id}
-                loggedUserId={userLoginId}
-              />
+          {loggedUserIsSAdmin && (
+            <Flex css={{ width: '40%' }} justify="end">
+              <Flex align="center" css={{ width: '$237' }} justify="start">
+                <SuperAdmin
+                  userSAdmin={isSAdmin}
+                  loggedUserSAdmin={loggedUserIsSAdmin}
+                  userId={_id}
+                  loggedUserId={userLoginId}
+                />
+              </Flex>
+              <CardEnd user={userWithTeams.user} />
             </Flex>
-            {loggedUserIsSAdmin && <CardEnd user={userWithTeams.user} />}
-          </Flex>
+          )}
         </Flex>
       </InnerContainer>
     </Flex>

--- a/frontend/src/components/Users/UsersList/partials/ListOfCards/index.tsx
+++ b/frontend/src/components/Users/UsersList/partials/ListOfCards/index.tsx
@@ -74,7 +74,8 @@ const ListOfCards = React.memo(() => {
       fetchUsers.refetch();
     }, 100);
     return () => clearTimeout(timer);
-  }, [search, fetchUsers]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [search]);
 
   return (
     <>

--- a/frontend/src/pages/users/[userId].tsx
+++ b/frontend/src/pages/users/[userId].tsx
@@ -1,3 +1,37 @@
-const UserDetails = () => <h1>User Details</h1>;
+import { ReactElement, Suspense } from 'react';
+import { useSession } from 'next-auth/react';
+
+import QueryError from '@/components/Errors/QueryError';
+import Layout from '@/components/layouts/Layout';
+import LoadingPage from '@/components/loadings/LoadingPage';
+import Flex from '@/components/Primitives/Flex';
+import UsersEdit from '@/components/Users/UserEdit';
+import { ContentSection } from '@/components/layouts/DashboardLayout/styles';
+import UserHeader from '@/components/Users/UserEdit/partials/UserHeader';
+
+const UserDetails = () => {
+  const { data: session } = useSession({ required: true });
+
+  if (!session) return null;
+
+  return (
+    <Flex direction="column">
+      <Suspense fallback={<LoadingPage />}>
+        <QueryError>
+          <ContentSection gap="36" justify="between">
+            <Flex css={{ width: '100%' }} direction="column">
+              <Flex justify="start">
+                <UserHeader title="Nuno Caseiro" />
+              </Flex>
+            </Flex>
+            <UsersEdit />
+          </ContentSection>
+        </QueryError>
+      </Suspense>
+    </Flex>
+  );
+};
+
+UserDetails.getLayout = (page: ReactElement) => <Layout>{page}</Layout>;
 
 export default UserDetails;

--- a/frontend/src/styles/stitches/partials/colors/primary.colors.ts
+++ b/frontend/src/styles/stitches/partials/colors/primary.colors.ts
@@ -13,6 +13,8 @@ const primaryColors = {
   primary600: '#212832',
   primary700: '#141A22',
   primary800: '#060D16',
+  primary900: '#3EC796',
+  primary1000: '#E3FFF5',
 };
 
 export { primaryColors };


### PR DESCRIPTION

#712 

Relates to #594

## Screenshots (if visual changes)

![image](https://user-images.githubusercontent.com/118206043/208474607-e7a592df-1aa0-4ee1-b637-7086b02ec9b6.png)


## Proposed Changes
 - As a Super Admin, in the top left of the page, I want to see which User I am editing and, in case I am editing a Super Admin, have a "SUPER ADMIN" banner next to its name.
 - In addition, I want to see a button in the top right that says "Add user to new team".
  


Mention people who discussed this issue previously
@GuiSanto 



This pull request closes #712 