### PR TITLE
fix: use unique name or email to add a user into slack main channel

### DIFF
--- a/backend/src/modules/azure/services/auth.azure.service.ts
+++ b/backend/src/modules/azure/services/auth.azure.service.ts
@@ -70,7 +70,7 @@ export default class AuthAzureServiceImpl implements AuthAzureService {
 			providerAccountCreatedAt: userFromAzure.value[0].createdDateTime
 		});
 
-		this.slackCommunicationService.executeAddUserMainChannel({ email });
+		this.slackCommunicationService.executeAddUserMainChannel({ email: emailOrUniqueName });
 
 		if (!createdUser) return null;
 


### PR DESCRIPTION
<!--
Add the issue number
-->

## Proposed Changes

  - Use email or the unique name to add a user to the slack main channel
  
<!--
Mention people who discussed this issue previously
@someone
-->