### PR TITLE
feat: displaying all teams of user. Delete team of user too

### DIFF
--- a/frontend/src/api/teamService.tsx
+++ b/frontend/src/api/teamService.tsx
@@ -7,8 +7,13 @@ import { CreatedTeamUser, TeamUserAddAndRemove, TeamUserUpdate } from '../types/
 export const getAllTeams = (context?: GetServerSidePropsContext): Promise<Team[]> =>
   fetchData(`/teams`, { context, serverSide: !!context });
 
-export const getTeamsOfUser = (context?: GetServerSidePropsContext): Promise<Team[]> =>
-  fetchData(`/teams/user`, { context, serverSide: !!context });
+export const getTeamsOfUser = (
+  context?: GetServerSidePropsContext,
+  userId?: string,
+): Promise<Team[]> =>
+  userId
+    ? fetchData(`/teams/user?userId=${userId ?? ''}`, { context, serverSide: !!context })
+    : fetchData(`/teams/user`, { context, serverSide: !!context });
 
 export const createTeamRequest = (newTeam: CreateTeamDto): Promise<Team> =>
   fetchData(`/teams`, { method: 'POST', data: newTeam });

--- a/frontend/src/components/Teams/CreateTeam/CardEnd/RoleDescription.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardEnd/RoleDescription.tsx
@@ -4,7 +4,7 @@ import Text from '@/components/Primitives/Text';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 
 type RoleDescriptionProps = {
-  role: string;
+  role: string | undefined;
 };
 
 const RoleDescription = ({ role }: RoleDescriptionProps) => (

--- a/frontend/src/components/Teams/TeamsList/partials/CardTeam/CardBody.tsx
+++ b/frontend/src/components/Teams/TeamsList/partials/CardTeam/CardBody.tsx
@@ -14,6 +14,7 @@ import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 import { useRouter } from 'next/router';
 import RoleDescription from '@/components/Teams/CreateTeam/CardEnd/RoleDescription';
 import PopoverRoleSettings from '@/components/Teams/CreateTeam/CardMember/RoleSettings';
+import { TeamUser } from '@/types/team/team.user';
 import BoardsInfo from './BoardsInfo';
 import CardEnd from './CardEnd';
 import CardTitle from './CardTitle';
@@ -38,6 +39,10 @@ const CardBody = React.memo<CardBodyProps>(({ userId, team }) => {
   const isSAdmin = session?.user.isSAdmin;
 
   const { _id: id, users } = team;
+
+  const userFound: TeamUser | undefined = users.find((member) => member.user._id === userId);
+
+  const userRole = userFound?.role;
 
   const userIsParticipating = useMemo(
     () => users.some((user) => user.user._id === userId),
@@ -126,7 +131,7 @@ const CardBody = React.memo<CardBodyProps>(({ userId, team }) => {
             />
             {router.pathname.includes('users') ? (
               <Flex align="center" css={{ width: '$237' }} justify="end">
-                <RoleDescription role={TeamUserRoles.ADMIN} />
+                <RoleDescription role={userRole} />
 
                 <PopoverRoleSettings userId={userId} />
               </Flex>

--- a/frontend/src/components/Users/UserEdit/index.tsx
+++ b/frontend/src/components/Users/UserEdit/index.tsx
@@ -1,11 +1,16 @@
+import { Team } from '@/types/team/team';
 import React from 'react';
 
 import ListOfCards from './partials/ListOfCards';
 
 type UserEditProps = {
   userId: string | undefined;
+  teams: Team[];
+  isLoading: boolean;
 };
 
-const UsersEdit = ({ userId }: UserEditProps) => <ListOfCards userId={userId} />;
+const UsersEdit = ({ userId, teams, isLoading }: UserEditProps) => (
+  <ListOfCards userId={userId} teams={teams} isLoading={isLoading} />
+);
 
 export default UsersEdit;

--- a/frontend/src/components/Users/UserEdit/partials/ListOfCards/index.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/ListOfCards/index.tsx
@@ -4,49 +4,27 @@ import Flex from '@/components/Primitives/Flex';
 import { ScrollableContent } from '@/components/Boards/MyBoards/styles';
 import CardBody from '@/components/Teams/TeamsList/partials/CardTeam/CardBody';
 import { Team } from '@/types/team/team';
-import { TeamUser } from '@/types/team/team.user';
-import { TeamUserRoles } from '@/utils/enums/team.user.roles';
+import { DotsLoading } from '@/components/loadings/DotsLoading';
 
 type ListOfCardsProp = {
   userId: string | undefined;
+  teams: Team[];
+  isLoading: boolean;
 };
 
-const users: TeamUser = {
-  user: {
-    _id: '1',
-    firstName: 'zeca',
-    lastName: 'pola',
-    email: 'zeca@twe.pt',
-    isSAdmin: true,
-    joinedAt: '2022-11-17T12:51:21.897+00:00',
-  },
-  role: TeamUserRoles.ADMIN,
-  isNewJoiner: false,
-};
-
-const ListOfCards = React.memo<ListOfCardsProp>(({ userId }) => {
-  const dummyData: Team[] = [
-    {
-      _id: '1',
-      name: 'xgeeks',
-      users: [users],
-    },
-    {
-      _id: '2',
-      name: 'xkigroup',
-      users: [users],
-    },
-  ];
-
-  return (
-    <ScrollableContent direction="column" gap="24" justify="start">
-      <Flex direction="column" gap="20">
-        {dummyData.map((team) => (
-          <CardBody key={team._id} team={team} userId={userId} />
-        ))}
+const ListOfCards = React.memo<ListOfCardsProp>(({ userId, teams, isLoading }) => (
+  <ScrollableContent direction="column" gap="24" justify="start">
+    <Flex direction="column" gap="20">
+      {teams.map((team: Team) => (
+        <CardBody key={team._id} team={team} userId={userId} />
+      ))}
+    </Flex>
+    {isLoading && (
+      <Flex justify="center">
+        <DotsLoading />
       </Flex>
-    </ScrollableContent>
-  );
-});
+    )}
+  </ScrollableContent>
+));
 
 export default ListOfCards;

--- a/frontend/src/components/Users/UserEdit/partials/UserHeader/index.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/UserHeader/index.tsx
@@ -7,10 +7,11 @@ import Icon from '@/components/icons/Icon';
 import { TitleSection } from './styles';
 
 type UserHeaderProps = {
-  title: string;
+  firstName: string | string[] | undefined;
+  lastName: string | string[] | undefined;
 };
 
-const UserHeader = ({ title }: UserHeaderProps) => {
+const UserHeader = ({ firstName, lastName }: UserHeaderProps) => {
   // Set breadcrumbs
   const breadcrumbItems: BreadcrumbType = [
     {
@@ -18,7 +19,7 @@ const UserHeader = ({ title }: UserHeaderProps) => {
       link: '/users',
     },
     {
-      title,
+      title: `${firstName} ${lastName}`,
       isActive: true,
     },
   ];
@@ -29,7 +30,9 @@ const UserHeader = ({ title }: UserHeaderProps) => {
           <Breadcrumb items={breadcrumbItems} />
         </Flex>
         <TitleSection>
-          <Text heading="1">{title}</Text>
+          <Text heading="1">
+            {firstName} {lastName}
+          </Text>
           <Text
             css={{
               ml: '$14',

--- a/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/CardBody.tsx
@@ -65,7 +65,9 @@ const CardBody = React.memo<CardBodyProps>(({ userWithTeams }) => {
 
           <Flex align="center" css={{ width: '$147' }} gap="8">
             {loggedUserIsSAdmin ? (
-              <Link href={`/users/${userWithTeams.user._id}`}>
+              <Link
+                href={`/users/${userWithTeams.user._id}?firstName=${userWithTeams.user.firstName}&lastName=${userWithTeams.user.lastName}`}
+              >
                 <Flex>
                   <CardTitle firstName={firstName} lastName={lastName} />
                 </Flex>

--- a/frontend/src/components/Users/UsersList/partials/CardUser/EditUser.tsx
+++ b/frontend/src/components/Users/UsersList/partials/CardUser/EditUser.tsx
@@ -7,7 +7,7 @@ type EditUserProps = { user: User };
 
 const EditUser: React.FC<EditUserProps> = ({ user }) => (
   <Flex pointer>
-    <Link href={`/users/${user._id}`}>
+    <Link href={`/users/${user._id}?firstName=${user.firstName}&lastName=${user.lastName}`}>
       <Icon
         name="edit"
         css={{


### PR DESCRIPTION
Relates to #594 

## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/99729373/208952129-5fcdac09-b06f-4972-8ca2-45abf9883375.png)



## Proposed Changes

  - Showing all teams that a user is part of
  - Delete team of a user is also done, because we used the existing component of Teams.
  - Page auto-refreshes when a user is deleted


This pull request closes #715 #717 