### PR TITLE
fix: bug drop down design

### DIFF
--- a/frontend/src/components/Boards/Filters/FilterBoards.tsx
+++ b/frontend/src/components/Boards/Filters/FilterBoards.tsx
@@ -15,7 +15,7 @@ const StyledButton = styled(Button, {
   border: '1px solid $colors$primary100',
   borderRadius: '0px',
   height: '$36 !important',
-  backgroundColor: '$background !important',
+  backgroundColor: '$white !important',
   color: '$primary300 !important',
   fontSize: '$14 !important',
   lineHeight: '$20 !important',

--- a/frontend/src/components/Boards/Filters/FilterSelect.tsx
+++ b/frontend/src/components/Boards/Filters/FilterSelect.tsx
@@ -54,10 +54,8 @@ const FilterSelect: React.FC<FilterSelectProps> = ({ options }) => {
         ...theme,
         colors: {
           ...theme.colors,
-          primary25: '#A9B3BF',
-          primary50: 'white',
+          primary50: '#2F3742',
           primary: '#2F3742',
-          text: '#060D16',
         },
       })}
       styles={filterByTeamSelectStyles}

--- a/frontend/src/components/Boards/Filters/styles.tsx
+++ b/frontend/src/components/Boards/Filters/styles.tsx
@@ -4,7 +4,7 @@ import Select, { CSSObjectWithLabel } from 'react-select';
 const filterByTeamSelectStyles = {
   control: (styles: CSSObjectWithLabel) => ({
     ...styles,
-    backgroundColor: 'transparent',
+    backgroundColor: 'white',
     minWidth: 0,
     width: '179px',
     minHeight: '36px',
@@ -20,6 +20,9 @@ const filterByTeamSelectStyles = {
   menu: (base: CSSObjectWithLabel) => ({
     ...base,
     marginTop: 2,
+    paddingTop: '6px',
+    paddingBottom: '6px',
+    borderRadius: '12px',
   }),
   valueContainer: (base: CSSObjectWithLabel) => ({
     ...base,
@@ -44,6 +47,10 @@ const filterByTeamSelectStyles = {
   dropdownIndicator: (base: CSSObjectWithLabel) => ({
     ...base,
     padding: 0,
+  }),
+  option: (base: CSSObjectWithLabel) => ({
+    ...base,
+    cursor: 'pointer',
   }),
 };
 

--- a/frontend/src/components/Boards/Filters/styles.tsx
+++ b/frontend/src/components/Boards/Filters/styles.tsx
@@ -48,9 +48,16 @@ const filterByTeamSelectStyles = {
     ...base,
     padding: 0,
   }),
-  option: (base: CSSObjectWithLabel) => ({
+  option: (base: CSSObjectWithLabel, state: any) => ({
     ...base,
-    cursor: 'pointer',
+    backgroundColor: state.isSelected ? '#2F3742' : 'white',
+    color: state.isSelected ? 'white' : '#060D16',
+    '&:hover': {
+      ...base,
+      cursor: 'pointer',
+      backgroundColor: '#2F3742',
+      color: 'white',
+    },
   }),
 };
 


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #869 
Fixes #869 

## Screenshots (if visual changes)

 - Filters now have a White Background, as shown in the design documents
<img width="393" alt="image" src="https://user-images.githubusercontent.com/8330038/212701796-49334d78-eaec-42f5-a908-5c2c5dc676ac.png">

 - Dropdown options cursor is now a pointer.
 - Dropdown "menu" has a 12px rounded border
 - Dropdown options selected and hover background color fixed
<img width="362" alt="image" src="https://user-images.githubusercontent.com/8330038/212701993-3844ef28-362d-4efa-939b-0e0c31d693e3.png">

<!--
Mention people who discussed this issue previously
@JoaoSaIvador
-->


This pull request closes #869 