### PR TITLE
fix: card settings background color

### DIFF
--- a/frontend/src/components/Board/Column/partials/SortMenu/styles.tsx
+++ b/frontend/src/components/Board/Column/partials/SortMenu/styles.tsx
@@ -43,9 +43,9 @@ const PopoverItemStyled = styled(PopoverItem, {
         '&>svg': { color: '$primary300' },
 
         '&:hover': {
-          backgroundColor: '$primary50',
-          '&>span': { color: '$primary800 !important' },
-          '&>svg': { color: '$primary300 !important' },
+          backgroundColor: '$primary500',
+          '& span': { color: '$white' },
+          '& svg': { color: '$white' },
         },
       },
     },

--- a/frontend/src/components/Primitives/Popover.tsx
+++ b/frontend/src/components/Primitives/Popover.tsx
@@ -43,7 +43,6 @@ const StyledContent = styled(PopoverPrimitive.Content, {
 const StyledPopoverItem = styled(Flex, {
   pl: '$16',
   py: '$8',
-  backgroundColor: '$primary50',
   '& svg': {
     color: '$primary400',
     size: '$16',


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #899 
Fixes #899 

## Screenshots

![image](https://user-images.githubusercontent.com/24455614/213471509-88a222c0-dff3-4ae4-83ac-6ab9de5c4089.png)

![image](https://user-images.githubusercontent.com/24455614/213471561-77a6cdb4-281f-44ad-8ca5-70d0734a4703.png)


## Proposed Changes

  - Fix the settings and sorting popup options background color

<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #899 