### PR TITLE
fix: slack participants and votes

### DIFF
--- a/backend/src/libs/constants/database.ts
+++ b/backend/src/libs/constants/database.ts
@@ -1,1 +1,3 @@
 export const DATABASE_URI_KEY = 'database.uri';
+
+export const WRITE_LOCK_ERROR = 112;

--- a/backend/src/modules/boards/interfaces/services/get.board.service.interface.ts
+++ b/backend/src/modules/boards/interfaces/services/get.board.service.interface.ts
@@ -23,6 +23,8 @@ export interface GetBoardServiceInterface {
 
 	getBoardFromRepo(boardId: string): Promise<LeanDocument<BoardDocument> | null>;
 
+	getBoardData(boardId: string): Promise<Board>;
+
 	getBoard(
 		boardId: string,
 		userId: string

--- a/backend/src/modules/boards/services/create.board.service.ts
+++ b/backend/src/modules/boards/services/create.board.service.ts
@@ -154,7 +154,7 @@ export default class CreateBoardServiceImpl implements CreateBoardService {
 			newUsers = [...users];
 		}
 
-		this.saveBoardUsers(newUsers, newBoard._id);
+		await this.saveBoardUsers(newUsers, newBoard._id);
 
 		if (newBoard && recurrent && team && maxUsers) {
 			const addCronJobDto: AddCronJobDto = {
@@ -172,11 +172,11 @@ export default class CreateBoardServiceImpl implements CreateBoardService {
 		this.logger.verbose(`Communication Slack Enable is set to "${boardData.slackEnable}".`);
 
 		if (slackEnable) {
-			const result = await this.getBoardService.getBoard(newBoard._id, userId);
+			const populatedBoard = await this.getBoardService.getBoardData(newBoard._id);
 
-			if (result?.board) {
+			if (populatedBoard) {
 				this.logger.verbose(`Call Slack Communication Service for board id "${newBoard._id}".`);
-				const board = fillDividedBoardsUsersWithTeamUsers(translateBoard(result.board));
+				const board = fillDividedBoardsUsersWithTeamUsers(translateBoard(populatedBoard));
 				this.slackCommunicationService.execute(board);
 			} else {
 				this.logger.error(

--- a/backend/src/modules/boards/services/get.board.service.ts
+++ b/backend/src/modules/boards/services/get.board.service.ts
@@ -215,7 +215,7 @@ export default class GetBoardServiceImpl implements GetBoardServiceInterface {
 		});
 	}
 
-	private async getBoardData(boardId: string) {
+	async getBoardData(boardId: string) {
 		const board = await this.boardModel
 			.findById(boardId)
 			.populate(BoardDataPopulate)

--- a/backend/src/modules/votes/services/create.vote.service.ts
+++ b/backend/src/modules/votes/services/create.vote.service.ts
@@ -1,6 +1,7 @@
 import { BadRequestException, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { ClientSession, Model } from 'mongoose';
+import { WRITE_LOCK_ERROR } from 'src/libs/constants/database';
 import { BOARD_NOT_FOUND, INSERT_VOTE_FAILED, UPDATE_FAILED } from 'src/libs/exceptions/messages';
 import Board, { BoardDocument } from 'src/modules/boards/schemas/board.schema';
 import BoardUser, { BoardUserDocument } from 'src/modules/boards/schemas/board.user.schema';
@@ -115,7 +116,7 @@ export default class CreateVoteServiceImpl implements CreateVoteServiceInterface
 			await userSession.abortTransaction();
 			await session.abortTransaction();
 
-			if (e.code === 112 && retryCount < 5) {
+			if (e.code === WRITE_LOCK_ERROR && retryCount < 5) {
 				retryCount++;
 				await userSession.endSession();
 				await session.endSession();
@@ -169,7 +170,7 @@ export default class CreateVoteServiceImpl implements CreateVoteServiceInterface
 			await session.abortTransaction();
 			await userSession.abortTransaction();
 
-			if (e.code === 112 && retryCount < 5) {
+			if (e.code === WRITE_LOCK_ERROR && retryCount < 5) {
 				retryCount++;
 				await userSession.endSession();
 				await session.endSession();

--- a/backend/src/modules/votes/services/create.vote.service.ts
+++ b/backend/src/modules/votes/services/create.vote.service.ts
@@ -76,9 +76,17 @@ export default class CreateVoteServiceImpl implements CreateVoteServiceInterface
 		count: number
 	) {
 		const userSession = await this.boardUserModel.db.startSession();
-		userSession.startTransaction();
+		userSession.startTransaction({
+			readPreference: 'primary',
+			readConcern: { level: 'local' },
+			writeConcern: { w: 'majority' }
+		});
 		const session = await this.boardModel.db.startSession();
-		session.startTransaction();
+		session.startTransaction({
+			readPreference: 'primary',
+			readConcern: { level: 'local' },
+			writeConcern: { w: 'majority' }
+		});
 
 		const canUserVote = await this.canUserVote(boardId, userId, count, session, userSession);
 

--- a/backend/src/modules/votes/services/delete.vote.service.ts
+++ b/backend/src/modules/votes/services/delete.vote.service.ts
@@ -2,6 +2,7 @@ import { BadRequestException, Inject, Injectable, Logger, NotFoundException } fr
 import { InjectModel } from '@nestjs/mongoose';
 import { UpdateResult } from 'mongodb';
 import { ClientSession, Model } from 'mongoose';
+import { WRITE_LOCK_ERROR } from 'src/libs/constants/database';
 import { DELETE_VOTE_FAILED, UPDATE_FAILED } from 'src/libs/exceptions/messages';
 import { arrayIdToString } from 'src/libs/utils/arrayIdToString';
 import isEmpty from 'src/libs/utils/isEmpty';
@@ -141,7 +142,7 @@ export default class DeleteVoteServiceImpl implements DeleteVoteServiceInterface
 			await userSession.abortTransaction();
 			await session.abortTransaction();
 
-			if (e.code === 112 && retryCount < 5) {
+			if (e.code === WRITE_LOCK_ERROR && retryCount < 5) {
 				retryCount++;
 				await userSession.endSession();
 				await session.endSession();
@@ -201,7 +202,7 @@ export default class DeleteVoteServiceImpl implements DeleteVoteServiceInterface
 				await userSession.abortTransaction();
 				await session.abortTransaction();
 
-				if (e.code === 112 && retryCount < 5) {
+				if (e.code === WRITE_LOCK_ERROR && retryCount < 5) {
 					retryCount++;
 					await userSession.endSession();
 					await session.endSession();

--- a/frontend/src/helper/board/transformBoard.tsx
+++ b/frontend/src/helper/board/transformBoard.tsx
@@ -338,3 +338,17 @@ export const handleDeleteComments = (board: BoardType, changes: DeleteCommentDto
 
   return boardData;
 };
+
+export const handleUpdateCardItemIdOfUnmergedCard = (
+  board: BoardType,
+  variables: RemoveFromCardGroupDto,
+): BoardType => {
+  const mappedBoard = removeReadOnly(board);
+  const column = mappedBoard.columns.find((col) => col._id === variables.columnId);
+  const card = column?.cards.find((cardFound) => cardFound._id === variables.cardId);
+  if (card && variables.newCardItemId) {
+    card.items[0]._id = variables.newCardItemId;
+  }
+
+  return mappedBoard;
+};

--- a/frontend/src/hooks/useComments.tsx
+++ b/frontend/src/hooks/useComments.tsx
@@ -11,6 +11,8 @@ import BoardType from '@/types/board/board';
 import AddCommentDto from '@/types/comment/addComment.dto';
 import DeleteCommentDto from '@/types/comment/deleteComment.dto';
 import UpdateCommentDto from '@/types/comment/updateComment.dto';
+import { operationsQueueAtom } from '@/store/operations/atom/operations-queue.atom';
+import { useSetRecoilState } from 'recoil';
 import { addCommentRequest, deleteCommentRequest, updateCommentRequest } from '../api/boardService';
 import { ToastStateEnum } from '../utils/enums/toast-types';
 import useBoardUtils from './useBoardUtils';
@@ -18,6 +20,7 @@ import useBoardUtils from './useBoardUtils';
 const useComments = () => {
   const { queryClient, setToastState } = useBoardUtils();
   const { data: session } = useSession({ required: false });
+  const setReady = useSetRecoilState(operationsQueueAtom);
 
   const user = session?.user;
 
@@ -29,7 +32,7 @@ const useComments = () => {
       firstName: user?.firstName,
       lastName: user?.lastName,
     } as User;
-
+    setReady(false);
     queryClient.setQueryData<{ board: BoardType } | undefined>(
       getBoardQuery(data.boardId),
       (old: { board: BoardType } | undefined) => {
@@ -46,6 +49,7 @@ const useComments = () => {
         return old;
       },
     );
+    setReady(true);
   };
 
   const addCommentInCard = useMutation(addCommentRequest, {
@@ -70,6 +74,7 @@ const useComments = () => {
   });
 
   const setQueryDataDeleteComment = (data: DeleteCommentDto) => {
+    setReady(false);
     queryClient.setQueryData<{ board: BoardType } | undefined>(
       getBoardQuery(data.boardId),
       (old: { board: BoardType } | undefined) => {
@@ -86,6 +91,7 @@ const useComments = () => {
         return old;
       },
     );
+    setReady(true);
   };
 
   const deleteComment = useMutation(deleteCommentRequest, {
@@ -105,6 +111,7 @@ const useComments = () => {
   });
 
   const setQueryDataUpdateComment = (data: UpdateCommentDto) => {
+    setReady(false);
     queryClient.setQueryData<{ board: BoardType } | undefined>(
       getBoardQuery(data.boardId),
       (old: { board: BoardType } | undefined) => {
@@ -121,6 +128,7 @@ const useComments = () => {
         return old;
       },
     );
+    setReady(true);
   };
 
   const updateComment = useMutation(updateCommentRequest, {

--- a/frontend/src/hooks/useSocketIO.ts
+++ b/frontend/src/hooks/useSocketIO.ts
@@ -16,8 +16,24 @@ import AddCommentDto from '@/types/comment/addComment.dto';
 import UpdateCommentDto from '@/types/comment/updateComment.dto';
 import DeleteCommentDto from '@/types/comment/deleteComment.dto';
 import { useQueryClient } from '@tanstack/react-query';
-import useVotes from './useVotes';
+import isEmpty from '@/utils/isEmpty';
+import { useRecoilValue } from 'recoil';
+import { operationsQueueAtom } from '@/store/operations/atom/operations-queue.atom';
 import useComments from './useComments';
+import useVotes from './useVotes';
+
+enum BoardAction {
+  UPDATECARDPOSITION,
+  VOTE,
+  UNMERGE,
+  MERGE,
+  ADDCARD,
+  UPDATECARD,
+  DELETECARD,
+  ADDCOMMENT,
+  DELETECOMMENT,
+  UPDATECOMMENT,
+}
 
 export const useSocketIO = (boardId: string): string | undefined => {
   const queryClient = useQueryClient();
@@ -33,6 +49,9 @@ export const useSocketIO = (boardId: string): string | undefined => {
   const { updateVote } = useVotes();
   const { setQueryDataAddComment, setQueryDataDeleteComment, setQueryDataUpdateComment } =
     useComments();
+
+  const [queue, setQueue] = useState<{ action: BoardAction; dto: any }[]>([]);
+  const ready = useRecoilValue(operationsQueueAtom);
 
   useEffect(() => {
     const newSocket: Socket = io(NEXT_PUBLIC_BACKEND_URL ?? 'http://127.0.0.1:3200', {
@@ -60,47 +79,91 @@ export const useSocketIO = (boardId: string): string | undefined => {
     });
 
     socket?.on(`${boardId}cardPosition`, (updateCardPositionDto: UpdateCardPositionDto) => {
-      setQueryDataUpdateCardPosition(updateCardPositionDto);
+      setQueue((prev) => [
+        ...prev,
+        { action: BoardAction.UPDATECARDPOSITION, dto: updateCardPositionDto },
+      ]);
     });
 
     socket?.on(`${boardId}vote`, (votesDto: VoteDto) => {
-      updateVote(votesDto);
+      setQueue((prev) => [...prev, { action: BoardAction.VOTE, dto: votesDto }]);
     });
 
     socket?.on(`${boardId}unmerge`, (unmergeDto: RemoveFromCardGroupDto) => {
-      setQueryDataUnmergeCard(unmergeDto);
+      setQueue((prev) => [...prev, { action: BoardAction.UNMERGE, dto: unmergeDto }]);
     });
 
     socket?.on(`${boardId}merge`, (mergeDto: MergeCardsDto) => {
-      setQueryDataMergeCard(mergeDto);
+      setQueue((prev) => [...prev, { action: BoardAction.MERGE, dto: mergeDto }]);
     });
 
     socket?.on(`${boardId}addCard`, (addCardDto: AddCardDto) => {
       addCardDto.user = undefined;
-      setQueryDataAddCard(addCardDto);
+      setQueue((prev) => [...prev, { action: BoardAction.ADDCARD, dto: addCardDto }]);
     });
 
     socket?.on(`${boardId}updateCard`, (updateCardDto: UpdateCardDto) => {
-      setQueryDataUpdateCard(updateCardDto);
+      setQueue((prev) => [...prev, { action: BoardAction.UPDATECARD, dto: updateCardDto }]);
     });
 
     socket?.on(`${boardId}deleteCard`, (deleteCardDto: DeleteCardDto) => {
-      setQueryDataDeleteCard(deleteCardDto);
+      setQueue((prev) => [...prev, { action: BoardAction.DELETECARD, dto: deleteCardDto }]);
     });
 
     socket?.on(`${boardId}addComment`, (addCommentDto: AddCommentDto) => {
       addCommentDto.fromSocket = true;
-      setQueryDataAddComment(addCommentDto);
+      setQueue((prev) => [...prev, { action: BoardAction.ADDCOMMENT, dto: addCommentDto }]);
     });
 
     socket?.on(`${boardId}deleteComment`, (deleteCommentDto: DeleteCommentDto) => {
-      setQueryDataDeleteComment(deleteCommentDto);
+      setQueue((prev) => [...prev, { action: BoardAction.DELETECOMMENT, dto: deleteCommentDto }]);
     });
 
     socket?.on(`${boardId}updateComment`, (updateCommentDto: UpdateCommentDto) => {
-      setQueryDataUpdateComment(updateCommentDto);
+      setQueue((prev) => [...prev, { action: BoardAction.UPDATECOMMENT, dto: updateCommentDto }]);
     });
   }, [queryClient, socket, boardId]);
+
+  useEffect(() => {
+    if (!isEmpty(queue) && ready) {
+      switch (queue[0].action) {
+        case BoardAction.UPDATECARDPOSITION:
+          setQueryDataUpdateCardPosition(queue[0].dto);
+          break;
+        case BoardAction.VOTE:
+          updateVote(queue[0].dto);
+          break;
+        case BoardAction.UNMERGE:
+          setQueryDataUnmergeCard(queue[0].dto);
+          break;
+        case BoardAction.MERGE:
+          setQueryDataMergeCard(queue[0].dto);
+          break;
+        case BoardAction.ADDCARD:
+          setQueryDataAddCard(queue[0].dto);
+          break;
+        case BoardAction.UPDATECARD:
+          setQueryDataUpdateCard(queue[0].dto);
+          break;
+        case BoardAction.DELETECARD:
+          setQueryDataDeleteCard(queue[0].dto);
+          break;
+        case BoardAction.ADDCOMMENT:
+          setQueryDataAddComment(queue[0].dto);
+          break;
+        case BoardAction.DELETECOMMENT:
+          setQueryDataDeleteComment(queue[0].dto);
+          break;
+        case BoardAction.UPDATECOMMENT:
+          setQueryDataUpdateComment(queue[0].dto);
+          break;
+        default:
+          break;
+      }
+      queue.splice(0, 1);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [boardId, queryClient, queue, ready]);
 
   return socket?.id;
 };

--- a/frontend/src/hooks/useSocketIO.ts
+++ b/frontend/src/hooks/useSocketIO.ts
@@ -126,36 +126,37 @@ export const useSocketIO = (boardId: string): string | undefined => {
 
   useEffect(() => {
     if (!isEmpty(queue) && ready) {
+      const { dto } = queue[0];
       switch (queue[0].action) {
         case BoardAction.UPDATECARDPOSITION:
-          setQueryDataUpdateCardPosition(queue[0].dto);
+          setQueryDataUpdateCardPosition(dto);
           break;
         case BoardAction.VOTE:
-          updateVote(queue[0].dto);
+          updateVote(dto);
           break;
         case BoardAction.UNMERGE:
-          setQueryDataUnmergeCard(queue[0].dto);
+          setQueryDataUnmergeCard(dto);
           break;
         case BoardAction.MERGE:
-          setQueryDataMergeCard(queue[0].dto);
+          setQueryDataMergeCard(dto);
           break;
         case BoardAction.ADDCARD:
-          setQueryDataAddCard(queue[0].dto);
+          setQueryDataAddCard(dto);
           break;
         case BoardAction.UPDATECARD:
-          setQueryDataUpdateCard(queue[0].dto);
+          setQueryDataUpdateCard(dto);
           break;
         case BoardAction.DELETECARD:
-          setQueryDataDeleteCard(queue[0].dto);
+          setQueryDataDeleteCard(dto);
           break;
         case BoardAction.ADDCOMMENT:
-          setQueryDataAddComment(queue[0].dto);
+          setQueryDataAddComment(dto);
           break;
         case BoardAction.DELETECOMMENT:
-          setQueryDataDeleteComment(queue[0].dto);
+          setQueryDataDeleteComment(dto);
           break;
         case BoardAction.UPDATECOMMENT:
-          setQueryDataUpdateComment(queue[0].dto);
+          setQueryDataUpdateComment(dto);
           break;
         default:
           break;

--- a/frontend/src/hooks/useVotes.tsx
+++ b/frontend/src/hooks/useVotes.tsx
@@ -303,6 +303,7 @@ const useVotes = () => {
     onError: (_, variables) => {
       queryClient.cancelQueries(['board', { id: variables.boardId }]);
       queryClient.invalidateQueries(['board', { id: variables.boardId }]);
+      setReady(true);
       toastErrorMessage(`Error ${variables.count > 0 ? 'adding' : 'removing'} the vote`);
     },
   });

--- a/frontend/src/store/operations/atom/operations-queue.atom.ts
+++ b/frontend/src/store/operations/atom/operations-queue.atom.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const operationsQueueAtom = atom<Boolean>({
+  key: 'usersWithTeams',
+  default: true,
+});


### PR DESCRIPTION
<!--
#912 
-->

Fixes #912

## Proposed Changes

  - wait for the board users creation before sending the slack message
  - simple queue implementation to save board operations that comes from the socket
  - lock board updates if some transformation is happening

Note: this queue system works well locally with two users but it needs a test with more users
<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #912 