### PR TITLE
fix: text area new line and height

### DIFF
--- a/backend/src/modules/communication/applications/slack-communication.application.ts
+++ b/backend/src/modules/communication/applications/slack-communication.application.ts
@@ -56,7 +56,6 @@ export class SlackCommunicationApplication implements CommunicationApplicationIn
     Each team has a *random* selected responsible, in order to create the board, organize the retro and everything else that is described in the doc(https://confluence.kigroup.de/display/OX/Retro) :eyes: :thumbsup:\n\n
     This must be done until \`${until} 1st\`\n\n
     All the channels needed have been created automatically for your team and another one for responsibles of the teams.\n\n
-    (Note: currently, retrobot does not check if the chosen responsibles joined xgeeks less than 3 months ago, so, if that happens, you have to decide who will take that role in the team. In the future, retrobot will automatically validate this rule.)\n\n
     Talent wins games, but teamwork and intelligence wins championships. :fire: :muscle:`;
 
 		this.chatHandler.postMessage(this.config.slackMasterChannelId, generalText);

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -96,7 +96,7 @@ const Column = React.memo<ColumnBoardType>(
                 )}
               </Flex>
               <Separator css={{ backgroundColor: '$primary100', mb: '$20' }} />
-              <Flex css={{}} direction="column">
+              <Flex direction="column">
                 {!isSubmited && (
                   <Flex
                     align="center"

--- a/frontend/src/components/Primitives/TextArea.tsx
+++ b/frontend/src/components/Primitives/TextArea.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { styled } from '@/styles/stitches/stitches.config';
@@ -117,13 +117,17 @@ const TextArea: React.FC<ResizableTextAreaProps> = ({ id, placeholder, disabled 
     return autoState;
   }, [autoState, disabled, id, touchedFields]);
 
+  useEffect(() => {
+    textAreaAdjust(textareaRef.current);
+  }, []);
+
   return (
     <StyledTextArea
       {...rest}
       css={{ minHeight: '$80', backgroundColor: '$primary50', py: '$12', px: '$16' }}
       disabled={disabled}
       id={id}
-      onKeyUp={() => textAreaAdjust(textareaRef.current)}
+      onChange={() => textAreaAdjust(textareaRef.current)}
       placeholder={placeholder}
       variant={currentState}
       ref={(e) => {

--- a/frontend/src/components/Primitives/TextArea.tsx
+++ b/frontend/src/components/Primitives/TextArea.tsx
@@ -28,13 +28,14 @@ const StyledTextArea = styled('textarea', {
 
   fontSize: '$16',
   lineHeight: '$20',
-  resize: 'none',
+  resize: 'vertical',
   height: 'auto',
   boxShadow: '0',
   border: '1px solid $primary200',
   borderRadius: '$4',
   outline: 'none',
   fontWeight: 'normal',
+  whiteSpace: 'pre-line',
   width: '100%',
   pt: '$28',
   pb: '$8',
@@ -140,6 +141,7 @@ const TextArea: React.FC<ResizableTextAreaProps> = ({
       direction="column"
       ref={flexRef}
     >
+      <TextArea />
       <Flex>
         {floatPlaceholder && (
           <Flex>

--- a/frontend/src/components/Primitives/TextArea.tsx
+++ b/frontend/src/components/Primitives/TextArea.tsx
@@ -2,11 +2,7 @@ import { useMemo, useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { styled } from '@/styles/stitches/stitches.config';
-
-import Icon from '@/components/icons/Icon';
 import isEmpty from '@/utils/isEmpty';
-import Flex from './Flex';
-import Text from './Text';
 
 const StyledTextArea = styled('textarea', {
   // Reset
@@ -28,7 +24,7 @@ const StyledTextArea = styled('textarea', {
 
   fontSize: '$16',
   lineHeight: '$20',
-  resize: 'vertical',
+  resize: 'none',
   height: 'auto',
   boxShadow: '0',
   border: '1px solid $primary200',
@@ -77,19 +73,6 @@ const StyledTextArea = styled('textarea', {
   },
 });
 
-const StyledText = styled(Text, {
-  fontSize: '$16',
-  top: '0',
-  p: '$16',
-  pl: '$17',
-  lineHeight: '24px',
-  color: '$primary300',
-  position: 'absolute',
-  pointerEvents: 'none',
-  transformOrigin: '0 0',
-  transition: 'all .2s ease-in-out',
-});
-
 interface ResizableTextAreaProps {
   id: string;
   placeholder: string;
@@ -98,20 +81,19 @@ interface ResizableTextAreaProps {
   floatPlaceholder?: boolean;
 }
 
-const TextArea: React.FC<ResizableTextAreaProps> = ({
-  id,
-  placeholder,
-  helperText,
-  disabled,
-  floatPlaceholder,
-}) => {
+const TextArea: React.FC<ResizableTextAreaProps> = ({ id, placeholder, disabled }) => {
   TextArea.defaultProps = {
     helperText: undefined,
     disabled: false,
   };
 
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  const flexRef = useRef<HTMLDivElement | null>(null);
+
+  function textAreaAdjust(element: HTMLTextAreaElement | null) {
+    if (!element) return;
+    element.style.height = '1px';
+    element.style.height = `${25 + element.scrollHeight}px`;
+  }
 
   const {
     register,
@@ -136,69 +118,19 @@ const TextArea: React.FC<ResizableTextAreaProps> = ({
   }, [autoState, disabled, id, touchedFields]);
 
   return (
-    <Flex
-      css={{ position: 'relative', width: '100%', height: 'auto' }}
-      direction="column"
-      ref={flexRef}
-    >
-      <TextArea />
-      <Flex>
-        {floatPlaceholder && (
-          <Flex>
-            <StyledTextArea
-              {...rest}
-              disabled={disabled}
-              id={id}
-              placeholder=" "
-              variant={currentState}
-              ref={(e) => {
-                if (ref) ref(e);
-                textareaRef.current = e;
-              }}
-            />
-            <StyledText as="label" htmlFor={id}>
-              {placeholder}
-            </StyledText>
-          </Flex>
-        )}
-      </Flex>
-      <StyledTextArea
-        {...rest}
-        css={{ minHeight: '$80', backgroundColor: '$primary50', py: '$12', px: '$16' }}
-        disabled={disabled}
-        id={id}
-        placeholder={placeholder}
-        variant={currentState}
-        ref={(e) => {
-          if (ref) ref(e);
-          textareaRef.current = e;
-        }}
-      />
-      {floatPlaceholder && (
-        <Flex
-          align="center"
-          gap="4"
-          css={{
-            mt: '$8',
-            '& svg': {
-              height: '$16 !important',
-              width: '$16 !important',
-              color: '$dangerBase',
-            },
-          }}
-        >
-          {currentState === 'error' && <Icon css={{ width: '$24', height: '$24' }} name="info" />}
-          <Text
-            hint
-            css={{
-              color: currentState === 'error' ? '$dangerBase' : '$primary300',
-            }}
-          >
-            {!isEmpty(helperText) ? helperText : errors[`${id}`]?.message}
-          </Text>
-        </Flex>
-      )}
-    </Flex>
+    <StyledTextArea
+      {...rest}
+      css={{ minHeight: '$80', backgroundColor: '$primary50', py: '$12', px: '$16' }}
+      disabled={disabled}
+      id={id}
+      onKeyUp={() => textAreaAdjust(textareaRef.current)}
+      placeholder={placeholder}
+      variant={currentState}
+      ref={(e) => {
+        if (ref) ref(e);
+        textareaRef.current = e;
+      }}
+    />
   );
 };
 export default TextArea;

--- a/frontend/src/pages/boards/[boardId].tsx
+++ b/frontend/src/pages/boards/[boardId].tsx
@@ -197,15 +197,17 @@ const Board: NextPage<Props> = ({ boardId, mainBoardId }) => {
                 Board settings
                 <Icon name="arrow-down" />
               </Button>
-              <BoardSettings
-                isOpen={isOpen}
-                isOwner={isOwner}
-                isResponsible={isResponsible}
-                isSAdmin={session?.user.isSAdmin}
-                isStakeholderOrAdmin={isStakeholderOrAdmin}
-                setIsOpen={setIsOpen}
-                socketId={socketId}
-              />
+              {isOpen && (
+                <BoardSettings
+                  isOpen={isOpen}
+                  isOwner={isOwner}
+                  isResponsible={isResponsible}
+                  isSAdmin={session?.user.isSAdmin}
+                  isStakeholderOrAdmin={isStakeholderOrAdmin}
+                  setIsOpen={setIsOpen}
+                  socketId={socketId}
+                />
+              )}
             </>
           )}
 


### PR DESCRIPTION
<!--
#776
-->
Fixes #776

## Proposed Changes

  - Hide board settings when it's closed so the on press enter key observer that is present on that component is not triggered. Now all users can add a new line on the text area
  - Increase text area height based on the content length
  - When the card or comment is edited it now appears with the height based on the content

<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes  #776