### PR TITLE
feat: filter boards by team endpoint

### DIFF
--- a/backend/src/libs/dto/param/pagination.params.ts
+++ b/backend/src/libs/dto/param/pagination.params.ts
@@ -17,4 +17,8 @@ export class PaginationParams {
 	@IsOptional()
 	@Type(() => String)
 	searchUser?: string;
+
+	@IsOptional()
+	@Type(() => String)
+	team?: string;
 }

--- a/backend/src/modules/boards/applications/get.board.application.ts
+++ b/backend/src/modules/boards/applications/get.board.application.ts
@@ -27,6 +27,10 @@ export class GetBoardApplication implements GetBoardApplicationInterface {
 		return this.getBoardService.getUsersBoards(userId, page, size);
 	}
 
+	getTeamBoards(teamId: string, page?: number, size?: number): Promise<BoardsAndPage | null> {
+		return this.getBoardService.getTeamBoards(teamId, page, size);
+	}
+
 	getBoard(boardId: string, userId: string) {
 		return this.getBoardService.getBoard(boardId, userId);
 	}

--- a/backend/src/modules/boards/applications/get.board.application.ts
+++ b/backend/src/modules/boards/applications/get.board.application.ts
@@ -19,16 +19,18 @@ export class GetBoardApplication implements GetBoardApplicationInterface {
 		return this.getBoardService.getUserBoardsOfLast3Months(userId, page, size);
 	}
 
-	getSuperAdminBoards(userId: string, page?: number, size?: number): Promise<BoardsAndPage | null> {
-		return this.getBoardService.getSuperAdminBoards(userId, page, size);
-	}
+	getAllBoards(
+		teamId?: string,
+		userId?: string,
+		isSuperAdmin?: boolean,
+		page?: number,
+		size?: number
+	) {
+		if (teamId) return this.getBoardService.getTeamBoards(teamId, page, size);
 
-	getUsersBoards(userId: string, page?: number, size?: number): Promise<BoardsAndPage | null> {
+		if (isSuperAdmin) return this.getBoardService.getSuperAdminBoards(userId, page, size);
+
 		return this.getBoardService.getUsersBoards(userId, page, size);
-	}
-
-	getTeamBoards(teamId: string, page?: number, size?: number): Promise<BoardsAndPage | null> {
-		return this.getBoardService.getTeamBoards(teamId, page, size);
 	}
 
 	getBoard(boardId: string, userId: string) {

--- a/backend/src/modules/boards/controller/boards.controller.ts
+++ b/backend/src/modules/boards/controller/boards.controller.ts
@@ -134,8 +134,15 @@ export default class BoardsController {
 		type: InternalServerErrorResponse
 	})
 	@Get()
-	async getAllBoards(@Req() request: RequestWithUser, @Query() { page, size }: PaginationParams) {
+	async getAllBoards(
+		@Req() request: RequestWithUser,
+		@Query() { page, size, team }: PaginationParams
+	) {
 		const { _id: userId, isSAdmin } = request.user;
+
+		if (team) {
+			return this.getBoardApp.getTeamBoards(team, page, size);
+		}
 
 		if (isSAdmin) {
 			return this.getBoardApp.getSuperAdminBoards(userId, page, size);

--- a/backend/src/modules/boards/controller/boards.controller.ts
+++ b/backend/src/modules/boards/controller/boards.controller.ts
@@ -140,15 +140,7 @@ export default class BoardsController {
 	) {
 		const { _id: userId, isSAdmin } = request.user;
 
-		if (team) {
-			return this.getBoardApp.getTeamBoards(team, page, size);
-		}
-
-		if (isSAdmin) {
-			return this.getBoardApp.getSuperAdminBoards(userId, page, size);
-		}
-
-		return this.getBoardApp.getUsersBoards(userId, page, size);
+		return this.getBoardApp.getAllBoards(team, userId, isSAdmin, page, size);
 	}
 
 	@ApiOperation({ summary: 'Retrieve one board by id' })

--- a/backend/src/modules/boards/interfaces/applications/get.board.application.interface.ts
+++ b/backend/src/modules/boards/interfaces/applications/get.board.application.interface.ts
@@ -13,6 +13,8 @@ export interface GetBoardApplicationInterface {
 
 	getUsersBoards(userId: string, page?: number, size?: number): Promise<BoardsAndPage | null>;
 
+	getTeamBoards(teamId: string, page?: number, size?: number): Promise<BoardsAndPage | null>;
+
 	getBoard(
 		boardId: string,
 		userId: string

--- a/backend/src/modules/boards/interfaces/applications/get.board.application.interface.ts
+++ b/backend/src/modules/boards/interfaces/applications/get.board.application.interface.ts
@@ -9,11 +9,13 @@ export interface GetBoardApplicationInterface {
 		size?: number
 	): Promise<BoardsAndPage | null>;
 
-	getSuperAdminBoards(userId: string, page?: number, size?: number): Promise<BoardsAndPage | null>;
-
-	getUsersBoards(userId: string, page?: number, size?: number): Promise<BoardsAndPage | null>;
-
-	getTeamBoards(teamId: string, page?: number, size?: number): Promise<BoardsAndPage | null>;
+	getAllBoards(
+		teamId?: string,
+		userId?: string,
+		isSuperAdmin?: boolean,
+		page?: number,
+		size?: number
+	): Promise<BoardsAndPage | null>;
 
 	getBoard(
 		boardId: string,

--- a/backend/src/modules/boards/interfaces/findQuery.ts
+++ b/backend/src/modules/boards/interfaces/findQuery.ts
@@ -25,6 +25,10 @@ export type QueryType = {
 							};
 							_id?: undefined;
 					  }
+					| {
+							team: Team | string;
+							_id?: undefined;
+					  }
 				)[];
 				isSubBoard?: undefined;
 				updatedAt?: undefined;

--- a/backend/src/modules/boards/interfaces/services/get.board.service.interface.ts
+++ b/backend/src/modules/boards/interfaces/services/get.board.service.interface.ts
@@ -13,6 +13,8 @@ export interface GetBoardServiceInterface {
 
 	getUsersBoards(userId: string, page?: number, size?: number): Promise<BoardsAndPage | null>;
 
+	getTeamBoards(teamId: string, page?: number, size?: number): Promise<BoardsAndPage | null>;
+
 	getBoardFromRepo(boardId: string): Promise<LeanDocument<BoardDocument> | null>;
 
 	getBoard(

--- a/backend/src/modules/boards/services/get.board.service.ts
+++ b/backend/src/modules/boards/services/get.board.service.ts
@@ -79,7 +79,7 @@ export default class GetBoardServiceImpl implements GetBoardServiceInterface {
 		return this.getBoards(false, query, page, size);
 	}
 
-	async getTeamBoards(teamId: string, page: number, size?: number) {
+	getTeamBoards(teamId: string, page: number, size?: number) {
 		const query = {
 			$and: [{ isSubBoard: false }, { $or: [{ team: teamId }] }]
 		};

--- a/backend/src/modules/boards/services/get.board.service.ts
+++ b/backend/src/modules/boards/services/get.board.service.ts
@@ -79,6 +79,14 @@ export default class GetBoardServiceImpl implements GetBoardServiceInterface {
 		return this.getBoards(false, query, page, size);
 	}
 
+	async getTeamBoards(teamId: string, page: number, size?: number) {
+		const query = {
+			$and: [{ isSubBoard: false }, { $or: [{ team: teamId }] }]
+		};
+
+		return this.getBoards(false, query, page, size);
+	}
+
 	async getBoards(allBoards: boolean, query: QueryType, page = 0, size = 10) {
 		const count = await this.boardModel.find(query).countDocuments().exec();
 		const hasNextPage = page + 1 < Math.ceil(count / (allBoards ? count : size));

--- a/frontend/src/api/boardService.tsx
+++ b/frontend/src/api/boardService.tsx
@@ -47,16 +47,6 @@ export const getBoardsRequest = (
     { context, serverSide: !!context },
   );
 
-export const getBoardsByTeamRequest = (
-  team: string,
-  pageParam: number,
-  context?: GetServerSidePropsContext,
-): Promise<{ boards: BoardType[]; hasNextPage: boolean; page: number }> =>
-  fetchData(`/boards/teamId/${team}?page=${pageParam ?? 0}&size=10`, {
-    context,
-    serverSide: !!context,
-  });
-
 export const deleteBoardRequest = async ({
   id,
   socketId,

--- a/frontend/src/api/boardService.tsx
+++ b/frontend/src/api/boardService.tsx
@@ -38,14 +38,12 @@ export const getDashboardBoardsRequest = (
   });
 
 export const getBoardsRequest = (
-  pageParam: number,
+  pageParam = 0,
   team?: string,
   context?: GetServerSidePropsContext,
 ): Promise<{ boards: BoardType[]; hasNextPage: boolean; page: number }> =>
   fetchData(
-    team
-      ? `/boards?team=${team}&page=${pageParam ?? 0}&size=10`
-      : `/boards?page=${pageParam ?? 0}&size=10`,
+    team ? `/boards?team=${team}&page=${pageParam}&size=10` : `/boards?page=${pageParam}&size=10`,
     { context, serverSide: !!context },
   );
 

--- a/frontend/src/api/boardService.tsx
+++ b/frontend/src/api/boardService.tsx
@@ -39,9 +39,25 @@ export const getDashboardBoardsRequest = (
 
 export const getBoardsRequest = (
   pageParam: number,
+  team?: string,
   context?: GetServerSidePropsContext,
 ): Promise<{ boards: BoardType[]; hasNextPage: boolean; page: number }> =>
-  fetchData(`/boards?page=${pageParam ?? 0}&size=10`, { context, serverSide: !!context });
+  fetchData(
+    team
+      ? `/boards?team=${team}&page=${pageParam ?? 0}&size=10`
+      : `/boards?page=${pageParam ?? 0}&size=10`,
+    { context, serverSide: !!context },
+  );
+
+export const getBoardsByTeamRequest = (
+  team: string,
+  pageParam: number,
+  context?: GetServerSidePropsContext,
+): Promise<{ boards: BoardType[]; hasNextPage: boolean; page: number }> =>
+  fetchData(`/boards/teamId/${team}?page=${pageParam ?? 0}&size=10`, {
+    context,
+    serverSide: !!context,
+  });
 
 export const deleteBoardRequest = async ({
   id,

--- a/frontend/src/components/Teams/CreateTeam/CardMember/RoleSettings.tsx
+++ b/frontend/src/components/Teams/CreateTeam/CardMember/RoleSettings.tsx
@@ -44,7 +44,6 @@ const PopoverRoleSettings: React.FC<PopoverRoleSettingsProps> = React.memo(
 
     const updateUser = (value: TeamUserRoles, teamUser?: TeamUser) => {
       if (teamUser && teamUser.team) {
-
         const updateTeamUserRole: TeamUserUpdate = {
           team: teamUser.team,
           user: userId,


### PR DESCRIPTION
Relates to #756

## Proposed Changes

  - Filter boards by team endpoint (with pagination)


This pull request closes #756