### PR TITLE
fix: verify checkbox id

### DIFF
--- a/frontend/src/components/Primitives/Checkbox.tsx
+++ b/frontend/src/components/Primitives/Checkbox.tsx
@@ -110,7 +110,7 @@ const Checkbox: React.FC<{
     if (handleSelectAll) handleSelectAll();
     setCurrentCheckValue(isChecked);
     if (setCheckedTerms != null) setCheckedTerms(!!isChecked);
-    if (formContext) {
+    if (id === 'slackEnable' && formContext) {
       formContext.setValue(id, !!isChecked);
     }
   };


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #924
Fixes #924 

## Proposed Changes

  - Verify checkbox id to check if it's being used to enable slack in creating a board because it's preventing the user from creating teams with members.

<!--
Mention people who discussed this issue previously
@StereoPT 
-->


This pull request closes #924 