### PR TITLE
fix: close popover when modal is opened

### DIFF
--- a/frontend/src/components/Board/Card/PopoverSettings.tsx
+++ b/frontend/src/components/Board/Card/PopoverSettings.tsx
@@ -127,6 +127,8 @@ const PopoverCardSettings: React.FC<PopoverSettingsProps> = React.memo(
     userId,
     hideCards,
   }) => {
+    const [openPopover, setOpenPopover] = useState(false);
+
     const { removeFromMergeCard } = useCards();
 
     const unmergeCard = () => {
@@ -141,8 +143,15 @@ const PopoverCardSettings: React.FC<PopoverSettingsProps> = React.memo(
       });
     };
 
+    const handleOpenPopover = (value: boolean) => setOpenPopover(value);
+
+    const handleDelete = () => {
+      setOpenPopover(false);
+      if (handleDeleteCard) handleDeleteCard();
+    };
+
     return (
-      <Popover>
+      <Popover open={openPopover} onOpenChange={handleOpenPopover}>
         <PopoverTriggerStyled
           disabled={hideCards && item.createdBy?._id !== userId}
           css={{
@@ -163,7 +172,7 @@ const PopoverCardSettings: React.FC<PopoverSettingsProps> = React.memo(
         <PopoverSettingsContent
           isItem={isItem}
           isOwner={item.createdBy?._id === userId}
-          setDeleteCard={handleDeleteCard}
+          setDeleteCard={handleDelete}
           setEditCard={handleEditing}
           unmergeCard={unmergeCard}
         />

--- a/frontend/src/components/Board/Column/partials/OptionsMenu/index.tsx
+++ b/frontend/src/components/Board/Column/partials/OptionsMenu/index.tsx
@@ -81,9 +81,11 @@ const OptionsMenu = ({
     setOpenPopover(false);
   };
 
+  const handleOpenPopover = (value: boolean) => setOpenPopover(value);
+
   return (
     <>
-      <Popover open={openPopover} onOpenChange={(value: boolean) => setOpenPopover(value)}>
+      <Popover open={openPopover} onOpenChange={handleOpenPopover}>
         <PopoverTriggerStyled disabled={disabled} css={{ ml: '$8' }}>
           <Icon name="menu-dots" size={24} />
         </PopoverTriggerStyled>


### PR DESCRIPTION

Fixes #967 

## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/59372326/215729185-75fb5a64-0e1e-4e35-9c4a-0d173f5b543d.png)


## Proposed Changes

  - When the modal to eliminate the card is open, the popover closes


This pull request closes #967 