### PR TITLE
feat: layout complete

### DIFF
--- a/frontend/src/components/Users/UserEdit/partials/TeamsDialog/SearchInput.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/TeamsDialog/SearchInput.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import Icon from '@/components/icons/Icon';
+import Flex from '@/components/Primitives/Flex';
+import { IconWrapper, PlaceholderText, StyledInput } from './styles';
+
+interface InputProps {
+  id: string;
+  placeholder: string;
+  icon?: 'search';
+  iconPosition?: 'left' | 'right';
+  disabled?: boolean;
+  currentValue?: string;
+  handleChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const SearchInput: React.FC<InputProps> = ({
+  id,
+  placeholder,
+  icon,
+  iconPosition,
+  disabled,
+  currentValue,
+  handleChange,
+}) => {
+  SearchInput.defaultProps = {
+    iconPosition: undefined,
+    icon: undefined,
+    disabled: false,
+    currentValue: undefined,
+    handleChange: undefined,
+  };
+
+  return (
+    <Flex
+      css={{ position: 'relative', width: '100%', mb: '$16', height: 'auto' }}
+      direction="column"
+    >
+      {!!icon && (
+        <IconWrapper data-iconposition={iconPosition}>
+          {icon === 'search' && (
+            <Icon
+              name="search"
+              css={{
+                width: '$24',
+                height: '$24',
+              }}
+            />
+          )}
+        </IconWrapper>
+      )}
+      <Flex>
+        <StyledInput
+          autoComplete="off"
+          data-iconposition={iconPosition}
+          disabled={disabled}
+          id={id}
+          placeholder=" "
+          value={currentValue}
+          variant="default"
+          onChange={handleChange}
+        />
+        <PlaceholderText as="label" data-iconposition={iconPosition} htmlFor={id}>
+          {placeholder}
+        </PlaceholderText>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default SearchInput;

--- a/frontend/src/components/Users/UserEdit/partials/TeamsDialog/index.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/TeamsDialog/index.tsx
@@ -1,0 +1,138 @@
+import React, { Dispatch, SetStateAction, useMemo, useRef, useState } from 'react';
+// import { useSession } from 'next-auth/react';
+import { useRecoilState } from 'recoil';
+import { Dialog, DialogClose, DialogTrigger, Portal } from '@radix-ui/react-dialog';
+
+import Icon from '@/components/icons/Icon';
+import Text from '@/components/Primitives/Text';
+import { usersListState, userTeamsListState } from '@/store/team/atom/team.atom';
+// import { toastState } from '@/store/toast/atom/toast.atom';
+// import { TeamUserRoles } from '@/utils/enums/team.user.roles';
+// import { ToastStateEnum } from '@/utils/enums/toast-types';
+
+import {
+  ButtonsContainer,
+  StyledDialogCloseButton,
+  StyledDialogContainer,
+  StyledDialogContent,
+  StyledDialogOverlay,
+  StyledDialogTitle,
+} from '@/components/Board/Settings/styles';
+import Flex from '@/components/Primitives/Flex';
+import Checkbox from '@/components/Primitives/Checkbox';
+import Button from '@/components/Primitives/Button';
+// import { CreateTeamUser, TeamUserAddAndRemove } from '@/types/team/team.user';
+// import { useRouter } from 'next/router';
+
+// import { verifyIfIsNewJoiner } from '@/utils/verifyIfIsNewJoiner';
+// import useTeam from '@/hooks/useTeam';
+import { AddNewBoardButton } from '@/components/layouts/DashboardLayout/styles';
+import SearchInput from './SearchInput';
+import { ScrollableContent } from './styles';
+
+type Props = {
+  setIsOpen: Dispatch<SetStateAction<boolean>>;
+  isOpen: boolean;
+};
+
+const ListTeams = ({ isOpen, setIsOpen }: Props) => {
+  const [searchTeam, setSearchTeam] = useState<string>('');
+
+  const [usersList, setUsersListState] = useRecoilState(usersListState);
+  const [userTeamsList] = useRecoilState(userTeamsListState);
+
+  // const setToastState = useSetRecoilState(toastState);
+
+  // References
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const dialogContainerRef = useRef<HTMLSpanElement>(null);
+
+  // Method to close dialog
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTeam(event.target.value);
+  };
+
+  const handleChecked = (id: string) => {
+    const updateCheckedUser = usersList.map((user) =>
+      user._id === id ? { ...user, isChecked: !user.isChecked } : user,
+    );
+
+    setUsersListState(updateCheckedUser);
+  };
+
+  const filteredList = useMemo(() => userTeamsList, [userTeamsList]);
+
+  return (
+    <StyledDialogContainer ref={dialogContainerRef}>
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogTrigger asChild>
+          <AddNewBoardButton css={{ mt: '-10px' }} size="sm">
+            <Icon css={{ color: 'white' }} name="plus" />
+            Add user to new team
+          </AddNewBoardButton>
+        </DialogTrigger>
+        <Portal>
+          <StyledDialogOverlay />
+          <StyledDialogContent>
+            <StyledDialogTitle>
+              <Text heading="4">Add new team</Text>
+              <DialogClose asChild>
+                <StyledDialogCloseButton isIcon size="lg">
+                  <Icon css={{ color: '$primary400' }} name="close" size={24} />
+                </StyledDialogCloseButton>
+              </DialogClose>
+            </StyledDialogTitle>
+            <Flex css={{ padding: '$24 $32 $40' }} direction="column" gap={16}>
+              <SearchInput
+                currentValue={searchTeam}
+                handleChange={handleSearchChange}
+                icon="search"
+                iconPosition="left"
+                id="search"
+                placeholder="Search team"
+              />
+            </Flex>
+            <Text css={{ display: 'block', px: '$32', py: '$10' }} heading="4">
+              Teams
+            </Text>
+            <ScrollableContent direction="column" justify="start" ref={scrollRef}>
+              <Flex css={{ flex: '1 1', px: '$32' }} direction="column" gap={16}>
+                {filteredList?.map((user) => (
+                  <Flex key={user._id} align="center" justify="between">
+                    <Flex css={{ width: '50%' }}>
+                      <Checkbox
+                        checked={false}
+                        handleChange={handleChecked}
+                        id={user._id}
+                        label={user.name}
+                        size="16"
+                      />
+                    </Flex>
+                  </Flex>
+                ))}
+              </Flex>
+            </ScrollableContent>
+            <ButtonsContainer gap={24} justify="end">
+              <Button
+                css={{ margin: '0 $24 0 auto', padding: '$16 $24' }}
+                variant="primaryOutline"
+                onClick={handleClose}
+              >
+                Cancel
+              </Button>
+              <Button css={{ marginRight: '$32', padding: '$16 $24' }} variant="primary">
+                Add
+              </Button>
+            </ButtonsContainer>
+          </StyledDialogContent>
+        </Portal>
+      </Dialog>
+    </StyledDialogContainer>
+  );
+};
+
+export { ListTeams };

--- a/frontend/src/components/Users/UserEdit/partials/TeamsDialog/styles.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/TeamsDialog/styles.tsx
@@ -1,0 +1,180 @@
+import { styled } from '@/styles/stitches/stitches.config';
+import Flex from '@/components/Primitives/Flex';
+import Text from '@/components/Primitives/Text';
+
+const ButtonAddMember = styled('button', {
+  color: 'black',
+  display: 'flex',
+  alignItems: 'center',
+  backgroundColor: 'transparent',
+  border: 0,
+  fontSize: '13px',
+  '&:hover': {
+    cursor: 'pointer',
+    textDecoration: 'underline',
+  },
+  marginTop: '10px',
+});
+
+const ScrollableContent = styled(Flex, {
+  mt: '$24',
+  height: 'calc(100vh - 390px)',
+  overflowY: 'auto',
+  pr: '$10',
+  pb: '$10',
+});
+
+const PlaceholderText = styled(Text, {
+  color: '$primary300',
+  position: 'absolute',
+  pointerEvents: 'none',
+  transformOrigin: '0 0',
+  transition: 'all .2s ease-in-out',
+  p: '$16',
+  '&[data-iconposition="left"]': {
+    pl: '$57',
+  },
+  '&[data-iconposition="right"]': {
+    pl: '$17',
+  },
+});
+
+const IconWrapper = styled(Flex, {
+  position: 'absolute',
+  top: '$16',
+  left: 'none',
+  right: 'none',
+  cursor: 'default',
+  '&[data-iconposition="left"]': {
+    left: '$16',
+  },
+  '&[data-iconposition="right"]': {
+    right: '$16',
+  },
+  '&[data-type="password"]': {
+    '&:hover': {
+      cursor: 'pointer',
+    },
+  },
+});
+
+const StyledInput = styled('input', {
+  // Reset
+  appearance: 'none',
+  borderWidth: '0',
+  boxSizing: 'border-box',
+  margin: '0',
+  outlineOffset: '0',
+  padding: '0',
+  fontFamily: '$body',
+  WebkitTapHighlightColor: 'rgba(0,0,0,0)',
+  backgroundColor: '$white',
+  '&::before': {
+    boxSizing: 'border-box',
+  },
+  '&::after': {
+    boxSizing: 'border-box',
+  },
+  '&:-internal-autofill-selected': {
+    backgroundColor: '$white',
+  },
+
+  '&:-webkit-autofill,&:-webkit-autofill:active,&:-webkit-autofill:focus': {
+    '-webkit-box-shadow': '0 0 0px 1000px white inset, 0px 0px 0px 2px $colors$successLightest',
+  },
+
+  '&:-webkit-autofill::first-line': {
+    color: '$dangerBase',
+    fontFamily: '$body',
+    fontSize: '$16',
+  },
+
+  ':-internal-autofill-previewed': {
+    fontFamily: '$body',
+    fontSize: '$16',
+  },
+
+  // Custom
+
+  display: 'flex',
+  fontSize: '$16',
+  px: '$16',
+  boxShadow: '0',
+  border: '1px solid $primary200',
+  outline: 'none',
+  width: '100%',
+  borderRadius: '$4',
+  lineHeight: '$20',
+  height: '$56',
+  pt: '$28',
+  pb: '$8',
+  '&::-webkit-input-placeholder': {
+    fontSize: '22px !important',
+    color: '$primary300',
+  },
+  '&:disabled': {
+    backgroundColor: '$primary50',
+  },
+  variants: {
+    variant: {
+      default: {
+        '&:focus': {
+          borderColor: '$primary400',
+          boxShadow: '0px 0px 0px 2px $colors$primaryLightest',
+        },
+        '&:-webkit-autofill': {
+          '-webkit-box-shadow':
+            '0 0 0px 1000px white inset, 0px 0px 0px 2px $colors$primaryLightest',
+        },
+      },
+      valid: {
+        borderColor: '$success700',
+        boxShadow: '0px 0px 0px 2px $colors$successLightest',
+        '&:-webkit-autofill': {
+          '-webkit-box-shadow':
+            '0 0 0px 1000px white inset, 0px 0px 0px 2px $colors$successLightest',
+        },
+      },
+      error: {
+        borderColor: '$danger700',
+        boxShadow: '0px 0px 0px 2px $colors$dangerLightest',
+        '&:-webkit-autofill': {
+          '-webkit-box-shadow':
+            '0 0 0px 1000px white inset, 0px 0px 0px 2px $colors$dangerLightest',
+        },
+      },
+    },
+  },
+  color: '$primaryBase',
+  '&::placeholder': {
+    '&:disabled': {
+      color: '$primaryBase',
+    },
+    color: '$primary300',
+  },
+  '&:not(:placeholder-shown) ~ label': {
+    transform: `scale(0.875) translateX(0.2rem) translateY(-0.5rem)`,
+  },
+  '&:-internal-autofill-selected ~ label': {
+    transform: `scale(0.875) translateX(0.2rem) translateY(-0.5rem)`,
+  },
+  '&:focus ~ label': {
+    transform: `scale(0.875) translateX(0.2rem) translateY(-0.5rem)`,
+  },
+
+  '&[data-iconposition="left"]': {
+    pl: '$56',
+    '&:not(:placeholder-shown) ~ label': {
+      transform: `scale(0.875) translateX(0.5rem) translateY(-0.5rem)`,
+    },
+    '&:focus ~ label': {
+      transform: `scale(0.875) translateX(0.5rem) translateY(-0.5rem)`,
+    },
+  },
+
+  '&[data-iconposition="right"]': {
+    pr: '$56',
+  },
+});
+
+export { ButtonAddMember, IconWrapper, PlaceholderText, ScrollableContent, StyledInput };

--- a/frontend/src/components/Users/UserEdit/partials/UserHeader/index.tsx
+++ b/frontend/src/components/Users/UserEdit/partials/UserHeader/index.tsx
@@ -1,10 +1,10 @@
 import Breadcrumb from '@/components/breadcrumb/Breadcrumb';
-import { AddNewBoardButton } from '@/components/layouts/DashboardLayout/styles';
 import Flex from '@/components/Primitives/Flex';
 import Text from '@/components/Primitives/Text';
 import { BreadcrumbType } from '@/types/board/Breadcrumb';
-import Icon from '@/components/icons/Icon';
+import { useState } from 'react';
 import { TitleSection } from './styles';
+import { ListTeams } from '../TeamsDialog';
 
 type UserHeaderProps = {
   firstName: string;
@@ -24,6 +24,9 @@ const UserHeader = ({ firstName, lastName, isSAdmin }: UserHeaderProps) => {
       isActive: true,
     },
   ];
+
+  const [isOpen, setIsOpen] = useState(false);
+
   return (
     <Flex align="center" justify="between" css={{ width: '100%' }}>
       <Flex direction="column">
@@ -56,11 +59,8 @@ const UserHeader = ({ firstName, lastName, isSAdmin }: UserHeaderProps) => {
           )}
         </TitleSection>
       </Flex>
-      <Flex justify="end" css={{ height: '$10 ' }}>
-        <AddNewBoardButton size="sm">
-          <Icon css={{ color: 'white' }} name="plus" />
-          Add user to new team
-        </AddNewBoardButton>
+      <Flex justify="end" css={{ mt: '$40' }}>
+        <ListTeams isOpen={isOpen} setIsOpen={setIsOpen} />
       </Flex>
     </Flex>
   );


### PR DESCRIPTION
#747

Relates to #594 

## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/99729373/209659637-cc7f8fb2-0be0-484d-9faa-427668842d33.png)


## Proposed Changes

- As a Super Admin, I want to click on a button called "Add user to new team" and see a layout pop-up on the side with the list of Teams that user is not yet part of.
- In the top-left, it must say "Add new team" and on the top-right an "X" icon, to close the pop-up.
- Below it, must be a search box, with a magnifying glass icon and a "Search team" placeholder.
- In the middle, must say "Team", followed by the list of teams that user is not a member of. The list must only have 1 column.
- In the bottom, there should be 2 buttons: Cancel and Add, both should close the pop-up.


This pull request closes #747