### PR TITLE
fix: font weight board settings and add new card buttons

### DIFF
--- a/frontend/src/components/Board/AddCardOrComment.tsx
+++ b/frontend/src/components/Board/AddCardOrComment.tsx
@@ -174,6 +174,7 @@ const AddCard = React.memo<AddCardProps>(
           css={{
             mx: '$20',
             display: 'flex',
+            fontWeight: '$medium',
           }}
           onClick={() => setIsOpen(true)}
         >

--- a/frontend/src/pages/boards/[boardId].tsx
+++ b/frontend/src/pages/boards/[boardId].tsx
@@ -216,7 +216,7 @@ const Board: NextPage<Props> = ({ boardId, mainBoardId }) => {
 
           {hasAdminRole && !board?.submitedAt && (
             <>
-              <Button onClick={handleOpen} variant="primaryOutline">
+              <Button onClick={handleOpen} variant="primaryOutline" css={{ fontWeight: '$medium' }}>
                 <Icon name="settings" />
                 Board settings
                 <Icon name="arrow-down" />


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #902 
Fixes #902 

## Screenshots (if visual changes)

 - Both texts with font weight of medium just like in the figma designs 
 
<img width="234" alt="image" src="https://user-images.githubusercontent.com/8330038/213479428-70696f38-bf38-497f-8540-bd267189f986.png">

<img width="404" alt="image" src="https://user-images.githubusercontent.com/8330038/213479470-1029919d-200a-4b7e-a1e4-110ad8acf3b8.png">

<!--
Mention people who discussed this issue previously
@miguel-felix1
-->

This pull request closes #902 