### PR TITLE
fix: new split board page scroll

### DIFF
--- a/frontend/src/components/Board/Settings/styles.tsx
+++ b/frontend/src/components/Board/Settings/styles.tsx
@@ -41,12 +41,9 @@ const StyledDialogContent = styled(DialogPrimitive.Content, {
   position: 'fixed',
   top: 0,
   right: 0,
-  overflow: 'auto',
   height: '100vh',
   width: '592px',
-
   padding: 0,
-
   backgroundColor: 'white',
   zIndex: 10,
 

--- a/frontend/src/components/Boards/MyBoards/ListBoardMembers/styles.tsx
+++ b/frontend/src/components/Boards/MyBoards/ListBoardMembers/styles.tsx
@@ -2,11 +2,10 @@ import { styled } from '../../../../styles/stitches/stitches.config';
 import Flex from '../../../Primitives/Flex';
 
 const ScrollableContent = styled(Flex, {
-  mt: '$24',
-  height: 'calc(100vh - 100px)',
+  py: '$24',
+  height: 'calc(100vh - 89px)',
   overflowY: 'auto',
   pr: '$10',
-  pb: '$10',
 });
 
 export { ScrollableContent };

--- a/frontend/src/components/CreateBoard/TipBar.tsx
+++ b/frontend/src/components/CreateBoard/TipBar.tsx
@@ -17,7 +17,6 @@ const CreateBoardTipBar = ({ isSplitBoard, isRegularBoard }: CreateBoardTipBarPr
   <Flex
     direction="column"
     css={{
-      minHeight: 'calc(100vh - $sizes$92 - $sizes$81)',
       backgroundColor: '$primary800',
       padding: '$32',
       pt: '$100',

--- a/frontend/src/styles/pages/boards/newSplitBoard.styles.tsx
+++ b/frontend/src/styles/pages/boards/newSplitBoard.styles.tsx
@@ -37,20 +37,18 @@ const PageHeader = styled('header', {
 });
 
 const ContentWrapper = styled('section', {
-  width: '100%',
+  position: 'relative',
   height: 'calc(100vh - $sizes$92 - $sizes$81)',
-  overflowY: 'scroll',
+  overflowY: 'auto',
 });
 
 const ContentContainer = styled('section', {
   display: 'flex',
-  width: '100%',
   height: 'auto',
 });
 
 const InnerContent = styled(Flex, {
   flex: '1 1 auto',
-  width: '100%',
   height: '100%',
 });
 


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #917
Fixes #917

## Screenshots (if visual changes)

## Proposed Changes

  - Fix double scrollbar on create new board pages
 
<img width="490" alt="image" src="https://user-images.githubusercontent.com/24455614/213737314-fa1d9269-7c5f-4451-882d-ccfa9d464c9f.png">

  - Fix double scrollbar on board members list dialog

<img width="595" alt="image" src="https://user-images.githubusercontent.com/24455614/213737634-c0b8a7fa-941a-4f6d-89e0-136e0068e57f.png">

<!--
Mention people who discussed this issue previously
@StereoPT 
-->


This pull request closes #917