### PR TITLE
fix: split instead of splitted

### DIFF
--- a/frontend/src/components/CardBoard/CardBody/CardTitle.tsx
+++ b/frontend/src/components/CardBoard/CardBody/CardTitle.tsx
@@ -76,7 +76,7 @@ const CardTitle: React.FC<CardTitleProps> = ({
 
   if (isSubBoard) {
     return (
-      <Tooltip content="It’s a sub-team board. A huge team got splitted into sub teams.">
+      <Tooltip content="It’s a sub-team board. A huge team got split into sub teams.">
         {getTitle()}
       </Tooltip>
     );

--- a/frontend/src/components/CardBoard/CardBody/CardTitle/index.tsx
+++ b/frontend/src/components/CardBoard/CardBody/CardTitle/index.tsx
@@ -17,7 +17,7 @@ const CardTitle: React.FC<CardTitleProps> = ({
   mainBoardId,
 }) =>
   isSubBoard ? (
-    <Tooltip content="It’s a sub-team board. A huge team got splitted into sub teams.">
+    <Tooltip content="It’s a sub-team board. A huge team got split into sub teams.">
       <Title
         boardId={boardId}
         isSubBoard={isSubBoard}

--- a/frontend/src/components/CreateBoard/TipBar.tsx
+++ b/frontend/src/components/CreateBoard/TipBar.tsx
@@ -40,7 +40,7 @@ const CreateBoardTipBar = ({ isSplitBoard, isRegularBoard }: CreateBoardTipBarPr
         <UnorderedList>
           <LiWhite>The participants of the sub-teams are generated randomly.</LiWhite>
 
-          <LiWhite>The number of participants is splitted equally between all sub-teams.</LiWhite>
+          <LiWhite>The number of participants is split equally between all sub-teams.</LiWhite>
 
           <LiWhite>For each sub-team there is one responsible selected.</LiWhite>
         </UnorderedList>

--- a/frontend/src/pages/boards/newSplitBoard.tsx
+++ b/frontend/src/pages/boards/newSplitBoard.tsx
@@ -251,7 +251,7 @@ const NewSplitBoard: NextPage = () => {
                 <SubContainer>
                   {haveError && (
                     <AlertBox
-                      text="In order to create a SPLIT retrospective, you need to have a team with an amount of people big enough to be splitted into smaller sub-teams. Also you need to be team-admin to create SPLIT retrospectives."
+                      text="In order to create a SPLIT retrospective, you need to have a team with an amount of people big enough to be split into smaller sub-teams. Also you need to be team-admin to create SPLIT retrospectives."
                       title="No team yet!"
                       type="error"
                       css={{


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #914  
Fixes #914 

## Proposed Changes

  - Found and replaced 4 occurrences of "splitted", changed them to "split"

<!--
Mention people who discussed this issue previously
@miguel-felix1 
-->


This pull request closes #914 