### PR TITLE
fix: new split board team selection

### DIFF
--- a/frontend/src/components/CreateBoard/Select/index.tsx
+++ b/frontend/src/components/CreateBoard/Select/index.tsx
@@ -7,12 +7,12 @@ import { selectStyles, StyledBox, StyledSelect } from './styles';
 
 const Control = ({ children, ...props }: ControlProps) => (
   <components.Control {...props}>
-    {(props.selectProps.value as { label: string; value: string }).label && (
-      <Text color="primary300" size="xs">
-        Select Team
-      </Text>
-    )}
     <Flex direction="column" css={{ width: '100%', px: '$17' }}>
+      {(props.selectProps.value as { label: string; value: string }).label && (
+        <Text color="primary300" size="xs">
+          Select Team
+        </Text>
+      )}
       <Flex css={{ width: '100%' }}>{children}</Flex>
     </Flex>
   </components.Control>


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #895 
Fixes #895 

## Screenshots (if visual changes)

 - Any user will only see the teams he is a team-admin or stakeholder. And no longer be able to select a team he can't create a board for.
<img width="386" alt="image" src="https://user-images.githubusercontent.com/8330038/213230852-b0b41a31-b050-4f42-9d44-db1703bc17d4.png">

 - If the user doesn't have any teams he can create boards for, it displays the error message.
<img width="1412" alt="image" src="https://user-images.githubusercontent.com/8330038/213232035-1a30efde-4d6a-4302-a9a9-845926b9b666.png">

<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #895 