### PR TITLE
fix: order board members

### DIFF
--- a/frontend/src/components/Boards/MyBoards/ListBoardMembers/index.tsx
+++ b/frontend/src/components/Boards/MyBoards/ListBoardMembers/index.tsx
@@ -52,10 +52,10 @@ const ListBoardMembers = ({
         <Text heading="4">Board Members</Text>
       </Dialog.Header>
       <ScrollableContent direction="column" justify="start">
-        {!isEmpty(members) && (
+        {!isEmpty(admin) && (
           <FilterBoardMembers
-            title={isRegularBoardNoTeam ? 'Participants' : 'Team Members'}
-            users={members}
+            title={admin.length > 1 ? 'Team Admins' : 'Team Admin'}
+            users={admin}
           />
         )}
         {!isEmpty(responsible) && isSubBoard && (
@@ -70,10 +70,10 @@ const ListBoardMembers = ({
             users={stakeholders}
           />
         )}
-        {!isEmpty(admin) && (
+        {!isEmpty(members) && (
           <FilterBoardMembers
-            title={admin.length > 1 ? 'Team Admins' : 'Team Admin'}
-            users={admin}
+            title={isRegularBoardNoTeam ? 'Participants' : 'Team Members'}
+            users={members}
           />
         )}
       </ScrollableContent>


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #990
Fixes #990

## Screenshots

![image](https://user-images.githubusercontent.com/8330038/216373157-5e9a0089-05de-49c1-a2e8-2fad148da3f9.png)

## Proposed Changes

  - Board Members now show Team Admins and Stakeholders first in case of a SPLIT Board.
  - In case of a Regular Board, it displays the Board Creator or Responsible first.
  - Then it shows all the Team Members

<!--
Mention people who discussed this issue previously
@dpompeu-xgeeks 
-->


This pull request closes #990