### PR TITLE
fix: board loading

### DIFF
--- a/backend/src/modules/boards/services/get.board.service.ts
+++ b/backend/src/modules/boards/services/get.board.service.ts
@@ -208,13 +208,13 @@ export default class GetBoardServiceImpl implements GetBoardServiceInterface {
 		// board1 = this.commentsClean(b)
 		board = this.cleanBoard(board, userId);
 
-		if (board.isSubBoard) {
-			const mainBoard = await this.getMainBoardData(boardId);
+		// if (board.isSubBoard) {
+		// 	const mainBoard = await this.getMainBoardData(boardId);
 
-			if (!mainBoard) return null;
+		// 	if (!mainBoard) return null;
 
-			return { board, mainBoardData: mainBoard };
-		}
+		// 	return { board, mainBoardData: mainBoard };
+		// }
 
 		return { board };
 	}

--- a/backend/src/modules/boards/services/get.board.service.ts
+++ b/backend/src/modules/boards/services/get.board.service.ts
@@ -208,14 +208,6 @@ export default class GetBoardServiceImpl implements GetBoardServiceInterface {
 		// board1 = this.commentsClean(b)
 		board = this.cleanBoard(board, userId);
 
-		// if (board.isSubBoard) {
-		// 	const mainBoard = await this.getMainBoardData(boardId);
-
-		// 	if (!mainBoard) return null;
-
-		// 	return { board, mainBoardData: mainBoard };
-		// }
-
 		return { board };
 	}
 

--- a/backend/src/modules/teams/repositories/team.repository.ts
+++ b/backend/src/modules/teams/repositories/team.repository.ts
@@ -47,13 +47,19 @@ export class TeamRepository
 	}
 
 	getAllTeams(): Promise<Team[]> {
-		return this.findAllWithQuery(null, null, {
-			path: 'users',
-			select: 'user role email isNewJoiner',
-			populate: {
-				path: 'user',
-				select: '_id firstName lastName email joinedAt providerAccountCreatedAt'
+		return this.findAllWithQuery(null, null, [
+			{
+				path: 'users',
+				select: 'user role email isNewJoiner',
+				populate: {
+					path: 'user',
+					select: '_id firstName lastName email joinedAt providerAccountCreatedAt'
+				}
+			},
+			{
+				path: 'boards',
+				select: '_id'
 			}
-		});
+		]);
 	}
 }

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -47,8 +47,12 @@ export default class GetTeamService implements GetTeamServiceInterface {
 		return this.teamUserRepository.findOneByField({ user: userId, team: teamId });
 	}
 
-	getAllTeams() {
-		return this.teamRepository.getAllTeams();
+	async getAllTeams() {
+		const teams = await this.teamRepository.getAllTeams();
+
+		return teams.map((team) => {
+			return { ...team, boardsCount: team.boards?.length ?? 0, boards: undefined };
+		});
 	}
 
 	getUsersOfTeam(teamId: string) {

--- a/frontend/src/components/Board/Header/index.tsx
+++ b/frontend/src/components/Board/Header/index.tsx
@@ -18,6 +18,7 @@ import { BreadcrumbType } from '@/types/board/Breadcrumb';
 import { TeamUser } from '@/types/team/team.user';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 import isEmpty from '@/utils/isEmpty';
+import { useRouter } from 'next/router';
 import {
   BoardCounter,
   MergeIconContainer,
@@ -33,6 +34,7 @@ import {
 
 const BoardHeader = () => {
   const { data: session } = useSession({ required: true });
+  const router = useRouter();
 
   // Atoms
   const boardData = useRecoilValue(boardInfoState);
@@ -71,12 +73,15 @@ const BoardHeader = () => {
     },
   ];
 
-  if (isSubBoard && !!boardData?.mainBoardData) {
-    const { title: mainTitle, id: mainId } = boardData.mainBoardData;
+  const { mainBoardTitle, mainBoardId } = router.query;
 
+  const mainTitle = mainBoardTitle as string;
+  const mainId = mainBoardId as string;
+
+  if (isSubBoard) {
     breadcrumbItems.push(
       {
-        title: mainTitle,
+        title: mainTitle ?? title,
         link: `/boards/${mainId}`,
       },
       {
@@ -107,6 +112,7 @@ const BoardHeader = () => {
                     query: {
                       boardId: getSubBoard()?.id,
                       mainBoardId: boardData?.board._id,
+                      mainBoardTitle: boardData?.board.title,
                     },
                   }}
                 >

--- a/frontend/src/components/Board/Header/index.tsx
+++ b/frontend/src/components/Board/Header/index.tsx
@@ -115,6 +115,7 @@ const BoardHeader = () => {
                       mainBoardTitle: boardData?.board.title,
                     },
                   }}
+                  as={`/${getSubBoard()?.id}?mainBoardId=${boardData?.board._id}`}
                 >
                   <StyledBoardLink>{getSubBoard()?.title.replace('team ', '')}</StyledBoardLink>
                 </Link>

--- a/frontend/src/components/CardBoard/CardBody/CardBody.tsx
+++ b/frontend/src/components/CardBoard/CardBody/CardBody.tsx
@@ -91,10 +91,21 @@ type CardBodyProps = {
   mainBoardId?: string;
   isSAdmin?: boolean;
   socketId?: string;
+  mainBoardTitle?: string;
 };
 
 const CardBody = React.memo<CardBodyProps>(
-  ({ userId, board, index, isDashboard, dividedBoardsCount, mainBoardId, isSAdmin, socketId }) => {
+  ({
+    userId,
+    board,
+    index,
+    isDashboard,
+    dividedBoardsCount,
+    mainBoardId,
+    isSAdmin,
+    socketId,
+    mainBoardTitle,
+  }) => {
     const { _id: id, columns, users, team, dividedBoards, isSubBoard } = board;
     const countDividedBoards = dividedBoardsCount || dividedBoards.length;
     const [openSubBoards, setSubBoardsOpen] = useState(false);
@@ -146,9 +157,10 @@ const CardBody = React.memo<CardBodyProps>(
           mainBoardId={board._id}
           socketId={socketId}
           userId={userId}
+          mainBoardTitle={board.title}
         />
       ),
-      [board._id, countDividedBoards, isDashboard, userId, socketId],
+      [countDividedBoards, isDashboard, board._id, board.title, socketId, userId],
     );
 
     const iconLockConditions =
@@ -190,6 +202,7 @@ const CardBody = React.memo<CardBodyProps>(
                     mainBoardId={mainBoardId}
                     title={board.title}
                     userIsParticipating={userIsParticipating}
+                    mainBoardTitle={mainBoardTitle}
                   />
                   {isSubBoard && (
                     <Text color="primary300" size="xs">

--- a/frontend/src/components/CardBoard/CardBody/CardTitle.tsx
+++ b/frontend/src/components/CardBoard/CardBody/CardTitle.tsx
@@ -51,6 +51,7 @@ const CardTitle: React.FC<CardTitleProps> = ({
             pathname: `boards/[boardId]`,
             query: isSubBoard ? { boardId, mainBoardId, mainBoardTitle } : { boardId },
           }}
+          as={isSubBoard ? `/${boardId}?mainBoardId=${mainBoardId}` : `/${boardId}`}
         >
           <StyledBoardTitle data-disabled={!userIsParticipating && !havePermissions}>
             {title}

--- a/frontend/src/components/CardBoard/CardBody/CardTitle.tsx
+++ b/frontend/src/components/CardBoard/CardBody/CardTitle.tsx
@@ -13,6 +13,7 @@ type CardTitleProps = {
   isSubBoard: boolean | undefined;
   mainBoardId?: string;
   havePermissions: boolean;
+  mainBoardTitle?: string;
 };
 
 const StyledBoardTitle = styled(Text, {
@@ -39,6 +40,7 @@ const CardTitle: React.FC<CardTitleProps> = ({
   title,
   isSubBoard,
   mainBoardId,
+  mainBoardTitle,
 }) => {
   const getTitle = useCallback(() => {
     if (userIsParticipating || havePermissions) {
@@ -47,7 +49,7 @@ const CardTitle: React.FC<CardTitleProps> = ({
           key={boardId}
           href={{
             pathname: `boards/[boardId]`,
-            query: isSubBoard ? { boardId, mainBoardId } : { boardId },
+            query: isSubBoard ? { boardId, mainBoardId, mainBoardTitle } : { boardId },
           }}
         >
           <StyledBoardTitle data-disabled={!userIsParticipating && !havePermissions}>
@@ -62,7 +64,15 @@ const CardTitle: React.FC<CardTitleProps> = ({
         {title}
       </StyledBoardTitle>
     );
-  }, [boardId, havePermissions, isSubBoard, mainBoardId, title, userIsParticipating]);
+  }, [
+    boardId,
+    havePermissions,
+    isSubBoard,
+    mainBoardId,
+    mainBoardTitle,
+    title,
+    userIsParticipating,
+  ]);
 
   if (isSubBoard) {
     return (

--- a/frontend/src/components/CardBoard/CardBody/CardTitle/partials/Title/styles.tsx
+++ b/frontend/src/components/CardBoard/CardBody/CardTitle/partials/Title/styles.tsx
@@ -7,15 +7,14 @@ const StyledBoardTitle = styled(Text, {
   fontSize: '$14',
   letterSpacing: '$0-17',
   '&[data-disabled="true"]': { opacity: 0.4 },
-  '@hover': {
-    '&:hover': {
-      '&[data-disabled="true"]': {
-        textDecoration: 'none',
-        cursor: 'default',
-      },
-      textDecoration: 'underline',
-      cursor: 'pointer',
+
+  '&:hover': {
+    '&[data-disabled="true"]': {
+      textDecoration: 'none',
+      cursor: 'default',
     },
+    textDecoration: 'underline',
+    cursor: 'pointer',
   },
 });
 

--- a/frontend/src/components/Teams/TeamsList/partials/CardTeam/CardBody.tsx
+++ b/frontend/src/components/Teams/TeamsList/partials/CardTeam/CardBody.tsx
@@ -114,7 +114,7 @@ const CardBody = React.memo<CardBodyProps>(({ userId, teamId, team, isTeamPage }
             }}
           />
 
-          <Flex align="center" css={{ ml: '$40', alignItems: 'center' }} gap="8">
+          <Flex align="center" css={{ ml: '$20', alignItems: 'center' }} gap="8">
             <Flex align="center" css={{ width: '$160' }}>
               <Text color="primary300" css={{ mr: '$2' }} size="sm">
                 Team admin
@@ -125,7 +125,7 @@ const CardBody = React.memo<CardBodyProps>(({ userId, teamId, team, isTeamPage }
             <Separator
               orientation="vertical"
               css={{
-                ml: '$4x0',
+                ml: '$20',
                 backgroundColor: '$primary100',
                 height: '$24 !important',
               }}

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -17,13 +17,13 @@ export const getServerSideProps: GetServerSideProps = requireAuthentication(asyn
 }));
 
 const Dashboard = () => {
-  const { data: session } = useSession({ required: true });
+  const { data: session } = useSession();
 
   const { data, isLoading } = useQuery('dashboardInfo', () => getDashboardHeaderInfo(), {
     enabled: true,
     refetchOnWindowFocus: false,
   });
-  if (!isLoading && (!session || !data)) return null;
+  if (!isLoading && !data) return null;
   if (isLoading) {
     return <LoadingPage />;
   }


### PR DESCRIPTION

Fixes #846 


## Proposed Changes

  - Fix superAdmin/ stakeholder access to the boards
  - Fix breadCrumbs when an user interacts with a board
  - Fix board count on the teams page
  - Remove mainBoardData object from response when a board is fetched



This pull request closes #846 