### PR TITLE
feat: add teams to user (create teamuser db documents)

### DIFF
--- a/backend/src/modules/teams/applications/update.team.application.ts
+++ b/backend/src/modules/teams/applications/update.team.application.ts
@@ -17,4 +17,8 @@ export class UpdateTeamApplication implements UpdateTeamApplicationInterface {
 	addAndRemoveTeamUsers(addUsers: TeamUserDto[], removeUsers: string[]) {
 		return this.updateTeamService.addAndRemoveTeamUsers(addUsers, removeUsers);
 	}
+
+	addTeamUsers(teamUsers: TeamUserDto[]) {
+		return this.updateTeamService.addTeamUsers(teamUsers);
+	}
 }

--- a/backend/src/modules/teams/controller/team.controller.ts
+++ b/backend/src/modules/teams/controller/team.controller.ts
@@ -289,6 +289,38 @@ export default class TeamsController {
 		return this.updateTeamApp.addAndRemoveTeamUsers(users.addUsers, users.removeUsers);
 	}
 
+	@ApiOperation({ summary: 'Add team members' })
+	@ApiBody({ type: TeamUserDto })
+	@ApiOkResponse({
+		type: TeamUserDto,
+		description: 'Team member updated successfully!'
+	})
+	@ApiBadRequestResponse({
+		description: 'Bad Request',
+		type: BadRequestResponse
+	})
+	@ApiUnauthorizedResponse({
+		description: 'Unauthorized',
+		type: UnauthorizedResponse
+	})
+	@ApiNotFoundResponse({
+		type: NotFoundResponse,
+		description: 'Not found!'
+	})
+	@ApiForbiddenResponse({
+		description: 'Forbidden',
+		type: ForbiddenResponse
+	})
+	@ApiInternalServerErrorResponse({
+		description: 'Internal Server Error',
+		type: InternalServerErrorResponse
+	})
+	@UseGuards(SuperAdminGuard)
+	@Put('add/user')
+	addTeamUsers(@Body() teamUsers: TeamUserDto[]) {
+		return this.updateTeamApp.addTeamUsers(teamUsers);
+	}
+
 	@ApiOperation({ summary: 'Delete a specific team' })
 	@ApiParam({ type: String, name: 'teamId', required: true })
 	@ApiOkResponse({ type: Boolean, description: 'Team successfully deleted!' })

--- a/backend/src/modules/teams/interfaces/applications/update.team.application.interface.ts
+++ b/backend/src/modules/teams/interfaces/applications/update.team.application.interface.ts
@@ -8,4 +8,5 @@ export interface UpdateTeamApplicationInterface {
 		addUsers: TeamUserDto[],
 		removeUsers: string[]
 	): Promise<LeanDocument<TeamUserDocument[]>>;
+	addTeamUsers(teamUsers: TeamUserDto[]): Promise<LeanDocument<TeamUserDocument>[]>;
 }

--- a/backend/src/modules/teams/interfaces/services/update.team.service.interface.ts
+++ b/backend/src/modules/teams/interfaces/services/update.team.service.interface.ts
@@ -8,4 +8,5 @@ export interface UpdateTeamServiceInterface {
 		addUsers: TeamUserDto[],
 		removeUsers: string[]
 	): Promise<LeanDocument<TeamUserDocument[]>>;
+	addTeamUsers(teamUsers: TeamUserDto[]): Promise<LeanDocument<TeamUserDocument>[]>;
 }


### PR DESCRIPTION
Issue #749

Relates to #594


## Proposed Changes

  - receive a TeamUser DTO and create document/s on that Mongo collection


This pull request closes ##749