### PR TITLE
fix: random responsible generator fixed

### DIFF
--- a/frontend/src/components/Board/Settings/index.tsx
+++ b/frontend/src/components/Board/Settings/index.tsx
@@ -175,7 +175,7 @@ const BoardSettings = ({
 
   // Method to generate a random responsible
   const handleRandomResponsible = () => {
-    if (switchesState.responsible) return;
+    if (!switchesState.responsible) return;
 
     const cloneUsers = [...deepClone(data.users)].map((user) => ({
       ...user,


### PR DESCRIPTION
Fixes #780

## Proposed Changes

  - clicking on the magic wand generates a new Responsible
  - the code was correct, but the initial if statement was doing the opposite of what it should


This pull request closes #780 