### PR TITLE
fix: set check value only on slackEnable

### DIFF
--- a/frontend/src/components/Primitives/Checkbox.tsx
+++ b/frontend/src/components/Primitives/Checkbox.tsx
@@ -100,7 +100,7 @@ const Checkbox: React.FC<{
   );
 
   useEffect(() => {
-    if (formContext) {
+    if (id === 'slackEnable' && formContext) {
       setCurrentCheckValue(formContext.getValues(id));
     }
   }, [formContext, id]);


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #934 
Fixes #934 

## Screenshots

![image](https://user-images.githubusercontent.com/24455614/215051658-5a81fef7-bf1d-48b8-bc71-23db30b30da7.png)

## Proposed Changes

  - Set check value only on slackEnable (so it is persistent when changing tabs when creating a board but doesn't affect the behaviour of the checkbox on other components)

<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #934