### PR TITLE
fix: card amount background color

### DIFF
--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -93,6 +93,7 @@ const Column = React.memo<ColumMemoProps>(
                       border: '1px solid $colors$primary100',
                       px: '$8',
                       py: '$2',
+                      backgroundColor: '$primary50',
                     }}
                   >
                     {cards.length} cards


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #901 
Fixes #901 

## Screenshots (if visual changes)

<img width="450" alt="image" src="https://user-images.githubusercontent.com/8330038/213471183-fee624a5-6eff-4966-8e58-a46a654fe9b0.png">

## Proposed Changes

  - Changed Background color of the card amount "badge"

<!--
Mention people who discussed this issue previously
@miguel-felix1 
-->


This pull request closes #901