### PR TITLE
feat: configurations tab

### DIFF
--- a/frontend/src/components/CreateBoard/Configurations/BoardConfigurations.tsx
+++ b/frontend/src/components/CreateBoard/Configurations/BoardConfigurations.tsx
@@ -10,7 +10,11 @@ import { createBoardDataState } from '@/store/createBoard/atoms/create-board.ato
 
 const DEFAULT_MAX_VOTES = 6;
 
-const BoardConfigurations = () => {
+type BoardConfigurationsProps = {
+  isRegularBoard?: Boolean;
+};
+
+const BoardConfigurations = ({ isRegularBoard }: BoardConfigurationsProps) => {
   const [createBoardData, setCreateBoardData] = useRecoilState(createBoardDataState);
 
   const { board } = createBoardData;
@@ -54,6 +58,16 @@ const BoardConfigurations = () => {
 
     setValue('maxVotes', DEFAULT_MAX_VOTES);
     register('maxVotes');
+  };
+
+  const handleMakeBoardPublicChange = (checked: boolean) => {
+    setCreateBoardData((prev) => ({
+      ...prev,
+      board: {
+        ...prev.board,
+        isPublic: checked,
+      },
+    }));
   };
 
   return (
@@ -133,7 +147,7 @@ const BoardConfigurations = () => {
               Make votes more significant by limiting them.
             </Text>
             <Input
-              css={{ mt: '$8' }}
+              css={{ mt: '$8', mb: 0 }}
               disabled={!board.maxVotes}
               id="maxVotes"
               placeholder="Max votes"
@@ -141,6 +155,33 @@ const BoardConfigurations = () => {
             />
           </Flex>
         </Flex>
+        {isRegularBoard && (
+          <Flex gap="16">
+            <Switch checked={board.isPublic} onCheckedChange={handleMakeBoardPublicChange}>
+              <SwitchThumb>
+                {board.isPublic && (
+                  <Icon
+                    name="check"
+                    css={{
+                      width: '$14',
+                      height: '$14',
+                      color: '$successBase',
+                    }}
+                  />
+                )}
+              </SwitchThumb>
+            </Switch>
+            <Flex direction="column">
+              <Text size="md" weight="medium">
+                Make board public
+              </Text>
+              <Text color="primary500" size="sm">
+                If you make this board public anyone with the link to the board can access it. Where
+                to find the link? Just copy the URL of the board itself and share it.
+              </Text>
+            </Flex>
+          </Flex>
+        )}
       </Flex>
     </Flex>
   );

--- a/frontend/src/components/CreateBoard/RegularBoard/ParticipantsTab/ListParticipants/index.tsx
+++ b/frontend/src/components/CreateBoard/RegularBoard/ParticipantsTab/ListParticipants/index.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { usersListState } from '@/store/team/atom/team.atom';
 import { toastState } from '@/store/toast/atom/toast.atom';
 import { ToastStateEnum } from '@/utils/enums/toast-types';
@@ -16,13 +16,16 @@ type ListParticipantsProps = {
 const ListParticipants = ({ isOpen, setIsOpen }: ListParticipantsProps) => {
   const { data: session } = useSession();
 
-  const usersList = useRecoilValue(usersListState);
+  const [usersList, setUsersList] = useRecoilState(usersListState);
   const setCreateBoardData = useSetRecoilState(createBoardDataState);
 
   const setToastState = useSetRecoilState(toastState);
 
   const saveParticipants = () => {
     const selectedUsers = usersList.filter((user) => user.isChecked);
+    const usersListToBeSorted = [...usersList];
+
+    setUsersList(usersListToBeSorted.sort((a, b) => Number(b.isChecked) - Number(a.isChecked)));
 
     const users = selectedUsers.map((user) =>
       user._id === session?.user.id

--- a/frontend/src/components/CreateBoard/RegularBoard/ParticipantsTab/SelectParticipants/index.tsx
+++ b/frontend/src/components/CreateBoard/RegularBoard/ParticipantsTab/SelectParticipants/index.tsx
@@ -17,10 +17,9 @@ const SelectParticipants = () => {
 
   const usersListNames = useMemo(
     () =>
-      usersList.flatMap((user) => {
-        const foundUser = createBoardData.users.find((member) => user._id === member.user);
-        return foundUser ? [user] : [];
-      }),
+      usersList.flatMap((user) =>
+        createBoardData.users.find((member) => user._id === member.user) ? [user] : [],
+      ),
     [createBoardData.users, usersList],
   );
 

--- a/frontend/src/components/CreateBoard/RegularBoard/ParticipantsTab/SelectParticipants/index.tsx
+++ b/frontend/src/components/CreateBoard/RegularBoard/ParticipantsTab/SelectParticipants/index.tsx
@@ -1,11 +1,14 @@
 import Flex from '@/components/Primitives/Flex';
-import { useEffect, useMemo, useState } from 'react';
+import { MouseEvent, useEffect, useMemo, useState } from 'react';
 import UsersBox from '@/components/CreateBoard/SplitBoard/SubTeamsTab/UsersBox';
 import { useRecoilState } from 'recoil';
 import { createBoardDataState } from '@/store/createBoard/atoms/create-board.atom';
 import { usersListState } from '@/store/team/atom/team.atom';
 import { useSession } from 'next-auth/react';
 import { BoardUserRoles } from '@/utils/enums/board.user.roles';
+import { ButtonAddMember } from '@/components/Primitives/Dialog/styles';
+import Icon from '@/components/icons/Icon';
+import Text from '@/components/Primitives/Text';
 import ListParticipants from '../ListParticipants';
 
 const SelectParticipants = () => {
@@ -22,6 +25,11 @@ const SelectParticipants = () => {
       ),
     [createBoardData.users, usersList],
   );
+
+  const handleOpen = (event: MouseEvent) => {
+    event.preventDefault();
+    setIsOpen(true);
+  };
 
   useEffect(() => {
     const updateCheckedUser = usersList.map((user) => ({
@@ -48,6 +56,21 @@ const SelectParticipants = () => {
   return (
     <Flex direction="column" css={{ width: '100%' }}>
       <UsersBox haveError={false} participants={usersListNames} title="Participants" />
+      <Flex justify="end" css={{ mt: '$10' }}>
+        <ButtonAddMember onClick={handleOpen}>
+          <Icon css={{ width: '$16', height: '$16' }} name="plus" />{' '}
+          <Text
+            weight="medium"
+            css={{
+              ml: '$10',
+              fontSize: '$14',
+              lineHeight: '$18',
+            }}
+          >
+            Add/remove participants
+          </Text>
+        </ButtonAddMember>
+      </Flex>
       <ListParticipants isOpen={isOpen} setIsOpen={setIsOpen} />
     </Flex>
   );

--- a/frontend/src/components/CreateBoard/RegularBoard/SettingsTabs/index.tsx
+++ b/frontend/src/components/CreateBoard/RegularBoard/SettingsTabs/index.tsx
@@ -9,6 +9,7 @@ import { toastState } from '@/store/toast/atom/toast.atom';
 import Text from '@/components/Primitives/Text';
 import { StyledTextTab } from './styles';
 import ParticipantsTab from '../ParticipantsTab';
+import BoardConfigurations from '../../Configurations/BoardConfigurations';
 
 const SettingsTabs = () => {
   const [currentTab, setCurrentTab] = useState(1);
@@ -71,7 +72,7 @@ const SettingsTabs = () => {
       />
 
       {currentTab === 1 && <ParticipantsTab />}
-      {/* {currentTab === 2 && <BoardConfigurations />} */}
+      {currentTab === 2 && <BoardConfigurations isRegularBoard />}
     </Flex>
   );
 };

--- a/frontend/src/components/Teams/CreateTeam/ListCardsMembers/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListCardsMembers/index.tsx
@@ -40,7 +40,6 @@ const TeamMembersList = () => {
             Add/remove members
           </Text>
         </ButtonAddMember>
-        {/* <ListMembers isOpen={isOpen} setIsOpen={setIsOpen} /> */}
       </Flex>
       <ScrollableContent direction="column" justify="start">
         {membersList?.map((member) => (

--- a/frontend/src/components/Teams/CreateTeam/ListMembers/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListMembers/index.tsx
@@ -1,6 +1,6 @@
 import React, { Dispatch, SetStateAction } from 'react';
 import { useSession } from 'next-auth/react';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { membersListState, usersListState } from '@/store/team/atom/team.atom';
 import { toastState } from '@/store/toast/atom/toast.atom';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
@@ -26,14 +26,14 @@ const ListMembers = ({ isOpen, setIsOpen, isTeamPage }: Props) => {
 
   const { data: session } = useSession({ required: true });
 
-  const usersList = useRecoilValue(usersListState);
+  const [usersList, setUsersList] = useRecoilState(usersListState);
   const [membersList, setMembersListState] = useRecoilState(membersListState);
 
   const setToastState = useSetRecoilState(toastState);
 
   const saveMembers = () => {
     const listOfUsers = [...membersList];
-
+    const listOfUsersToBeSorted = [...usersList];
     const selectedUsers = usersList.filter((user) => user.isChecked);
     const unselectedUsers = usersList.filter((user) => !user.isChecked);
     const { teamId } = router.query;
@@ -95,6 +95,8 @@ const ListMembers = ({ isOpen, setIsOpen, isTeamPage }: Props) => {
     });
 
     setMembersListState(updatedListWithAdded);
+
+    setUsersList(listOfUsersToBeSorted.sort((a, b) => Number(b.isChecked) - Number(a.isChecked)));
 
     setIsOpen(false);
   };

--- a/frontend/src/components/Teams/CreateTeam/ListMembersDialog/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListMembersDialog/index.tsx
@@ -56,6 +56,11 @@ const ListMembersDialog = React.memo<ListMembersDialogProps>(
         user._id === id ? { ...user, isChecked: !user.isChecked } : user,
       );
 
+      updateCheckedUser.sort((x, y) => {
+        if (x === y) return 0;
+        return x ? 1 : -1;
+      });
+
       setUsersListState(updateCheckedUser);
     };
 

--- a/frontend/src/components/Teams/CreateTeam/ListMembersDialog/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListMembersDialog/index.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRecoilState } from 'recoil';
-import { Dialog, DialogClose, DialogTrigger, Portal } from '@radix-ui/react-dialog';
+import { Dialog, DialogClose, Portal } from '@radix-ui/react-dialog';
 import Icon from '@/components/icons/Icon';
 import Text from '@/components/Primitives/Text';
 import { usersListState } from '@/store/team/atom/team.atom';
@@ -16,7 +16,7 @@ import {
 import Flex from '@/components/Primitives/Flex';
 import Checkbox from '@/components/Primitives/Checkbox';
 import Button from '@/components/Primitives/Button';
-import { ButtonAddMember, ScrollableContent } from './styles';
+import { ScrollableContent } from './styles';
 import SearchInput from './SearchInput';
 
 type ListMembersDialogProps = {
@@ -44,6 +44,10 @@ const ListMembersDialog = React.memo<ListMembersDialogProps>(
 
     // Method to close dialog
     const handleClose = () => {
+      const listOfUsersToBeSorted = [...usersList];
+      setUsersListState(
+        listOfUsersToBeSorted.sort((a, b) => Number(b.isChecked) - Number(a.isChecked)),
+      );
       setIsOpen(false);
     };
 
@@ -97,24 +101,16 @@ const ListMembersDialog = React.memo<ListMembersDialogProps>(
     return (
       <StyledDialogContainer ref={dialogContainerRef}>
         <Dialog open={isOpen} onOpenChange={setIsOpen}>
-          <DialogTrigger asChild>
-            <ButtonAddMember>
-              <Icon css={{ width: '$16', height: '$16' }} name="plus" />{' '}
-              <Text
-                weight="medium"
-                css={{
-                  ml: '$10',
-                  fontSize: '$14',
-                  lineHeight: '$18',
-                }}
-              >
-                {btnTitle}
-              </Text>
-            </ButtonAddMember>
-          </DialogTrigger>
           <Portal>
             <StyledDialogOverlay />
-            <StyledDialogContent>
+            <StyledDialogContent
+              onPointerDownOutside={() => {
+                const listOfUsersToBeSorted = [...usersList];
+                setUsersListState(
+                  listOfUsersToBeSorted.sort((a, b) => Number(b.isChecked) - Number(a.isChecked)),
+                );
+              }}
+            >
               <StyledDialogTitle>
                 <Text heading="4">{btnTitle}</Text>
                 <DialogClose asChild>

--- a/frontend/src/pages/boards/newRegularBoard.tsx
+++ b/frontend/src/pages/boards/newRegularBoard.tsx
@@ -76,8 +76,8 @@ const NewRegularBoard: NextPage = () => {
   const [createBoard, setCreateBoard] = useState(false);
 
   const setToastState = useSetRecoilState(toastState);
-  // const setBoardState = useSetRecoilState(createBoardDataState);
-  const [boardState, setBoardState] = useRecoilState(createBoardDataState);
+  const setBoardState = useSetRecoilState(createBoardDataState);
+  // const [boardState, setBoardState] = useRecoilState(createBoardDataState);
   const [usersList, setUsersList] = useRecoilState(usersListState);
   const setTeams = useSetRecoilState(teamsOfUser);
   const setSelectedTeam = useSetRecoilState(createBoardTeam);
@@ -156,24 +156,16 @@ const NewRegularBoard: NextPage = () => {
    * Save board
 
    */
-  const saveBoard = (title?: string, maxVotes?: number, slackEnable?: boolean) => {
-    console.log({
-      ...boardState.board,
-      users: boardState.users,
-      title: title || boardState.board.title,
-      maxVotes,
-      slackEnable,
-      maxUsers: boardState.count.maxUsersCount,
-    });
-    // mutate( {
-    //   ...boardState.board,
-    //   users: boardState.users,
-    //   title: title || boardState.board.title,
-    //   maxVotes,
-    //   slackEnable,
-    //   maxUsers: boardState.count.maxUsersCount,
-    // });
-  };
+  // const saveBoard = (title?: string, maxVotes?: number, slackEnable?: boolean) => {
+  //   // mutate( {
+  //   //   ...boardState.board,
+  //   //   users: boardState.users,
+  //   //   title: title || boardState.board.title,
+  //   //   maxVotes,
+  //   //   slackEnable,
+  //   //   maxUsers: boardState.count.maxUsersCount,
+  //   // });
+  // };
 
   useEffect(() => {
     if (teamsData && allTeamsData && session && allUsers) {
@@ -245,9 +237,9 @@ const NewRegularBoard: NextPage = () => {
               <SubContainer>
                 <StyledForm
                   direction="column"
-                  onSubmit={methods.handleSubmit(({ text, maxVotes, slackEnable }) => {
-                    saveBoard(text, maxVotes, slackEnable);
-                  })}
+                  // onSubmit={methods.handleSubmit(({ text, maxVotes, slackEnable }) => {
+                  //   saveBoard(text, maxVotes, slackEnable);
+                  // })}
                 >
                   <InnerContent direction="column">
                     <FormProvider {...methods}>

--- a/frontend/src/pages/teams/[teamId].tsx
+++ b/frontend/src/pages/teams/[teamId].tsx
@@ -52,10 +52,12 @@ const Team = () => {
   const handleMembersList = useCallback(() => {
     if (!data || !usersData) return;
 
-    const checkboxUsersList = usersData.map((user): UserList => {
-      const userIsTeamMember = data.users.some((teamMember) => teamMember.user._id === user._id);
-      return { ...user, isChecked: userIsTeamMember };
-    });
+    const checkboxUsersList = usersData
+      .map((user): UserList => {
+        const userIsTeamMember = data.users.some((teamMember) => teamMember.user._id === user._id);
+        return { ...user, isChecked: userIsTeamMember };
+      })
+      .sort((a, b) => Number(b.isChecked) - Number(a.isChecked));
 
     setMembersListState(data.users);
     setUsersListState(checkboxUsersList);

--- a/frontend/src/pages/teams/new.tsx
+++ b/frontend/src/pages/teams/new.tsx
@@ -50,10 +50,12 @@ const NewTeam: NextPage = () => {
       }
     });
 
-    const usersWithChecked = data.map((user) => ({
-      ...user,
-      isChecked: user._id === session?.user.id,
-    }));
+    const usersWithChecked = data
+      .map((user) => ({
+        ...user,
+        isChecked: user._id === session?.user.id,
+      }))
+      .sort((a, b) => Number(b.isChecked) - Number(a.isChecked));
 
     setUsersListState(usersWithChecked);
     setMembersListState(listMembers);


### PR DESCRIPTION

Relates to #679 

## Proposed Changes

  - Add configuration tab with "Make board public" switch on the frontend
  -List members dialog shows users sorted by checked
- Fix team users page (remove duplicated add members button)


This pull request closes #679 