### PR TITLE
fix: update card position and votes with sockets

### DIFF
--- a/backend/src/modules/cards/controller/cards.controller.ts
+++ b/backend/src/modules/cards/controller/cards.controller.ts
@@ -290,17 +290,23 @@ export default class CardsController {
 		const { boardId, cardId } = params;
 		const { targetColumnId, newPosition, socketId } = boardData;
 
-		const board = await this.updateCardApp.updateCardPosition(
-			boardId,
-			cardId,
-			targetColumnId,
-			newPosition
-		);
+		try {
+			const board = await this.updateCardApp.updateCardPosition(
+				boardId,
+				cardId,
+				targetColumnId,
+				newPosition
+			);
 
-		if (!board) throw new BadRequestException(UPDATE_FAILED);
-		this.socketService.sendUpdatedBoard(boardId, socketId);
+			if (!board) throw new BadRequestException(UPDATE_FAILED);
+			this.socketService.sendUpdateCardPosition(socketId, boardData);
 
-		return board;
+			return board;
+		} catch (e) {
+			this.socketService.sendUpdatedBoard(boardId, socketId);
+
+			throw e;
+		}
 	}
 
 	@ApiOperation({ summary: 'Merge two cards together' })

--- a/backend/src/modules/cards/dto/update-position.card..dto.ts
+++ b/backend/src/modules/cards/dto/update-position.card..dto.ts
@@ -1,4 +1,4 @@
-import { IsMongoId, IsNotEmpty, IsNumber, IsString } from 'class-validator';
+import { IsBoolean, IsMongoId, IsNotEmpty, IsNumber, IsString } from 'class-validator';
 import { BaseDto } from 'src/libs/dto/base.dto';
 
 export class UpdateCardPositionDto extends BaseDto {
@@ -10,4 +10,31 @@ export class UpdateCardPositionDto extends BaseDto {
 	@IsNotEmpty()
 	@IsNumber()
 	newPosition!: number;
+
+	@IsNotEmpty()
+	@IsMongoId()
+	@IsString()
+	boardId!: string;
+
+	@IsNotEmpty()
+	@IsMongoId()
+	@IsString()
+	colIdOfCard: string;
+
+	@IsNotEmpty()
+	@IsNumber()
+	cardPosition: number;
+
+	@IsNotEmpty()
+	@IsMongoId()
+	@IsString()
+	cardId: string;
+
+	@IsNotEmpty()
+	@IsString()
+	socketId: string;
+
+	@IsNotEmpty()
+	@IsBoolean()
+	sorted: boolean;
 }

--- a/backend/src/modules/socket/gateway/socket.gateway.ts
+++ b/backend/src/modules/socket/gateway/socket.gateway.ts
@@ -8,6 +8,8 @@ import {
 	WebSocketServer
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
+import { UpdateCardPositionDto } from 'src/modules/cards/dto/update-position.card..dto';
+import VoteDto from 'src/modules/votes/dto/vote.dto';
 import JoinPayload from '../interfaces/joinPayload.interface';
 import JoinPayloadBoards from '../interfaces/joinPayloadBoards.interface';
 
@@ -30,6 +32,16 @@ export default class SocketGateway
 
 	sendUpdatedAllBoard(excludedClient: string) {
 		this.server.except(excludedClient).emit('updateAllBoard');
+	}
+
+	sendUpdateCardPosition(excludedClient: string, updateCardPositionDto: UpdateCardPositionDto) {
+		this.server
+			.except(excludedClient)
+			.emit(`${updateCardPositionDto.boardId}cardPosition`, updateCardPositionDto);
+	}
+
+	sendUpdateVotes(excludedClient: string, voteDto: VoteDto) {
+		this.server.except(excludedClient).emit(`${voteDto.boardId}vote`, voteDto);
 	}
 
 	afterInit() {

--- a/backend/src/modules/teams/repositories/team.repository.ts
+++ b/backend/src/modules/teams/repositories/team.repository.ts
@@ -49,7 +49,7 @@ export class TeamRepository
 	getAllTeams(): Promise<Team[]> {
 		return this.findAllWithQuery(null, null, {
 			path: 'users',
-			select: 'user role email',
+			select: 'user role email isNewJoiner',
 			populate: {
 				path: 'user',
 				select: '_id firstName lastName email joinedAt providerAccountCreatedAt'

--- a/backend/src/modules/votes/controller/votes.controller.ts
+++ b/backend/src/modules/votes/controller/votes.controller.ts
@@ -72,13 +72,25 @@ export default class VotesController {
 		const { boardId, cardId, itemId } = params;
 		const { count, socketId } = data;
 
-		if (count < 0) {
-			await this.deleteVoteApp.deleteVoteFromCard(boardId, cardId, request.user._id, itemId, count);
-		} else {
-			await this.createVoteApp.addVoteToCard(boardId, cardId, request.user._id, itemId, count);
-		}
+		try {
+			if (count < 0) {
+				await this.deleteVoteApp.deleteVoteFromCard(
+					boardId,
+					cardId,
+					request.user._id,
+					itemId,
+					count
+				);
+			} else {
+				await this.createVoteApp.addVoteToCard(boardId, cardId, request.user._id, itemId, count);
+			}
 
-		this.socketService.sendUpdatedBoard(boardId, socketId);
+			this.socketService.sendUpdateVotes(socketId, data);
+		} catch (e) {
+			this.socketService.sendUpdatedBoard(boardId, socketId);
+
+			throw e;
+		}
 
 		return HttpStatus.OK;
 	}
@@ -116,13 +128,19 @@ export default class VotesController {
 		const { boardId, cardId } = params;
 		const { count, socketId } = data;
 
-		if (count < 0) {
-			await this.deleteVoteApp.deleteVoteFromCardGroup(boardId, cardId, request.user._id, count);
-		} else {
-			await this.createVoteApp.addVoteToCardGroup(boardId, cardId, request.user._id, count);
-		}
+		try {
+			if (count < 0) {
+				await this.deleteVoteApp.deleteVoteFromCardGroup(boardId, cardId, request.user._id, count);
+			} else {
+				await this.createVoteApp.addVoteToCardGroup(boardId, cardId, request.user._id, count);
+			}
 
-		this.socketService.sendUpdatedBoard(boardId, socketId);
+			this.socketService.sendUpdateVotes(socketId, data);
+		} catch (e) {
+			this.socketService.sendUpdatedBoard(boardId, socketId);
+
+			throw e;
+		}
 
 		return HttpStatus.OK;
 	}

--- a/backend/src/modules/votes/dto/vote.dto.ts
+++ b/backend/src/modules/votes/dto/vote.dto.ts
@@ -1,5 +1,35 @@
-export default class VoteDto {
-	count!: number;
+import { IsBoolean, IsMongoId, IsNotEmpty, IsNumber, IsOptional, IsString } from 'class-validator';
 
-	socketId!: string;
+export default class VoteDto {
+	@IsNotEmpty()
+	@IsMongoId()
+	@IsString()
+	cardId: string;
+
+	@IsOptional()
+	@IsMongoId()
+	@IsString()
+	cardItemId?: string;
+
+	@IsNotEmpty()
+	@IsMongoId()
+	@IsString()
+	boardId: string;
+
+	@IsNotEmpty()
+	@IsString()
+	socketId?: string;
+
+	@IsNotEmpty()
+	@IsBoolean()
+	isCardGroup: boolean;
+
+	@IsNotEmpty()
+	@IsNumber()
+	count: number;
+
+	@IsNotEmpty()
+	@IsMongoId()
+	@IsString()
+	userId: string;
 }

--- a/backend/src/modules/votes/services/create.vote.service.ts
+++ b/backend/src/modules/votes/services/create.vote.service.ts
@@ -76,7 +76,7 @@ export default class CreateVoteServiceImpl implements CreateVoteServiceInterface
 		const session = await this.boardModel.db.startSession();
 		session.startTransaction();
 		try {
-			await this.incrementVoteUser(boardId, userId, count, userSession);
+			await this.incrementVoteUser(boardId, userId, count);
 			const board = await this.boardModel
 				.updateOne(
 					{
@@ -89,8 +89,7 @@ export default class CreateVoteServiceImpl implements CreateVoteServiceInterface
 						}
 					},
 					{
-						arrayFilters: [{ 'c._id': cardId }, { 'i._id': cardItemId }],
-						session
+						arrayFilters: [{ 'c._id': cardId }, { 'i._id': cardItemId }]
 					}
 				)
 				.lean()

--- a/frontend/src/components/Board/Card/CardBoard.tsx
+++ b/frontend/src/components/Board/Card/CardBoard.tsx
@@ -161,7 +161,7 @@ const CardBoard = React.memo<CardBoardProps>(
                         <Icon css={{ width: '$20', height: '$20' }} name="menu-dots" />
                       )}
 
-                      {!isSubmited && (userId === card?.createdBy?._id || !hideCards) && (
+                      {!isSubmited && userId === card?.createdBy?._id && (
                         <PopoverCardSettings
                           boardId={boardId}
                           cardGroupId={card._id}

--- a/frontend/src/components/Board/Card/CardFooter.tsx
+++ b/frontend/src/components/Board/Card/CardFooter.tsx
@@ -124,6 +124,7 @@ const CardFooter = React.memo<FooterProps>(
         cardItemId,
         isCardGroup: cardItemId === undefined,
         count: -1,
+        userId,
       });
 
       if (maxVotes) {
@@ -141,6 +142,7 @@ const CardFooter = React.memo<FooterProps>(
         cardItemId,
         isCardGroup: cardItemId === undefined,
         count: 1,
+        userId,
       });
 
       if (maxVotes) {

--- a/frontend/src/components/Board/Card/CardItem/CardItem.tsx
+++ b/frontend/src/components/Board/Card/CardItem/CardItem.tsx
@@ -94,7 +94,7 @@ const CardItem: React.FC<CardItemProps> = React.memo(
                   />
                 </Flex>
               )}
-              {!isSubmited && (!hideCards || userId === item?.createdBy?._id) && (
+              {!isSubmited && userId === item?.createdBy?._id && (
                 <PopoverCardSettings
                   isItem
                   boardId={boardId}

--- a/frontend/src/helper/board/transformBoard.tsx
+++ b/frontend/src/helper/board/transformBoard.tsx
@@ -55,13 +55,12 @@ export const handleUpdateText = (board: BoardType, data: UpdateCardDto) => {
 
 export const handleUpdateCardPosition = (board: BoardType, changes: UpdateCardPositionDto) => {
   const boardData = removeReadOnly(board);
-  const { targetColumnId, colIdOfCard, newPosition, cardPosition, sorted, cardId } = changes;
+  const { targetColumnId, colIdOfCard, newPosition, cardPosition, cardId } = changes;
   let currentCardPosition: number | undefined = cardPosition;
   const colToRemove = boardData.columns.find((col) => col._id === colIdOfCard);
   const colToAdd = boardData.columns.find((col) => col._id === targetColumnId);
-  if (sorted) {
-    currentCardPosition = colToRemove?.cards.findIndex((card) => card._id === cardId);
-  }
+
+  currentCardPosition = colToRemove?.cards.findIndex((card) => card._id === cardId);
 
   if (currentCardPosition !== undefined) {
     const cardToAdd = colToRemove?.cards[currentCardPosition];
@@ -77,16 +76,14 @@ export const handleUpdateCardPosition = (board: BoardType, changes: UpdateCardPo
 export const handleMergeCard = (board: BoardType, changes: MergeCardsDto) => {
   const boardData = removeReadOnly(board);
 
-  const { cardGroupId, cardId, colIdOfCardGroup, columnIdOfCard, cardPosition, sorted } = changes;
+  const { cardGroupId, cardId, colIdOfCardGroup, columnIdOfCard, cardPosition } = changes;
   let currentCardPosition: number | undefined = cardPosition;
   const targetColumn = boardData.columns.find((col) => col._id === colIdOfCardGroup);
   const cardGroup = targetColumn?.cards.find((card) => card._id === cardGroupId);
   const sourceColumn = boardData.columns.find((col) => col._id === columnIdOfCard);
   const selectedCard = sourceColumn?.cards.find((card) => card._id === cardId);
 
-  if (sorted) {
-    currentCardPosition = sourceColumn?.cards.findIndex((card) => card._id === cardId);
-  }
+  currentCardPosition = sourceColumn?.cards.findIndex((card) => card._id === cardId);
 
   if (cardGroup && selectedCard && sourceColumn && currentCardPosition !== undefined) {
     sourceColumn.cards = removeElementAtIndex(sourceColumn.cards, currentCardPosition);

--- a/frontend/src/hooks/useSocketIO.ts
+++ b/frontend/src/hooks/useSocketIO.ts
@@ -3,10 +3,16 @@ import { useQueryClient } from 'react-query';
 import { io, Socket } from 'socket.io-client';
 
 import { NEXT_PUBLIC_BACKEND_URL } from '@/utils/constants';
+import UpdateCardPositionDto from '@/types/card/updateCardPosition.dto';
+import useCards from '@/hooks/useCards';
+import VoteDto from '@/types/vote/vote.dto';
+import useVotes from './useVotes';
 
 export const useSocketIO = (boardId: string): string | undefined => {
   const queryClient = useQueryClient();
   const [socket, setSocket] = useState<Socket | null>(null);
+  const { updateCardPositionOptimistic } = useCards();
+  const { updateVote } = useVotes();
 
   useEffect(() => {
     const newSocket: Socket = io(NEXT_PUBLIC_BACKEND_URL ?? 'http://127.0.0.1:3200', {
@@ -18,15 +24,25 @@ export const useSocketIO = (boardId: string): string | undefined => {
       setSocket(newSocket);
     });
 
-    newSocket.on('updateAllBoard', () => {
-      queryClient.invalidateQueries(['board', { id: boardId }]);
-    });
-
     return () => {
       newSocket.disconnect();
       setSocket(null);
     };
   }, [boardId, queryClient, setSocket]);
+
+  useEffect(() => {
+    socket?.on('updateAllBoard', () => {
+      queryClient.invalidateQueries(['board', { id: boardId }]);
+    });
+
+    socket?.on(`${boardId}cardPosition`, (updateCardPositionDto: UpdateCardPositionDto) => {
+      updateCardPositionOptimistic(updateCardPositionDto);
+    });
+
+    socket?.on(`${boardId}vote`, (votesDto: VoteDto) => {
+      updateVote(votesDto);
+    });
+  }, [queryClient, socket]);
 
   return socket?.id;
 };

--- a/frontend/src/hooks/useVotes.tsx
+++ b/frontend/src/hooks/useVotes.tsx
@@ -236,7 +236,7 @@ const useVotes = () => {
       variables,
     );
 
-    if (newBoardData?.maxVotes && newBoardData && variables.userId === userId) {
+    if (newBoardData?.maxVotes && variables.userId === userId) {
       toastRemainingVotesMessage('', newBoardData);
     }
   };

--- a/frontend/src/hooks/useVotes.tsx
+++ b/frontend/src/hooks/useVotes.tsx
@@ -72,9 +72,9 @@ const useVotes = () => {
     return newBoardData;
   };
 
-  const updateBoardUser = (boardData: BoardType, action: Action) => {
+  const updateBoardUser = (boardData: BoardType, action: Action, currentUser: string) => {
     boardData.users = boardData.users.map((boardUser) => {
-      if (boardUser.user._id !== userId) return boardUser;
+      if (boardUser.user._id !== currentUser) return boardUser;
 
       return {
         ...boardUser,
@@ -189,7 +189,7 @@ const useVotes = () => {
         isCardGroup,
         action,
       );
-      updateBoardUser(newBoard, count > 0 ? Action.Add : Action.Remove);
+      updateBoardUser(newBoard, count > 0 ? Action.Add : Action.Remove, voteData.userId);
 
       return newBoard;
     }
@@ -236,7 +236,7 @@ const useVotes = () => {
       variables,
     );
 
-    if (newBoardData?.maxVotes && newBoardData) {
+    if (newBoardData?.maxVotes && newBoardData && variables.userId === userId) {
       toastRemainingVotesMessage('', newBoardData);
     }
   };
@@ -244,7 +244,6 @@ const useVotes = () => {
   const handleVote = useMutation(handleVotes, {
     onSuccess: async (data, variables) => {
       updateVote(variables);
-      queryClient.invalidateQueries(['board', { id: variables.boardId }]);
     },
     onError: (_, variables, context) => {
       queryClient.invalidateQueries(['board', { id: variables.boardId }]);
@@ -255,6 +254,7 @@ const useVotes = () => {
   return {
     handleVote,
     toastInfoMessage,
+    updateVote,
   };
 };
 

--- a/frontend/src/types/vote/vote.dto.ts
+++ b/frontend/src/types/vote/vote.dto.ts
@@ -10,4 +10,6 @@ export default interface VoteDto {
   isCardGroup: boolean;
 
   count: number;
+
+  userId: string;
 }


### PR DESCRIPTION
<!--
#825 
-->

Fixes #825 

## Proposed Changes

Note: this should solve the majority of issues regarding performance when many people are moving or voting the cards in real-time. This should be tested in the live version

  - When voting in a card or moving its position now a socket message is sent to all users that are seeing the board and receiving that they will update the board locally instead of making a board request 
  - If some error occurs in the backend during these updates a message is sent to all users to refetch the board. (this may not be necessary)

<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #825