### PR TITLE
fix: main board alert section padding

### DIFF
--- a/frontend/src/pages/boards/[boardId].tsx
+++ b/frontend/src/pages/boards/[boardId].tsx
@@ -175,9 +175,9 @@ const Board: NextPage<Props> = ({ boardId, mainBoardId }) => {
     <>
       <BoardHeader />
       <Container direction="column">
-        <Flex align="center" css={{ py: '$32', width: '100%' }} justify="between">
+        <Flex gap={40} align="center" css={{ py: '$32', width: '100%' }} justify="between">
           {!showMessageIfMerged && (
-            <Flex gap={40} css={{ flex: 1, pr: '$40' }}>
+            <Flex gap={40} css={{ flex: 1 }}>
               {showButtonToMerge && <AlertMergeIntoMain boardId={boardId} socketId={socketId} />}
 
               {showMessageHaveSubBoardsMerged && (


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #832
Fixes #832

## Screenshots

##### Previously:
<img width="1439" alt="main-board-alert-issue" src="https://user-images.githubusercontent.com/24455614/211295186-dcc09a2d-aeb0-44ad-831c-6917ed9d72a9.png">

##### Now:
<img width="1438" alt="main-board-alert-fix" src="https://user-images.githubusercontent.com/24455614/211295219-2789563f-95bc-4d64-8bd1-c56b4a6a654f.png">

<img width="1405" alt="main-board-alert-with-button" src="https://user-images.githubusercontent.com/24455614/211295231-b5950f90-a74f-483b-8767-3ef897dcd845.png">

## Proposed Changes

The alert section of the main board page doesn't have any right padding for non admin users, but still has a gap between the alert and the button for admin users.

<!--
Mention people who discussed this issue previously
@StereoPT 
-->


This pull request closes #832