### PR TITLE
feat: delete column/cards on a board

### DIFF
--- a/backend/src/modules/boards/services/update.board.service.ts
+++ b/backend/src/modules/boards/services/update.board.service.ts
@@ -24,7 +24,7 @@ import Board, { BoardDocument } from '../schemas/board.schema';
 import BoardUser, { BoardUserDocument } from '../schemas/board.user.schema';
 import { BoardDataPopulate } from '../utils/populate-board';
 import { UpdateColumnDto } from '../dto/column/update-column.dto';
-import { UPDATE_FAILED } from 'src/libs/exceptions/messages';
+import { DELETE_FAILED, UPDATE_FAILED } from 'src/libs/exceptions/messages';
 import SocketGateway from 'src/modules/socket/gateway/socket.gateway';
 import { DeleteVoteServiceInterface } from 'src/modules/votes/interfaces/services/delete.vote.service.interface';
 import Column from '../schemas/column.schema';

--- a/backend/src/modules/boards/services/update.board.service.ts
+++ b/backend/src/modules/boards/services/update.board.service.ts
@@ -24,7 +24,7 @@ import Board, { BoardDocument } from '../schemas/board.schema';
 import BoardUser, { BoardUserDocument } from '../schemas/board.user.schema';
 import { BoardDataPopulate } from '../utils/populate-board';
 import { UpdateColumnDto } from '../dto/column/update-column.dto';
-import { DELETE_FAILED, UPDATE_FAILED } from 'src/libs/exceptions/messages';
+import { UPDATE_FAILED } from 'src/libs/exceptions/messages';
 import SocketGateway from 'src/modules/socket/gateway/socket.gateway';
 import { DeleteVoteServiceInterface } from 'src/modules/votes/interfaces/services/delete.vote.service.interface';
 import Column from '../schemas/column.schema';

--- a/frontend/src/api/boardService.tsx
+++ b/frontend/src/api/boardService.tsx
@@ -14,7 +14,7 @@ import VoteDto from '@/types/vote/vote.dto';
 import fetchData from '@/utils/fetchData';
 import CardType from '@/types/card/card';
 import CommentType from '@/types/comment/comment';
-import ColumnType from '@/types/column';
+import ColumnType, { ColumnDeleteCards } from '@/types/column';
 
 // #region BOARD
 
@@ -79,9 +79,9 @@ export const updateColumnRequest = (
   });
 
 export const deleteCardsFromColumnRequest = (
-  columnData: ColumnType & { boardId: string; socketId: string },
+  columnData: ColumnDeleteCards & { boardId: string },
 ): Promise<BoardType> =>
-  fetchData(`/boards/${columnData.boardId}/column/${columnData._id}/cards`, {
+  fetchData(`/boards/${columnData.boardId}/column/${columnData.id}/cards`, {
     method: 'PUT',
     data: columnData,
   });

--- a/frontend/src/api/boardService.tsx
+++ b/frontend/src/api/boardService.tsx
@@ -77,6 +77,14 @@ export const updateColumnRequest = (
     method: 'PUT',
     data: columnData,
   });
+
+export const deleteCardsFromColumnRequest = (
+  columnData: ColumnType & { boardId: string; socketId: string },
+): Promise<BoardType> =>
+  fetchData(`/boards/${columnData.boardId}/column/${columnData._id}/cards`, {
+    method: 'PUT',
+    data: columnData,
+  });
 // #endRegion
 
 // #region CARD

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -43,12 +43,16 @@ const Column = React.memo<ColumMemoProps>(
   }) => {
     const [filter, setFilter] = useState<'asc' | 'desc' | undefined>();
     const setFilteredColumns = useSetRecoilState(filteredColumnsState);
-    const [openDialogName, setOpenDialogName] = useState(false);
+    const [openDialog, setOpenDialog] = useState({ columnName: false, deleteColumn: false });
     const [dialogType, setDialogType] = useState('ColumnName');
 
     const handleDialogNameChange = (open: boolean, type: string) => {
-      setOpenDialogName(open);
+      setOpenDialog({ columnName: open, deleteColumn: false });
       setDialogType(type);
+    };
+
+    const handleDialogChange = (open: boolean) => {
+      setOpenDialog({ columnName: open, deleteColumn: !open });
     };
 
     const filteredCards = useCallback(() => {
@@ -182,8 +186,8 @@ const Column = React.memo<ColumMemoProps>(
         </OuterContainer>
         <UpdateColumnDialog
           boardId={boardId}
-          isOpen={openDialogName}
-          setIsOpen={setOpenDialogName}
+          isOpen={openDialog.columnName}
+          setIsOpen={handleDialogChange}
           columnId={columnId}
           columnTitle={title}
           columnColor={color}

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -14,6 +14,7 @@ import { CardsContainer, Container, OuterContainer, Title } from './styles';
 import OptionsMenu from './partials/OptionsMenu';
 import UpdateColumnDialog from './partials/UpdateColumnDialog';
 import AlertDeleteColumn from './partials/AlertDeleteColumn';
+import AlertDeleteAllCards from './partials/AlertDeleteAllCards';
 
 type ColumMemoProps = {
   isRegularBoard?: boolean;
@@ -44,16 +45,28 @@ const Column = React.memo<ColumMemoProps>(
   }) => {
     const [filter, setFilter] = useState<'asc' | 'desc' | undefined>();
     const setFilteredColumns = useSetRecoilState(filteredColumnsState);
-    const [openDialog, setOpenDialog] = useState({ columnName: false, deleteColumn: false });
+    const [openDialog, setOpenDialog] = useState({
+      columnName: false,
+      deleteColumn: false,
+      deleteCards: false,
+    });
     const [dialogType, setDialogType] = useState('ColumnName');
 
     const handleDialogNameChange = (open: boolean, type: string) => {
-      setOpenDialog({ columnName: open, deleteColumn: false });
+      setOpenDialog({ columnName: open, deleteColumn: false, deleteCards: false });
       setDialogType(type);
     };
 
-    const handleDialogChange = (openName: boolean, openDelete: boolean) => {
-      setOpenDialog({ columnName: openName, deleteColumn: openDelete });
+    const handleDialogChange = (
+      openName: boolean,
+      openDeleteColumn: boolean,
+      openDeleteCards: boolean,
+    ) => {
+      setOpenDialog({
+        columnName: openName,
+        deleteColumn: openDeleteColumn,
+        deleteCards: openDeleteCards,
+      });
     };
 
     const filteredCards = useCallback(() => {
@@ -203,6 +216,16 @@ const Column = React.memo<ColumMemoProps>(
           columnId={columnId}
           columnTitle={title}
           isOpen={openDialog.deleteColumn}
+          handleDialogChange={handleDialogChange}
+        />
+        <AlertDeleteAllCards
+          socketId={socketId}
+          boardId={boardId}
+          columnId={columnId}
+          columnTitle={title}
+          columnColor={color}
+          cards={cards}
+          isOpen={openDialog.deleteCards}
           handleDialogChange={handleDialogChange}
         />
       </>

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -222,9 +222,6 @@ const Column = React.memo<ColumMemoProps>(
           socketId={socketId}
           boardId={boardId}
           columnId={columnId}
-          columnTitle={title}
-          columnColor={color}
-          cards={cards}
           isOpen={openDialog.deleteCards}
           handleDialogChange={handleDialogChange}
         />

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -13,6 +13,7 @@ import SortMenu from './partials/SortMenu';
 import { CardsContainer, Container, OuterContainer, Title } from './styles';
 import OptionsMenu from './partials/OptionsMenu';
 import UpdateColumnDialog from './partials/UpdateColumnDialog';
+import AlertDeleteColumn from './partials/AlertDeleteColumn';
 
 type ColumMemoProps = {
   isRegularBoard?: boolean;
@@ -51,8 +52,8 @@ const Column = React.memo<ColumMemoProps>(
       setDialogType(type);
     };
 
-    const handleDialogChange = (open: boolean) => {
-      setOpenDialog({ columnName: open, deleteColumn: !open });
+    const handleDialogChange = (openName: boolean, openDelete: boolean) => {
+      setOpenDialog({ columnName: openName, deleteColumn: openDelete });
     };
 
     const filteredCards = useCallback(() => {
@@ -127,6 +128,7 @@ const Column = React.memo<ColumMemoProps>(
                         columnId={columnId}
                         boardId={boardId}
                         setOpenDialogName={handleDialogNameChange}
+                        handleDialogChange={handleDialogChange}
                         isDefaultText={isDefaultText}
                         color={color}
                       />
@@ -195,6 +197,13 @@ const Column = React.memo<ColumMemoProps>(
           cardText={cardText}
           isDefaultText={isDefaultText}
           type={dialogType}
+        />
+        <AlertDeleteColumn
+          socketId={socketId}
+          columnId={columnId}
+          columnTitle={title}
+          isOpen={openDialog.deleteColumn}
+          handleDialogChange={handleDialogChange}
         />
       </>
     );

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -144,6 +144,7 @@ const Column = React.memo<ColumMemoProps>(
                         handleDialogChange={handleDialogChange}
                         isDefaultText={isDefaultText}
                         color={color}
+                        socketId={socketId}
                       />
                     )}
                   </Flex>
@@ -210,6 +211,7 @@ const Column = React.memo<ColumMemoProps>(
           cardText={cardText}
           isDefaultText={isDefaultText}
           type={dialogType}
+          socketId={socketId}
         />
         <AlertDeleteColumn
           socketId={socketId}

--- a/frontend/src/components/Board/Column/partials/AlertDeleteAllCards/index.tsx
+++ b/frontend/src/components/Board/Column/partials/AlertDeleteAllCards/index.tsx
@@ -7,7 +7,6 @@ import {
 import Flex from '@/components/Primitives/Flex';
 import Text from '@/components/Primitives/Text';
 import useColumn from '@/hooks/useColumn';
-import CardType from '@/types/card/card';
 
 type AlertDeleteAllCardsProps = {
   socketId: string;
@@ -19,18 +18,12 @@ type AlertDeleteAllCardsProps = {
     openDeleteCards: boolean,
   ) => void;
   columnId: string;
-  columnTitle: string;
-  columnColor: string;
-  cards: CardType[];
   boardId: string;
 };
 const AlertDeleteAllCards: React.FC<AlertDeleteAllCardsProps> = ({
   socketId,
   isOpen,
-  columnColor,
   columnId,
-  columnTitle,
-  cards,
   boardId,
   handleDialogChange,
 }) => {
@@ -41,10 +34,7 @@ const AlertDeleteAllCards: React.FC<AlertDeleteAllCardsProps> = ({
 
   const handleDeleteCards = () => {
     mutateBoard({
-      _id: columnId,
-      title: columnTitle,
-      color: columnColor,
-      cards,
+      id: columnId,
       boardId,
       socketId,
     });

--- a/frontend/src/components/Board/Column/partials/AlertDeleteAllCards/index.tsx
+++ b/frontend/src/components/Board/Column/partials/AlertDeleteAllCards/index.tsx
@@ -1,0 +1,78 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+} from '@/components/Primitives/AlertDialog';
+import Flex from '@/components/Primitives/Flex';
+import Text from '@/components/Primitives/Text';
+import useColumn from '@/hooks/useColumn';
+import CardType from '@/types/card/card';
+
+type AlertDeleteAllCardsProps = {
+  socketId: string;
+
+  isOpen: boolean;
+  handleDialogChange: (
+    openName: boolean,
+    openDeleteColumn: boolean,
+    openDeleteCards: boolean,
+  ) => void;
+  columnId: string;
+  columnTitle: string;
+  columnColor: string;
+  cards: CardType[];
+  boardId: string;
+};
+const AlertDeleteAllCards: React.FC<AlertDeleteAllCardsProps> = ({
+  socketId,
+  isOpen,
+  columnColor,
+  columnId,
+  columnTitle,
+  cards,
+  boardId,
+  handleDialogChange,
+}) => {
+  // Update Column Hook
+  const {
+    deleteCardsFromColumn: { mutate: mutateBoard },
+  } = useColumn();
+
+  const handleDeleteCards = () => {
+    mutateBoard({
+      _id: columnId,
+      title: columnTitle,
+      color: columnColor,
+      cards,
+      boardId,
+      socketId,
+    });
+
+    handleDialogChange(false, false, false);
+  };
+
+  return (
+    <AlertDialog open={isOpen}>
+      <AlertDialogContent
+        title="Empty column of all cards"
+        handleClose={() => handleDialogChange(false, false, false)}
+      >
+        <Text>Do you really want to remove all cards from this column?</Text>
+        <Flex gap="16" justify="end" css={{ mt: '$24' }}>
+          <AlertDialogCancel
+            variant="primaryOutline"
+            onClick={() => handleDialogChange(false, false, false)}
+          >
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction variant="danger" onClick={handleDeleteCards}>
+            Empty Column
+          </AlertDialogAction>
+        </Flex>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default AlertDeleteAllCards;

--- a/frontend/src/components/Board/Column/partials/AlertDeleteColumn/index.tsx
+++ b/frontend/src/components/Board/Column/partials/AlertDeleteColumn/index.tsx
@@ -1,0 +1,56 @@
+import Icon from '@/components/icons/Icon';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogTrigger,
+} from '@/components/Primitives/AlertDialog';
+import Button from '@/components/Primitives/Button';
+import Flex from '@/components/Primitives/Flex';
+import Text from '@/components/Primitives/Text';
+import useBoard from '@/hooks/useBoard';
+import { boardInfoState } from '@/store/board/atoms/board.atom';
+import { useRecoilValue } from 'recoil';
+
+type AlertDeleteColumnProps = {
+  socketId: string;
+  columnId: string;
+};
+const AlertDeleteColumn: React.FC<AlertDeleteColumnProps> = ({ columnId, socketId }) => {
+  // Recoil State used on [boardId].tsx
+  const { board } = useRecoilValue(boardInfoState);
+
+  // Update Board/Column Hook
+  const {
+    updateBoard: { mutate: mutateBoard },
+  } = useBoard({ autoFetchBoard: false });
+
+  const handleDeleteColumn = () => {
+    const columnsToUpdate = board.columns.filter((column) => columnId !== column._id);
+    const deletedColumns = [columnId];
+
+    mutateBoard({ ...board, columns: columnsToUpdate, deletedColumns, socketId });
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="primaryOutline" size="sm">
+          Delete column
+          <Icon name="merge" />
+        </Button>
+      </AlertDialogTrigger>
+
+      <AlertDialogContent title="Merge board into main board">
+        <Text>Do you really want to delete the column --TITLE?</Text>
+        <Flex gap="16" justify="end" css={{ mt: '$24' }}>
+          <AlertDialogCancel variant="primaryOutline">Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleDeleteColumn}>Delete Column</AlertDialogAction>
+        </Flex>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};
+
+export default AlertDeleteColumn;

--- a/frontend/src/components/Board/Column/partials/AlertDeleteColumn/index.tsx
+++ b/frontend/src/components/Board/Column/partials/AlertDeleteColumn/index.tsx
@@ -16,8 +16,17 @@ import { useRecoilValue } from 'recoil';
 type AlertDeleteColumnProps = {
   socketId: string;
   columnId: string;
+  columnTitle: string;
+  isOpen: boolean;
+  handleDialogChange: (openName: boolean, openDelete: boolean) => void;
 };
-const AlertDeleteColumn: React.FC<AlertDeleteColumnProps> = ({ columnId, socketId }) => {
+const AlertDeleteColumn: React.FC<AlertDeleteColumnProps> = ({
+  columnId,
+  socketId,
+  columnTitle,
+  isOpen,
+  handleDialogChange,
+}) => {
   // Recoil State used on [boardId].tsx
   const { board } = useRecoilValue(boardInfoState);
 
@@ -34,7 +43,7 @@ const AlertDeleteColumn: React.FC<AlertDeleteColumnProps> = ({ columnId, socketI
   };
 
   return (
-    <AlertDialog>
+    <AlertDialog open={isOpen}>
       <AlertDialogTrigger asChild>
         <Button variant="primaryOutline" size="sm">
           Delete column
@@ -42,11 +51,21 @@ const AlertDeleteColumn: React.FC<AlertDeleteColumnProps> = ({ columnId, socketI
         </Button>
       </AlertDialogTrigger>
 
-      <AlertDialogContent title="Merge board into main board">
-        <Text>Do you really want to delete the column --TITLE?</Text>
+      <AlertDialogContent
+        title="Merge board into main board"
+        handleClose={() => handleDialogChange(false, false)}
+      >
+        <Text>Do you really want to delete the column &quot;{columnTitle}&quot;?</Text>
         <Flex gap="16" justify="end" css={{ mt: '$24' }}>
-          <AlertDialogCancel variant="primaryOutline">Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={handleDeleteColumn}>Delete Column</AlertDialogAction>
+          <AlertDialogCancel
+            variant="primaryOutline"
+            onClick={() => handleDialogChange(false, false)}
+          >
+            Cancel
+          </AlertDialogCancel>
+          <AlertDialogAction variant="danger" onClick={handleDeleteColumn}>
+            Delete Column
+          </AlertDialogAction>
         </Flex>
       </AlertDialogContent>
     </AlertDialog>

--- a/frontend/src/components/Board/Column/partials/AlertDeleteColumn/index.tsx
+++ b/frontend/src/components/Board/Column/partials/AlertDeleteColumn/index.tsx
@@ -17,7 +17,11 @@ type AlertDeleteColumnProps = {
   columnId: string;
   columnTitle: string;
   isOpen: boolean;
-  handleDialogChange: (openName: boolean, openDelete: boolean) => void;
+  handleDialogChange: (
+    openName: boolean,
+    openDeleteColumn: boolean,
+    openDeleteCards: boolean,
+  ) => void;
 };
 const AlertDeleteColumn: React.FC<AlertDeleteColumnProps> = ({
   columnId,
@@ -56,7 +60,7 @@ const AlertDeleteColumn: React.FC<AlertDeleteColumnProps> = ({
 
   const boardData = initialData;
 
-  // Update Board/Column Hook
+  // Update Column Hook
   const {
     updateBoard: { mutate: mutateBoard },
   } = useBoard({ autoFetchBoard: false });
@@ -81,14 +85,14 @@ const AlertDeleteColumn: React.FC<AlertDeleteColumnProps> = ({
   return (
     <AlertDialog open={isOpen}>
       <AlertDialogContent
-        title="Merge board into main board"
-        handleClose={() => handleDialogChange(false, false)}
+        title="Delete column"
+        handleClose={() => handleDialogChange(false, false, false)}
       >
         <Text>Do you really want to delete the column &quot;{columnTitle}&quot;?</Text>
         <Flex gap="16" justify="end" css={{ mt: '$24' }}>
           <AlertDialogCancel
             variant="primaryOutline"
-            onClick={() => handleDialogChange(false, false)}
+            onClick={() => handleDialogChange(false, false, false)}
           >
             Cancel
           </AlertDialogCancel>

--- a/frontend/src/components/Board/Column/partials/OptionsMenu/index.tsx
+++ b/frontend/src/components/Board/Column/partials/OptionsMenu/index.tsx
@@ -48,8 +48,10 @@ const OptionsMenu = ({
 }: OptionsMenuProps) => {
   const [openPopover, setOpenPopover] = useState(false);
 
+  // Update Board Hook
+
   const {
-    updateColumn: { mutate },
+    updateColumn: { mutate: mutateColumn },
   } = useColumn();
 
   const handleDefaultTextCheck = () => {
@@ -63,7 +65,7 @@ const OptionsMenu = ({
       isDefaultText: !isDefaultText,
     };
 
-    mutate(column);
+    mutateColumn(column);
   };
 
   const handleColorChange = (selectedColor: string) => {
@@ -77,7 +79,7 @@ const OptionsMenu = ({
       isDefaultText,
     };
 
-    mutate(column);
+    mutateColumn(column);
   };
 
   const handleOpen = (type: string) => {

--- a/frontend/src/components/Board/Column/partials/OptionsMenu/index.tsx
+++ b/frontend/src/components/Board/Column/partials/OptionsMenu/index.tsx
@@ -23,6 +23,7 @@ type OptionsMenuProps = {
   boardId: string;
   cardText?: string;
   setOpenDialogName: (open: boolean, type: string) => void;
+  handleDialogChange: (openName: boolean, openDelete: boolean) => void;
   isDefaultText?: boolean;
 };
 
@@ -45,11 +46,11 @@ const OptionsMenu = ({
   boardId,
   isDefaultText,
   setOpenDialogName,
+  handleDialogChange,
 }: OptionsMenuProps) => {
   const [openPopover, setOpenPopover] = useState(false);
 
   // Update Board Hook
-
   const {
     updateColumn: { mutate: mutateColumn },
   } = useColumn();
@@ -117,7 +118,7 @@ const OptionsMenu = ({
                 disabled={cardText === 'Write your comment here...'}
               />
             </PopoverItem>
-            <PopoverItem>
+            <PopoverItem onClick={() => handleDialogChange(false, true)}>
               <Icon name="trash-alt" />
               <Text size="sm">Delete column</Text>
             </PopoverItem>

--- a/frontend/src/components/Board/Column/partials/OptionsMenu/index.tsx
+++ b/frontend/src/components/Board/Column/partials/OptionsMenu/index.tsx
@@ -29,6 +29,7 @@ type OptionsMenuProps = {
     openDeleteCards: boolean,
   ) => void;
   isDefaultText?: boolean;
+  socketId: string;
 };
 
 export const colors = [
@@ -49,6 +50,7 @@ const OptionsMenu = ({
   cardText,
   boardId,
   isDefaultText,
+  socketId,
   setOpenDialogName,
   handleDialogChange,
 }: OptionsMenuProps) => {
@@ -68,6 +70,7 @@ const OptionsMenu = ({
       cardText,
       boardId,
       isDefaultText: !isDefaultText,
+      socketId,
     };
 
     mutateColumn(column);
@@ -82,6 +85,7 @@ const OptionsMenu = ({
       cardText,
       boardId,
       isDefaultText,
+      socketId,
     };
 
     mutateColumn(column);

--- a/frontend/src/components/Board/Column/partials/OptionsMenu/index.tsx
+++ b/frontend/src/components/Board/Column/partials/OptionsMenu/index.tsx
@@ -23,7 +23,11 @@ type OptionsMenuProps = {
   boardId: string;
   cardText?: string;
   setOpenDialogName: (open: boolean, type: string) => void;
-  handleDialogChange: (openName: boolean, openDelete: boolean) => void;
+  handleDialogChange: (
+    openName: boolean,
+    openDeleteColumn: boolean,
+    openDeleteCards: boolean,
+  ) => void;
   isDefaultText?: boolean;
 };
 
@@ -102,7 +106,7 @@ const OptionsMenu = ({
               <Icon name="boards" />
               <Text size="sm">Edit column name </Text>
             </PopoverItem>
-            <PopoverItem onClick={() => handleColorChange('$highlight4Light')}>
+            <PopoverItem onClick={() => handleDialogChange(false, false, true)}>
               <Icon name="recurring" />
               <Text size="sm">Empty column cards</Text>
             </PopoverItem>
@@ -118,7 +122,7 @@ const OptionsMenu = ({
                 disabled={cardText === 'Write your comment here...'}
               />
             </PopoverItem>
-            <PopoverItem onClick={() => handleDialogChange(false, true)}>
+            <PopoverItem onClick={() => handleDialogChange(false, true, false)}>
               <Icon name="trash-alt" />
               <Text size="sm">Delete column</Text>
             </PopoverItem>

--- a/frontend/src/components/Board/Column/partials/UpdateColumnDialog/index.tsx
+++ b/frontend/src/components/Board/Column/partials/UpdateColumnDialog/index.tsx
@@ -24,7 +24,7 @@ type UpdateColumnNameProps = {
   columnColor: string;
   cards: CardType[];
   isOpen: boolean;
-  setIsOpen: (openName: boolean, openDelete: boolean) => void;
+  setIsOpen: (openName: boolean, openDeleteColumn: boolean, openDeleteCards: boolean) => void;
   cardText?: string;
   isDefaultText?: boolean;
   type: string;
@@ -72,7 +72,7 @@ const UpdateColumnDialog: React.FC<UpdateColumnNameProps> = ({
   const submitBtnRef = useRef<HTMLButtonElement | null>(null);
 
   const handleClose = () => {
-    setIsOpen(false, false);
+    setIsOpen(false, false, false);
   };
 
   const handleConfirm = (title: string, text: string) => {

--- a/frontend/src/components/Board/Column/partials/UpdateColumnDialog/index.tsx
+++ b/frontend/src/components/Board/Column/partials/UpdateColumnDialog/index.tsx
@@ -28,6 +28,7 @@ type UpdateColumnNameProps = {
   cardText?: string;
   isDefaultText?: boolean;
   type: string;
+  socketId: string;
 };
 
 const StyledForm = styled('form', Flex, { width: '100%', backgroundColor: 'transparent' });
@@ -43,6 +44,7 @@ const UpdateColumnDialog: React.FC<UpdateColumnNameProps> = ({
   setIsOpen,
   isDefaultText,
   type,
+  socketId,
 }) => {
   const {
     updateColumn: { mutate },
@@ -84,6 +86,7 @@ const UpdateColumnDialog: React.FC<UpdateColumnNameProps> = ({
       cardText: text,
       boardId,
       isDefaultText: type === 'ColumnName' ? isDefaultText : false,
+      socketId,
     };
 
     mutate(columnUpdate);

--- a/frontend/src/components/Board/Column/partials/UpdateColumnDialog/index.tsx
+++ b/frontend/src/components/Board/Column/partials/UpdateColumnDialog/index.tsx
@@ -24,7 +24,7 @@ type UpdateColumnNameProps = {
   columnColor: string;
   cards: CardType[];
   isOpen: boolean;
-  setIsOpen: (value: boolean) => void;
+  setIsOpen: (openName: boolean, openDelete: boolean) => void;
   cardText?: string;
   isDefaultText?: boolean;
   type: string;
@@ -72,7 +72,7 @@ const UpdateColumnDialog: React.FC<UpdateColumnNameProps> = ({
   const submitBtnRef = useRef<HTMLButtonElement | null>(null);
 
   const handleClose = () => {
-    setIsOpen(false);
+    setIsOpen(false, false);
   };
 
   const handleConfirm = (title: string, text: string) => {

--- a/frontend/src/components/Board/Settings/index.tsx
+++ b/frontend/src/components/Board/Settings/index.tsx
@@ -77,7 +77,7 @@ const BoardSettings = ({
   } = useRecoilValue(boardInfoState);
 
   const [editColumns, setEditColumns] = useRecoilState(editColumnsState);
-  const deletedColumns = useRecoilValue(deletedColumnsState);
+  const [deletedColumns, setDeletedColumns] = useRecoilState(deletedColumnsState);
 
   // State used to change values
   const initialData: UpdateBoardType = {
@@ -340,7 +340,11 @@ const BoardSettings = ({
 
     window?.addEventListener('keydown', keyDownHandler);
 
-    return () => window?.removeEventListener('keydown', keyDownHandler);
+    return () => {
+      window?.removeEventListener('keydown', keyDownHandler);
+      setEditColumns([]);
+      setDeletedColumns([]);
+    };
   }, []);
 
   const handleAddColumn = () => {

--- a/frontend/src/hooks/useColumn.tsx
+++ b/frontend/src/hooks/useColumn.tsx
@@ -68,27 +68,8 @@ const useColumn = () => {
   });
 
   const deleteCardsFromColumn = useMutation(deleteCardsFromColumnRequest, {
-    onMutate: async (data) => {
-      const prevBoard = await getPrevData(data.boardId);
-
-      if (prevBoard) {
-        const columnsWithUpdate = prevBoard.columns.map((column) =>
-          column._id === data._id
-            ? {
-                ...data,
-              }
-            : column,
-        );
-
-        updateBoardColumns(data.boardId, columnsWithUpdate);
-      }
-
-      return { previousBoard: prevBoard, data };
-    },
-    onSuccess: async (data) => {
-      const prevBoard = await getPrevData(data._id);
-
-      return { previousBoard: prevBoard, data };
+    onSuccess: (data) => {
+      queryClient.invalidateQueries(['board', { id: data._id }]);
     },
     onError: (_, variables) => {
       queryClient.invalidateQueries(getBoardQuery(variables.boardId));

--- a/frontend/src/types/column.ts
+++ b/frontend/src/types/column.ts
@@ -57,4 +57,9 @@ export type ColumnDragItem = {
   type: 'COLUMN';
 };
 
+export type ColumnDeleteCards = {
+  id: string;
+  socketId: string;
+};
+
 export default ColumnType;


### PR DESCRIPTION

Relates to #958 
Relates to #738 

## Proposed Changes

On a regular board, a user with permitions can:
  - Empty cards from column
  - Delete column
  - Console error fixed


This pull request closes #958 
This pull request closes #738 