### PR TITLE
feat: edit role of user of corresponding team when editing user

### DIFF
--- a/frontend/src/components/Teams/CreateTeam/CardMember/RoleSettings.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardMember/RoleSettings.tsx
@@ -12,7 +12,6 @@ import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 import useTeam from '@/hooks/useTeam';
 import Icon from '@/components/icons/Icon';
 import { useRouter } from 'next/router';
-import { UseMutationResult } from 'react-query';
 import { PopoverCloseStyled, PopoverItemStyled, PopoverTriggerStyled } from './styles';
 
 interface PopoverRoleSettingsProps {
@@ -30,7 +29,9 @@ const PopoverRoleSettings: React.FC<PopoverRoleSettingsProps> = React.memo(
 
     const router = useRouter();
 
-    const { updateTeamUser, updateUserTeam } = useTeam();
+    const {
+      updateTeamUser: { mutate },
+    } = useTeam();
 
     const selectRole = (value: TeamUserRoles) => {
       const members = membersList.map((member) =>
@@ -40,11 +41,7 @@ const PopoverRoleSettings: React.FC<PopoverRoleSettingsProps> = React.memo(
       setMembersList(members);
     };
 
-    const updateUser = (
-      value: TeamUserRoles,
-      users: TeamUser[],
-      update: UseMutationResult<TeamUserUpdate, unknown, TeamUserUpdate, unknown>,
-    ) => {
+    const updateUser = (value: TeamUserRoles, users: TeamUser[]) => {
       const userFound = users.find((member) => member.user._id === userId);
 
       if (userFound && userFound.team) {
@@ -55,21 +52,19 @@ const PopoverRoleSettings: React.FC<PopoverRoleSettingsProps> = React.memo(
           isNewJoiner: userFound.isNewJoiner,
         };
 
-        update.mutate(updateTeamUserRole);
+        mutate(updateTeamUserRole);
       }
     };
 
-    let updateUserRole: (value: TeamUserRoles) => void;
-
-    updateUserRole = (value: TeamUserRoles) => {
-      updateUser(value, membersList, updateTeamUser);
+    let updateUserRole = (value: TeamUserRoles) => {
+      updateUser(value, membersList);
     };
 
     if (router.pathname.includes('users')) {
       updateUserRole = (value: TeamUserRoles) => {
         const users = userTeamsList.flatMap((team) => team.users);
 
-        updateUser(value, users, updateUserTeam);
+        updateUser(value, users);
       };
     }
 

--- a/frontend/src/components/Teams/CreateTeam/CardMember/RoleSettings.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardMember/RoleSettings.tsx
@@ -31,15 +31,37 @@ const PopoverRoleSettings: React.FC<PopoverRoleSettingsProps> = React.memo(
 
     const { updateTeamUser, updateUserTeam } = useTeam();
 
-    let updateUserRole: any;
-    let selectRole: any;
+    const selectRole = (value: TeamUserRoles) => {
+      const members = membersList.map((member) =>
+        member.user._id === userId ? { ...member, role: value } : member,
+      );
+
+      setMembersList(members);
+    };
+
+    let updateUserRole: (value: TeamUserRoles) => void;
+
+    updateUserRole = (value: TeamUserRoles) => {
+      const userFound = membersList.find((member) => member.user._id === userId);
+
+      if (userFound && userFound.team) {
+        const updateTeamUserRole: TeamUserUpdate = {
+          team: userFound.team,
+          user: userId,
+          role: value,
+          isNewJoiner: userFound.isNewJoiner,
+        };
+
+        updateTeamUser.mutate(updateTeamUserRole);
+      }
+    };
 
     if (router.pathname.includes('users')) {
-      const users = userTeamsList.flatMap((team) => team.users);
-
-      const userFound = users.find((member) => member.user._id === userId);
-
       updateUserRole = (value: TeamUserRoles) => {
+        const users = userTeamsList.flatMap((team) => team.users);
+
+        const userFound = users.find((member) => member.user._id === userId);
+
         if (userFound && userFound.team) {
           const updateTeamUserRole: TeamUserUpdate = {
             team: userFound.team,
@@ -49,29 +71,6 @@ const PopoverRoleSettings: React.FC<PopoverRoleSettingsProps> = React.memo(
           };
 
           updateUserTeam.mutate(updateTeamUserRole);
-        }
-      };
-    } else {
-      selectRole = (value: TeamUserRoles) => {
-        const members = membersList.map((member) =>
-          member.user._id === userId ? { ...member, role: value } : member,
-        );
-
-        setMembersList(members);
-      };
-
-      updateUserRole = (value: TeamUserRoles) => {
-        const userFound = membersList.find((member) => member.user._id === userId);
-
-        if (userFound && userFound.team) {
-          const updateTeamUserRole: TeamUserUpdate = {
-            team: userFound.team,
-            user: userId,
-            role: value,
-            isNewJoiner: userFound.isNewJoiner,
-          };
-
-          updateTeamUser.mutate(updateTeamUserRole);
         }
       };
     }

--- a/frontend/src/components/Teams/CreateTeam/CardMember/RoleSettings.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardMember/RoleSettings.tsx
@@ -6,12 +6,13 @@ import { PopoverContent } from '@/components/Primitives/Popover';
 import Text from '@/components/Primitives/Text';
 
 import { membersListState, userTeamsListState } from '@/store/team/atom/team.atom';
-import { TeamUserUpdate } from '@/types/team/team.user';
+import { TeamUser, TeamUserUpdate } from '@/types/team/team.user';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 
 import useTeam from '@/hooks/useTeam';
 import Icon from '@/components/icons/Icon';
 import { useRouter } from 'next/router';
+import { UseMutationResult } from 'react-query';
 import { PopoverCloseStyled, PopoverItemStyled, PopoverTriggerStyled } from './styles';
 
 interface PopoverRoleSettingsProps {
@@ -39,10 +40,12 @@ const PopoverRoleSettings: React.FC<PopoverRoleSettingsProps> = React.memo(
       setMembersList(members);
     };
 
-    let updateUserRole: (value: TeamUserRoles) => void;
-
-    updateUserRole = (value: TeamUserRoles) => {
-      const userFound = membersList.find((member) => member.user._id === userId);
+    const updateUser = (
+      value: TeamUserRoles,
+      users: TeamUser[],
+      update: UseMutationResult<TeamUserUpdate, unknown, TeamUserUpdate, unknown>,
+    ) => {
+      const userFound = users.find((member) => member.user._id === userId);
 
       if (userFound && userFound.team) {
         const updateTeamUserRole: TeamUserUpdate = {
@@ -52,26 +55,21 @@ const PopoverRoleSettings: React.FC<PopoverRoleSettingsProps> = React.memo(
           isNewJoiner: userFound.isNewJoiner,
         };
 
-        updateTeamUser.mutate(updateTeamUserRole);
+        update.mutate(updateTeamUserRole);
       }
+    };
+
+    let updateUserRole: (value: TeamUserRoles) => void;
+
+    updateUserRole = (value: TeamUserRoles) => {
+      updateUser(value, membersList, updateTeamUser);
     };
 
     if (router.pathname.includes('users')) {
       updateUserRole = (value: TeamUserRoles) => {
         const users = userTeamsList.flatMap((team) => team.users);
 
-        const userFound = users.find((member) => member.user._id === userId);
-
-        if (userFound && userFound.team) {
-          const updateTeamUserRole: TeamUserUpdate = {
-            team: userFound.team,
-            user: userId,
-            role: value,
-            isNewJoiner: userFound.isNewJoiner,
-          };
-
-          updateUserTeam.mutate(updateTeamUserRole);
-        }
+        updateUser(value, users, updateUserTeam);
       };
     }
 

--- a/frontend/src/components/Teams/CreateTeam/CardMember/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardMember/index.tsx
@@ -33,7 +33,7 @@ const CardMember = React.memo<CardBodyProps>(
 
     const {
       updateTeamUser: { mutate },
-    } = useTeam({});
+    } = useTeam();
 
     const handleIsNewJoiner = (checked: boolean) => {
       const listUsersMembers = membersList.map((user) =>

--- a/frontend/src/components/Teams/CreateTeam/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/index.tsx
@@ -26,7 +26,7 @@ const CreateTeam = () => {
 
   const {
     createTeam: { mutate, status },
-  } = useTeam({});
+  } = useTeam();
 
   const [isBackButtonDisable, setBackButtonState] = useState(false);
 

--- a/frontend/src/components/Teams/TeamsList/partials/CardTeam/DeleteTeam.tsx
+++ b/frontend/src/components/Teams/TeamsList/partials/CardTeam/DeleteTeam.tsx
@@ -14,7 +14,7 @@ type DeleteTeamProps = {
 };
 
 const DeleteTeam: React.FC<DeleteTeamProps> = ({ teamName, teamId, teamUserId, isTeamPage }) => {
-  const { deleteTeam, deleteTeamUser } = useTeam({});
+  const { deleteTeam, deleteTeamUser } = useTeam();
 
   const handleDelete = () => {
     if (isTeamPage) {

--- a/frontend/src/hooks/useTeam.tsx
+++ b/frontend/src/hooks/useTeam.tsx
@@ -122,6 +122,25 @@ const useTeam = ({
     },
   });
 
+  const updateUserTeam = useMutation(updateTeamUserRequest, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(['teams', userId]);
+
+      setToastState({
+        open: true,
+        content: 'The team user was successfully updated.',
+        type: ToastStateEnum.SUCCESS,
+      });
+    },
+    onError: () => {
+      setToastState({
+        open: true,
+        content: 'Error while updating the team user',
+        type: ToastStateEnum.ERROR,
+      });
+    },
+  });
+
   const addAndRemoveTeamUser = useMutation(addAndRemoveTeamUserRequest, {
     onMutate: async (addedAndRemovedMembers) => {
       await queryClient.cancelQueries(['team', addedAndRemovedMembers.team]);
@@ -229,6 +248,7 @@ const useTeam = ({
     deleteTeam,
     deleteTeamUser,
     fetchTeamsOfSpecificUser,
+    updateUserTeam,
   };
 };
 

--- a/frontend/src/hooks/useTeam.tsx
+++ b/frontend/src/hooks/useTeam.tsx
@@ -104,27 +104,11 @@ const useTeam = ({
   });
 
   const updateTeamUser = useMutation(updateTeamUserRequest, {
-    onSuccess: () => {
-      queryClient.invalidateQueries(['team', teamId]);
-
-      setToastState({
-        open: true,
-        content: 'The team user was successfully updated.',
-        type: ToastStateEnum.SUCCESS,
-      });
-    },
-    onError: () => {
-      setToastState({
-        open: true,
-        content: 'Error while updating the team user',
-        type: ToastStateEnum.ERROR,
-      });
-    },
-  });
-
-  const updateUserTeam = useMutation(updateTeamUserRequest, {
-    onSuccess: () => {
-      queryClient.invalidateQueries(['teams', userId]);
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries(['team', teamId]),
+        queryClient.invalidateQueries(['teams', userId]),
+      ]);
 
       setToastState({
         open: true,
@@ -248,7 +232,6 @@ const useTeam = ({
     deleteTeam,
     deleteTeamUser,
     fetchTeamsOfSpecificUser,
-    updateUserTeam,
   };
 };
 

--- a/frontend/src/types/team/useTeam.ts
+++ b/frontend/src/types/team/useTeam.ts
@@ -26,6 +26,4 @@ export default interface UseTeamType {
   deleteTeamUser: UseMutationResult<TeamUser, unknown, DeleteTeamUser, unknown>;
 
   fetchTeamsOfSpecificUser: UseQueryResult<Team[], unknown>;
-
-  updateUserTeam: UseMutationResult<TeamUserUpdate, unknown, TeamUserUpdate, unknown>;
 }

--- a/frontend/src/types/team/useTeam.ts
+++ b/frontend/src/types/team/useTeam.ts
@@ -26,4 +26,6 @@ export default interface UseTeamType {
   deleteTeamUser: UseMutationResult<TeamUser, unknown, DeleteTeamUser, unknown>;
 
   fetchTeamsOfSpecificUser: UseQueryResult<Team[], unknown>;
+
+  updateUserTeam: UseMutationResult<TeamUserUpdate, unknown, TeamUserUpdate, unknown>;
 }


### PR DESCRIPTION

#716 

Relates to #594


## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/118206043/209541012-850130a1-9967-4a18-8fae-b54198907cd5.png)

![image](https://user-images.githubusercontent.com/118206043/209541039-e00c1a2a-e497-4856-9609-fa52078dbe3c.png)

## Proposed Changes

  - As a Super Admin, I want to change the role that a user has on a team. The options available should be: Team Member, Team Admin and Stakeholder.
 

@GuiSanto 



This pull request closes #716 