### PR TITLE
feat: layout of teams of the user when editing the user

### DIFF
--- a/frontend/src/components/CardBoard/CardAvatars.tsx
+++ b/frontend/src/components/CardBoard/CardAvatars.tsx
@@ -20,7 +20,7 @@ type CardAvatarProps = {
   responsible: boolean;
   teamAdmins: boolean;
   stakeholders?: boolean;
-  userId: string;
+  userId: string | undefined;
   myBoards?: boolean;
   haveError?: boolean;
   isBoardsPage?: boolean;

--- a/frontend/src/components/Teams/CreateTeam/CardMember/RoleSettings.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardMember/RoleSettings.tsx
@@ -14,7 +14,7 @@ import Icon from '@/components/icons/Icon';
 import { PopoverCloseStyled, PopoverItemStyled, PopoverTriggerStyled } from './styles';
 
 interface PopoverRoleSettingsProps {
-  userId: string;
+  userId: string | undefined;
   isTeamPage?: boolean;
 }
 

--- a/frontend/src/components/Teams/TeamsList/partials/CardTeam/CardBody.tsx
+++ b/frontend/src/components/Teams/TeamsList/partials/CardTeam/CardBody.tsx
@@ -11,6 +11,9 @@ import Separator from '@/components/Primitives/Separator';
 import Text from '@/components/Primitives/Text';
 import { Team } from '@/types/team/team';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
+import { useRouter } from 'next/router';
+import RoleDescription from '@/components/Teams/CreateTeam/CardEnd/RoleDescription';
+import PopoverRoleSettings from '@/components/Teams/CreateTeam/CardMember/RoleSettings';
 import BoardsInfo from './BoardsInfo';
 import CardEnd from './CardEnd';
 import CardTitle from './CardTitle';
@@ -22,13 +25,17 @@ const InnerContainer = styled(Flex, Box, {
 });
 
 type CardBodyProps = {
-  userId: string;
+  userId: string | undefined;
   team: Team;
   index?: number;
 };
 
 const CardBody = React.memo<CardBodyProps>(({ userId, team }) => {
   const { data: session } = useSession();
+
+  const router = useRouter();
+
+  console.log(router.pathname.includes('userId'));
 
   const isSAdmin = session?.user.isSAdmin;
 
@@ -119,14 +126,21 @@ const CardBody = React.memo<CardBodyProps>(({ userId, team }) => {
                 height: '$24 !important',
               }}
             />
+            {router.pathname.includes('users') ? (
+              <Flex align="center" css={{ width: '$237' }} justify="end">
+                <RoleDescription role={TeamUserRoles.ADMIN} />
 
-            <Flex align="center" css={{ width: '$237' }} justify="start">
-              <BoardsInfo
-                team={team}
-                teamAdminOrStakeholder={havePermissions}
-                userSAdmin={isSAdmin}
-              />
-            </Flex>
+                <PopoverRoleSettings userId={userId} />
+              </Flex>
+            ) : (
+              <Flex align="center" css={{ width: '$237' }} justify="start">
+                <BoardsInfo
+                  team={team}
+                  teamAdminOrStakeholder={havePermissions}
+                  userSAdmin={isSAdmin}
+                />
+              </Flex>
+            )}
           </Flex>
         </Flex>
         <Flex css={{ width: '20%' }} justify="end">

--- a/frontend/src/components/Teams/TeamsList/partials/CardTeam/CardEnd.tsx
+++ b/frontend/src/components/Teams/TeamsList/partials/CardTeam/CardEnd.tsx
@@ -7,7 +7,7 @@ import DeleteTeam from './DeleteTeam';
 type CardEndProps = {
   team: Team;
   havePermissions: boolean;
-  userId: string;
+  userId: string | undefined;
   userSAdmin?: boolean;
   userIsParticipating: boolean;
 };

--- a/frontend/src/components/Users/UserEdit/index.tsx
+++ b/frontend/src/components/Users/UserEdit/index.tsx
@@ -2,6 +2,10 @@ import React from 'react';
 
 import ListOfCards from './partials/ListOfCards';
 
-const UsersEdit = () => <ListOfCards />;
+type UserEditProps = {
+  userId: string | undefined;
+};
+
+const UsersEdit = ({ userId }: UserEditProps) => <ListOfCards userId={userId} />;
 
 export default UsersEdit;

--- a/frontend/src/components/Users/UserEdit/partials/ListOfCards/index.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/ListOfCards/index.tsx
@@ -1,13 +1,52 @@
+import React from 'react';
 import Flex from '@/components/Primitives/Flex';
 
-import React from 'react';
+import { ScrollableContent } from '@/components/Boards/MyBoards/styles';
+import CardBody from '@/components/Teams/TeamsList/partials/CardTeam/CardBody';
+import { Team } from '@/types/team/team';
+import { TeamUser } from '@/types/team/team.user';
+import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 
-const ListOfCards = React.memo(() => (
-  <>
-    <Flex css={{ mt: '$32' }} direction="column">
-      <Flex />
-    </Flex>
-  </>
-));
+type ListOfCardsProp = {
+  userId: string | undefined;
+};
+
+const users: TeamUser = {
+  user: {
+    _id: '1',
+    firstName: 'zeca',
+    lastName: 'pola',
+    email: 'zeca@twe.pt',
+    isSAdmin: true,
+    joinedAt: '2022-11-17T12:51:21.897+00:00',
+  },
+  role: TeamUserRoles.ADMIN,
+  isNewJoiner: false,
+};
+
+const ListOfCards = React.memo<ListOfCardsProp>(({ userId }) => {
+  const dummyData: Team[] = [
+    {
+      _id: '1',
+      name: 'xgeeks',
+      users: [users],
+    },
+    {
+      _id: '2',
+      name: 'xkigroup',
+      users: [users],
+    },
+  ];
+
+  return (
+    <ScrollableContent direction="column" gap="24" justify="start">
+      <Flex direction="column" gap="20">
+        {dummyData.map((team) => (
+          <CardBody key={team._id} team={team} userId={userId} />
+        ))}
+      </Flex>
+    </ScrollableContent>
+  );
+});
 
 export default ListOfCards;

--- a/frontend/src/pages/users/[userId].tsx
+++ b/frontend/src/pages/users/[userId].tsx
@@ -9,8 +9,13 @@ import UsersEdit from '@/components/Users/UserEdit';
 import { ContentSection } from '@/components/layouts/DashboardLayout/styles';
 import UserHeader from '@/components/Users/UserEdit/partials/UserHeader';
 
+import { useRouter } from 'next/router';
+
 const UserDetails = () => {
   const { data: session } = useSession({ required: true });
+
+  const router = useRouter();
+  const { userId } = router.query;
 
   if (!session) return null;
 
@@ -20,11 +25,11 @@ const UserDetails = () => {
         <QueryError>
           <ContentSection gap="36" justify="between">
             <Flex css={{ width: '100%' }} direction="column">
-              <Flex justify="start">
+              <Flex justify="between">
                 <UserHeader title="Nuno Caseiro" />
               </Flex>
+              <UsersEdit userId={userId?.toString()} />
             </Flex>
-            <UsersEdit />
           </ContentSection>
         </QueryError>
       </Suspense>

--- a/frontend/src/types/team/team.ts
+++ b/frontend/src/types/team/team.ts
@@ -4,7 +4,7 @@ export interface Team {
   _id: string;
   name: string;
   users: TeamUser[];
-  boardsCount: number;
+  boardsCount?: number;
 }
 
 export interface CreateTeamDto {

--- a/frontend/src/types/team/team.user.ts
+++ b/frontend/src/types/team/team.user.ts
@@ -28,7 +28,7 @@ export interface CreateTeamUser {
 export interface TeamUserUpdate {
   role: TeamUserRoles;
   isNewJoiner: boolean;
-  user: string;
+  user: string | undefined;
   team: string;
 }
 


### PR DESCRIPTION

#714 

Relates to #594 


## Screenshots (if visual changes)

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/118206043/208697572-f69f1ca3-f970-46e3-a7ba-6f12ffd25843.png">


## Proposed Changes

  - As a Super Admin, I want to see the list of teams a user is part of. Each card must contain: team name, members, team admins, role and a bin icon.


@GuiSanto 


This pull request closes #714 