### PR TITLE
fix: disable card drag on mainboard

### DIFF
--- a/frontend/src/components/Board/Card/CardBoard.tsx
+++ b/frontend/src/components/Board/Card/CardBoard.tsx
@@ -106,7 +106,7 @@ const CardBoard = React.memo<CardBoardProps>(
         key={card._id}
         draggableId={card._id}
         index={index}
-        isDragDisabled={isSubmited || hideCards}
+        isDragDisabled={isSubmited || (isMainboard && !hasAdminRole) || hideCards}
       >
         {(provided) => (
           <Flex
@@ -176,24 +176,25 @@ const CardBoard = React.memo<CardBoardProps>(
                       >
                         {card.text}
                       </Text>
-                      {!isSubmited && (userId === card?.createdBy?._id || hasAdminRole) && (
-                        <PopoverCardSettings
-                          boardId={boardId}
-                          cardGroupId={card._id}
-                          columnId={colId}
-                          firstOne={false}
-                          handleDeleteCard={handleDeleting}
-                          handleEditing={handleEditing}
-                          hideCards={hideCards}
-                          isItem={false}
-                          item={card}
-                          itemId={card.items[0]._id}
-                          newPosition={0}
-                          socketId={socketId}
-                          userId={userId}
-                          hasAdminRole={hasAdminRole}
-                        />
-                      )}
+                      {!isSubmited &&
+                        ((userId === card?.createdBy?._id && !isMainboard) || hasAdminRole) && (
+                          <PopoverCardSettings
+                            boardId={boardId}
+                            cardGroupId={card._id}
+                            columnId={colId}
+                            firstOne={false}
+                            handleDeleteCard={handleDeleting}
+                            handleEditing={handleEditing}
+                            hideCards={hideCards}
+                            isItem={false}
+                            item={card}
+                            itemId={card.items[0]._id}
+                            newPosition={0}
+                            socketId={socketId}
+                            userId={userId}
+                            hasAdminRole={hasAdminRole}
+                          />
+                        )}
                     </Flex>
                   )}
                   {card.items && isCardGroup && (

--- a/frontend/src/components/Board/Card/CardBoard.tsx
+++ b/frontend/src/components/Board/Card/CardBoard.tsx
@@ -106,7 +106,7 @@ const CardBoard = React.memo<CardBoardProps>(
         key={card._id}
         draggableId={card._id}
         index={index}
-        isDragDisabled={isSubmited || (isMainboard && !hasAdminRole) || hideCards}
+        isDragDisabled={isSubmited || (isMainboard && !hasAdminRole) || (isMainboard && hideCards)}
       >
         {(provided) => (
           <Flex

--- a/frontend/src/components/Board/Card/CardBoard.tsx
+++ b/frontend/src/components/Board/Card/CardBoard.tsx
@@ -256,6 +256,7 @@ const CardBoard = React.memo<CardBoardProps>(
                 columnId={colId}
                 isDefaultText={isDefaultText}
                 hasAdminRole={hasAdminRole}
+                isMainboard={isMainboard}
               />
             )}
           </Flex>

--- a/frontend/src/components/Board/Card/CardItem/CardItem.tsx
+++ b/frontend/src/components/Board/Card/CardItem/CardItem.tsx
@@ -95,24 +95,25 @@ const CardItem: React.FC<CardItemProps> = React.memo(
                   />
                 </Flex>
               )}
-              {!isSubmited && (
-                <PopoverCardSettings
-                  isItem
-                  boardId={boardId}
-                  cardGroupId={cardGroupId}
-                  columnId={columnId}
-                  firstOne={firstOne}
-                  handleDeleteCard={handleDeleting}
-                  handleEditing={handleEditing}
-                  hideCards={hideCards}
-                  item={item}
-                  itemId={item._id}
-                  newPosition={cardGroupPosition}
-                  socketId={socketId}
-                  userId={userId}
-                  hasAdminRole={hasAdminRole}
-                />
-              )}
+              {!isSubmited &&
+                ((userId === item?.createdBy?._id && !isMainboard) || hasAdminRole) && (
+                  <PopoverCardSettings
+                    isItem
+                    boardId={boardId}
+                    cardGroupId={cardGroupId}
+                    columnId={columnId}
+                    firstOne={firstOne}
+                    handleDeleteCard={handleDeleting}
+                    handleEditing={handleEditing}
+                    hideCards={hideCards}
+                    item={item}
+                    itemId={item._id}
+                    newPosition={cardGroupPosition}
+                    socketId={socketId}
+                    userId={userId}
+                    hasAdminRole={hasAdminRole}
+                  />
+                )}
             </Flex>
 
             {!lastOne && (

--- a/frontend/src/components/Board/Column/styles.tsx
+++ b/frontend/src/components/Board/Column/styles.tsx
@@ -6,6 +6,7 @@ import Text from '@/components/Primitives/Text';
 
 const CardsContainer = styled(Flex, {
   mt: '$20',
+  mb: '$8',
   px: '$20',
 
   '&::-webkit-scrollbar': {
@@ -29,7 +30,6 @@ const Container = styled(Flex, Box, {
   borderRadius: '$12',
   flexShrink: 0,
   flex: '1',
-  pb: '$24',
   width: '100%',
   boxShadow: '0px 2px 8px rgba(18, 25, 34, 0.05)',
   backgroundColor: '$surface',

--- a/frontend/src/components/Board/Comment/Comment.tsx
+++ b/frontend/src/components/Board/Comment/Comment.tsx
@@ -21,6 +21,7 @@ interface CommentProps {
   columnId: string;
   isDefaultText: boolean;
   hasAdminRole: boolean;
+  isMainboard: boolean;
 }
 
 const Comment: React.FC<CommentProps> = React.memo(
@@ -35,6 +36,7 @@ const Comment: React.FC<CommentProps> = React.memo(
     columnId,
     isDefaultText,
     hasAdminRole,
+    isMainboard,
   }) => {
     const { deleteComment } = useComments();
     const [editing, setEditing] = useState(false);
@@ -87,12 +89,13 @@ const Comment: React.FC<CommentProps> = React.memo(
                   }}
                 />
               )}
-              {!isSubmited && (userId === comment.createdBy._id || hasAdminRole) && (
-                <PopoverCommentSettings
-                  handleDeleteComment={handleDeleteComment}
-                  handleEditing={handleEditing}
-                />
-              )}
+              {!isSubmited &&
+                ((userId === comment.createdBy._id && !isMainboard) || hasAdminRole) && (
+                  <PopoverCommentSettings
+                    handleDeleteComment={handleDeleteComment}
+                    handleEditing={handleEditing}
+                  />
+                )}
             </Flex>
             <Flex align="center" css={{ minHeight: '$24', maxWidth: '$226' }}>
               {!comment.anonymous && (

--- a/frontend/src/components/Board/Comment/Comments.tsx
+++ b/frontend/src/components/Board/Comment/Comments.tsx
@@ -21,6 +21,7 @@ interface CommentsListProps {
   columnId: string;
   isDefaultText: boolean;
   hasAdminRole: boolean;
+  isMainboard: boolean;
 }
 
 const Comments = React.memo(
@@ -36,6 +37,7 @@ const Comments = React.memo(
     columnId,
     isDefaultText,
     hasAdminRole,
+    isMainboard,
   }: CommentsListProps) => {
     const [isCreateCommentOpened, setCreateComment] = useState(false);
 
@@ -64,6 +66,7 @@ const Comments = React.memo(
               columnId={columnId}
               isDefaultText={isDefaultText}
               hasAdminRole={hasAdminRole}
+              isMainboard={isMainboard}
               cardItemId={
                 cardItems.find((item) => {
                   if (item && item.comments)
@@ -91,7 +94,7 @@ const Comments = React.memo(
             />
           </Flex>
         )}
-        {!isCreateCommentOpened && !isSubmited && (
+        {!isCreateCommentOpened && !isSubmited && (!isMainboard || hasAdminRole) && (
           <Flex
             css={{ '@hover': { '&:hover': { cursor: 'pointer' } } }}
             onClick={handleSetCreateComment}


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #963 
Fixes #963

## Screenshots

<img width="412" alt="image" src="https://user-images.githubusercontent.com/8330038/217022822-0dc2f134-bc2c-41af-8794-e58a6fc58403.png">

## Proposed Changes

 - For "regular users" Disabled:
   - Card drag on the main board
   - Card edit on the main board
   - Adding new comments on the main board
   - Editing existing comments on the main board

<!--
Mention people who discussed this issue previously
@miguel-felix1 
-->


This pull request closes #963