### PR TITLE
feat: get teams the user is not part of

### DIFF
--- a/backend/src/modules/teams/applications/get.team.application.ts
+++ b/backend/src/modules/teams/applications/get.team.application.ts
@@ -26,4 +26,8 @@ export class GetTeamApplication implements GetTeamApplicationInterface {
 	getTeamsOfUser(userId: string) {
 		return this.getTeamService.getTeamsOfUser(userId);
 	}
+
+	getTeamsUserIsNotMember(userId: string) {
+		return this.getTeamService.getTeamsUserIsNotMember(userId);
+	}
 }

--- a/backend/src/modules/teams/controller/team.controller.ts
+++ b/backend/src/modules/teams/controller/team.controller.ts
@@ -197,6 +197,26 @@ export default class TeamsController {
 		return this.getTeamApp.getTeam(teamId, teamQueryParams);
 	}
 
+	@ApiOperation({ summary: 'Retrieve a list of teams that dont belong to an user' })
+	@ApiOkResponse({ description: 'Teams successfully retrieved!', type: TeamDto, isArray: true })
+	@ApiUnauthorizedResponse({
+		description: 'Unauthorized',
+		type: UnauthorizedResponse
+	})
+	@ApiBadRequestResponse({
+		description: 'Bad Request',
+		type: BadRequestResponse
+	})
+	@ApiInternalServerErrorResponse({
+		description: 'Internal Server Error',
+		type: InternalServerErrorResponse
+	})
+	@Get('not/:userId')
+	@UseGuards(SuperAdminGuard)
+	getTeamsUserIsNotMember(@Param() { userId }: UserTeamsParams) {
+		return this.getTeamApp.getTeamsUserIsNotMember(userId);
+	}
+
 	@ApiOperation({ summary: 'Update a specific team member' })
 	@ApiParam({ type: String, name: 'teamId', required: true })
 	@ApiBody({ type: TeamUserDto })

--- a/backend/src/modules/teams/interfaces/applications/get.team.application.interface.ts
+++ b/backend/src/modules/teams/interfaces/applications/get.team.application.interface.ts
@@ -13,4 +13,6 @@ export interface GetTeamApplicationInterface {
 	): Promise<LeanDocument<TeamDocument> | null>;
 
 	getTeamsOfUser(userId: string): Promise<LeanDocument<TeamDocument>[]>;
+
+	getTeamsUserIsNotMember(userId: string): Promise<LeanDocument<TeamDocument>[]>;
 }

--- a/backend/src/modules/teams/interfaces/services/get.team.service.interface.ts
+++ b/backend/src/modules/teams/interfaces/services/get.team.service.interface.ts
@@ -21,4 +21,6 @@ export interface GetTeamServiceInterface {
 	getAllTeams(): Promise<LeanDocument<Team>[]>;
 
 	getUsersOnlyWithTeams(users: User[]): Promise<LeanDocument<UserWithTeams>[]>;
+
+	getTeamsUserIsNotMember(userId: string): Promise<LeanDocument<Team>[]>;
 }

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -54,4 +54,28 @@ export default class GetTeamService implements GetTeamServiceInterface {
 	getUsersOfTeam(teamId: string) {
 		return this.teamUserRepository.getUsersOfTeam(teamId);
 	}
+
+	async getTeamsUserIsNotMember(userId: string) {
+		const allTeams = await this.teamRepository.getAllTeams();
+		const teamUsers = await this.teamUserRepository.getAllTeamsOfUser(userId);
+
+		if (teamUsers.length === 0) return allTeams;
+
+		const teamsWithUsers: Team[] = await this.teamRepository.getTeamsWithUsers(
+			teamUsers.map((teamUser) => teamUser._id)
+		);
+
+		//ID's of the teams the user IS member
+		const teamsIds = teamsWithUsers.map((team) => team._id.toString());
+
+		const teamsUserIsNotMember = allTeams.flatMap((team) => {
+			if (teamsIds.includes(team._id.toString())) return [];
+
+			const { name, _id } = team;
+
+			return { name, _id };
+		});
+
+		return teamsUserIsNotMember;
+	}
 }


### PR DESCRIPTION
Relates to #594

## Proposed Changes

  -  I should get a list of all teams a user does not belong to, so I can choose which ones to add him to.
 
This pull request closes #748