### PR TITLE
fix: blur, hide cards, hide text, post anonymously

### DIFF
--- a/backend/src/libs/utils/hideText.ts
+++ b/backend/src/libs/utils/hideText.ts
@@ -1,3 +1,3 @@
 export const hideText = (text: string): string => {
-	return text.replace(/[a-zA-Z\d'#]/g, 'a');
+	return text.replace(/[a-zA-Z0-9\u00C0-\u024F\u1E00-\u1EFF\u1000-\uFFFF]/g, 'a');
 };

--- a/backend/src/modules/boards/dto/board.dto.ts
+++ b/backend/src/modules/boards/dto/board.dto.ts
@@ -114,6 +114,11 @@ export default class BoardDto {
 	@IsBoolean()
 	addCards?: boolean;
 
+	@ApiPropertyOptional({ default: false })
+	@IsOptional()
+	@IsBoolean()
+	postAnonymously?: boolean;
+
 	@ApiProperty({ type: String, isArray: true })
 	responsibles!: string[];
 }

--- a/backend/src/modules/boards/interfaces/services/create.board.service.interface.ts
+++ b/backend/src/modules/boards/interfaces/services/create.board.service.interface.ts
@@ -9,6 +9,7 @@ export interface Configs {
 	maxUsersPerTeam: number;
 	slackEnable?: boolean;
 	date?: Date;
+	postAnonymously: boolean;
 }
 
 export interface CreateBoardService {

--- a/backend/src/modules/boards/schemas/board.schema.ts
+++ b/backend/src/modules/boards/schemas/board.schema.ts
@@ -70,6 +70,9 @@ export default class Board extends BaseModel {
 
 	@Prop({ type: Boolean, nullable: true, default: true })
 	addCards: boolean;
+
+	@Prop({ type: Boolean, nullable: true, default: false })
+	postAnonymously: boolean;
 }
 
 export const BoardSchema = SchemaFactory.createForClass(Board);

--- a/backend/src/modules/boards/services/create.board.service.ts
+++ b/backend/src/modules/boards/services/create.board.service.ts
@@ -96,7 +96,8 @@ export default class CreateBoardServiceImpl implements CreateBoardService {
 			const dividedBoardsWithTeam = dividedBoards.map((dividedBoard) => ({
 				...dividedBoard,
 				team,
-				slackEnable: boardData.slackEnable
+				slackEnable: boardData.slackEnable,
+				hideCards: true
 			}));
 
 			return this.boardModel.create({

--- a/backend/src/modules/boards/services/create.board.service.ts
+++ b/backend/src/modules/boards/services/create.board.service.ts
@@ -97,7 +97,8 @@ export default class CreateBoardServiceImpl implements CreateBoardService {
 				...dividedBoard,
 				team,
 				slackEnable: boardData.slackEnable,
-				hideCards: true
+				hideCards: true,
+				postAnonymously: true
 			}));
 
 			return this.boardModel.create({
@@ -270,7 +271,8 @@ export default class CreateBoardServiceImpl implements CreateBoardService {
 			dividedBoards: this.handleSplitBoards(maxTeams, teamUsersWotStakeholders, responsibles),
 			recurrent: configs.recurrent,
 			maxVotes: configs.maxVotes ?? null,
-			hideCards: configs.hideCards ?? false,
+			hideCards: true,
+			postAnonymously: configs.postAnonymously,
 			hideVotes: configs.hideVotes ?? false,
 			maxUsers: Math.ceil(configs.maxUsersPerTeam),
 			slackEnable: configs.slackEnable,

--- a/backend/src/modules/boards/services/update.board.service.ts
+++ b/backend/src/modules/boards/services/update.board.service.ts
@@ -170,6 +170,7 @@ export default class UpdateBoardServiceImpl implements UpdateBoardServiceInterfa
 		board.hideCards = boardData.hideCards;
 		board.addCards = boardData.addCards;
 		board.hideVotes = boardData.hideVotes;
+		board.postAnonymously = boardData.postAnonymously;
 
 		/**
 		 * Validate if:

--- a/backend/src/modules/schedules/services/create.schedules.service.ts
+++ b/backend/src/modules/schedules/services/create.schedules.service.ts
@@ -157,6 +157,7 @@ export class CreateSchedulesService implements CreateSchedulesServiceInterface {
 			maxVotes: oldBoard.maxVotes,
 			hideCards: oldBoard.hideCards,
 			hideVotes: oldBoard.hideVotes,
+			postAnonymously: oldBoard.postAnonymously,
 			maxUsersPerTeam: deletedSchedule.maxUsers,
 			slackEnable: oldBoard.slackEnable ?? false,
 			date: new Date(new Date().getFullYear(), month, day)

--- a/frontend/src/components/Board/AddCardOrComment.tsx
+++ b/frontend/src/components/Board/AddCardOrComment.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { joiResolver } from '@hookform/resolvers/joi';
 import Button from '@/components/Primitives/Button';
@@ -33,6 +33,7 @@ type AddCardProps = {
   isEditing?: boolean;
   anonymous: boolean;
   isDefaultText: boolean;
+  postAnonymously: boolean;
 };
 
 const AddCard = React.memo<AddCardProps>(
@@ -51,6 +52,7 @@ const AddCard = React.memo<AddCardProps>(
     isEditing = false,
     defaultOpen,
     anonymous,
+    postAnonymously,
     ...props
   }) => {
     const { addCardInColumn, updateCard } = useCards();
@@ -113,6 +115,11 @@ const AddCard = React.memo<AddCardProps>(
       updateCard.mutate(cardUpdated);
       cancelUpdate();
     };
+
+    useEffect(() => {
+      setIsAnonymous(postAnonymously);
+      setIsCommentAnonymous(postAnonymously);
+    }, [postAnonymously]);
 
     const handleAddComment = (text: string) => {
       if (!cardId || !cancelUpdate) return;
@@ -212,9 +219,9 @@ const AddCard = React.memo<AddCardProps>(
             {!isCard && (
               <Checkbox
                 id={colId + cardId}
-                label="Add anonymously"
+                label="Post anonymously"
                 size="16"
-                checked={anonymous}
+                checked={isCommentAnonymous || postAnonymously}
                 setCheckedTerms={() => {
                   setIsCommentAnonymous(!isCommentAnonymous);
                 }}
@@ -225,7 +232,7 @@ const AddCard = React.memo<AddCardProps>(
                 id={colId}
                 label="Post anonymously"
                 size="16"
-                checked={anonymous}
+                checked={isAnonymous || postAnonymously}
                 setCheckedTerms={() => {
                   setIsAnonymous(!isAnonymous);
                 }}

--- a/frontend/src/components/Board/Card/CardBoard.tsx
+++ b/frontend/src/components/Board/Card/CardBoard.tsx
@@ -119,6 +119,7 @@ const CardBoard = React.memo<CardBoardProps>(
               backgroundColor: color,
               borderRadius: '$8',
               mb: '$12',
+              pointerEvents: hideCards ? 'none' : 'auto',
             }}
           >
             <Container
@@ -129,6 +130,7 @@ const CardBoard = React.memo<CardBoardProps>(
                 py: !isCardGroup ? '$16' : '$8',
                 mb: isCardGroup ? '$12' : 'none',
                 filter: cardBlur(hideCards, card as CardType, userId),
+                transform: 'translate3d(1, 1, 1)',
               }}
             >
               {editing && !isSubmited && (

--- a/frontend/src/components/Board/Card/CardBoard.tsx
+++ b/frontend/src/components/Board/Card/CardBoard.tsx
@@ -41,6 +41,7 @@ interface CardBoardProps {
   isDefaultText: boolean;
   cardText?: string;
   hasAdminRole: boolean;
+  postAnonymously: boolean;
 }
 
 const CardBoard = React.memo<CardBoardProps>(
@@ -59,6 +60,7 @@ const CardBoard = React.memo<CardBoardProps>(
     hideCards,
     isDefaultText,
     hasAdminRole,
+    postAnonymously,
   }) => {
     const isCardGroup = card.items.length > 1;
     const comments = useMemo(
@@ -119,7 +121,7 @@ const CardBoard = React.memo<CardBoardProps>(
               backgroundColor: color,
               borderRadius: '$8',
               mb: '$12',
-              pointerEvents: hideCards ? 'none' : 'auto',
+              pointerEvents: hideCards && card.createdBy?._id !== userId ? 'none' : 'auto',
             }}
           >
             <Container
@@ -130,7 +132,7 @@ const CardBoard = React.memo<CardBoardProps>(
                 py: !isCardGroup ? '$16' : '$8',
                 mb: isCardGroup ? '$12' : 'none',
                 filter: cardBlur(hideCards, card as CardType, userId),
-                transform: 'translate3d(1, 1, 1)',
+                transform: 'translate3d(0.1, 0.1, 0.1)',
               }}
             >
               {editing && !isSubmited && (
@@ -147,6 +149,7 @@ const CardBoard = React.memo<CardBoardProps>(
                   socketId={socketId}
                   anonymous={card.anonymous}
                   isDefaultText={isDefaultText}
+                  postAnonymously={postAnonymously}
                 />
               )}
               {!editing && (
@@ -214,6 +217,7 @@ const CardBoard = React.memo<CardBoardProps>(
                       userId={userId}
                       isDefaultText={isDefaultText}
                       hasAdminRole={hasAdminRole}
+                      postAnonymously={postAnonymously}
                     />
                   )}
                   <CardFooter
@@ -258,6 +262,7 @@ const CardBoard = React.memo<CardBoardProps>(
                 columnId={colId}
                 isDefaultText={isDefaultText}
                 hasAdminRole={hasAdminRole}
+                postAnonymously={postAnonymously}
                 isMainboard={isMainboard}
               />
             )}

--- a/frontend/src/components/Board/Card/CardItem/CardItem.tsx
+++ b/frontend/src/components/Board/Card/CardItem/CardItem.tsx
@@ -28,6 +28,7 @@ interface CardItemProps {
   hideCards: boolean;
   isDefaultText: boolean;
   hasAdminRole: boolean;
+  postAnonymously: boolean;
 }
 
 const Container = styled(Flex, {
@@ -54,6 +55,7 @@ const CardItem: React.FC<CardItemProps> = React.memo(
     hideCards,
     isDefaultText,
     hasAdminRole,
+    postAnonymously,
   }) => {
     const [editing, setEditing] = useState(false);
     const [deleting, setDeleting] = useState(false);
@@ -144,6 +146,7 @@ const CardItem: React.FC<CardItemProps> = React.memo(
             socketId={socketId}
             anonymous={item.anonymous}
             isDefaultText={isDefaultText}
+            postAnonymously={postAnonymously}
           />
         )}
         {deleting && (

--- a/frontend/src/components/Board/Card/CardItem/CardItemList.tsx
+++ b/frontend/src/components/Board/Card/CardItem/CardItemList.tsx
@@ -18,6 +18,7 @@ interface CardItemListProps {
   hideCards: boolean;
   isDefaultText: boolean;
   hasAdminRole: boolean;
+  postAnonymously: boolean;
 }
 
 const CardItemList: React.FC<CardItemListProps> = ({
@@ -34,6 +35,7 @@ const CardItemList: React.FC<CardItemListProps> = ({
   hideCards,
   isDefaultText,
   hasAdminRole,
+  postAnonymously,
 }) => (
   <Flex direction="column">
     {items.map((item, idx) => (
@@ -66,6 +68,7 @@ const CardItemList: React.FC<CardItemListProps> = ({
           userId={userId}
           isDefaultText={isDefaultText}
           hasAdminRole={hasAdminRole}
+          postAnonymously={postAnonymously}
         />
       </Flex>
     ))}

--- a/frontend/src/components/Board/Column/CardsList.tsx
+++ b/frontend/src/components/Board/Column/CardsList.tsx
@@ -19,6 +19,7 @@ const CardsList = React.memo<ColumnInnerList>(
     hideCards,
     isDefaultText,
     hasAdminRole,
+    postAnonymously,
   }) => (
     <>
       {cards.map((card: CardType, idx) => (
@@ -38,6 +39,7 @@ const CardsList = React.memo<ColumnInnerList>(
           userId={userId}
           isDefaultText={isDefaultText || true}
           hasAdminRole={hasAdminRole}
+          postAnonymously={postAnonymously}
         />
       ))}
     </>

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -20,6 +20,7 @@ type ColumMemoProps = {
   isRegularBoard?: boolean;
   hasAdminRole: boolean;
   addCards: boolean;
+  postAnonymously: boolean;
 } & ColumnBoardType;
 
 const Column = React.memo<ColumMemoProps>(
@@ -42,6 +43,7 @@ const Column = React.memo<ColumMemoProps>(
     isRegularBoard,
     hasAdminRole,
     addCards,
+    postAnonymously,
   }) => {
     const [filter, setFilter] = useState<'asc' | 'desc' | undefined>();
     const setFilteredColumns = useSetRecoilState(filteredColumnsState);
@@ -170,6 +172,7 @@ const Column = React.memo<ColumMemoProps>(
                           anonymous={false}
                           cardText={cardText}
                           isDefaultText={isDefaultText ?? true}
+                          postAnonymously={postAnonymously}
                         />
                       )}
                     </Flex>
@@ -192,6 +195,7 @@ const Column = React.memo<ColumMemoProps>(
                       socketId={socketId}
                       userId={userId}
                       hasAdminRole={hasAdminRole}
+                      postAnonymously={postAnonymously}
                     />
                     {provided.placeholder}
                   </CardsContainer>
@@ -219,6 +223,7 @@ const Column = React.memo<ColumMemoProps>(
           columnTitle={title}
           isOpen={openDialog.deleteColumn}
           handleDialogChange={handleDialogChange}
+          postAnonymously={postAnonymously}
         />
         <AlertDeleteAllCards
           socketId={socketId}

--- a/frontend/src/components/Board/Column/partials/AlertDeleteColumn/index.tsx
+++ b/frontend/src/components/Board/Column/partials/AlertDeleteColumn/index.tsx
@@ -17,6 +17,7 @@ type AlertDeleteColumnProps = {
   columnId: string;
   columnTitle: string;
   isOpen: boolean;
+  postAnonymously: boolean;
   handleDialogChange: (
     openName: boolean,
     openDeleteColumn: boolean,
@@ -29,6 +30,7 @@ const AlertDeleteColumn: React.FC<AlertDeleteColumnProps> = ({
   columnTitle,
   isOpen,
   handleDialogChange,
+  postAnonymously,
 }) => {
   // Recoil State used on [boardId].tsx
   const {
@@ -56,6 +58,7 @@ const AlertDeleteColumn: React.FC<AlertDeleteColumnProps> = ({
     isPublic,
     columns,
     addCards,
+    postAnonymously,
   };
 
   const boardData = initialData;

--- a/frontend/src/components/Board/Comment/Comment.tsx
+++ b/frontend/src/components/Board/Comment/Comment.tsx
@@ -22,6 +22,7 @@ interface CommentProps {
   isDefaultText: boolean;
   hasAdminRole: boolean;
   isMainboard: boolean;
+  postAnonymously: boolean;
 }
 
 const Comment: React.FC<CommentProps> = React.memo(
@@ -37,6 +38,7 @@ const Comment: React.FC<CommentProps> = React.memo(
     isDefaultText,
     hasAdminRole,
     isMainboard,
+    postAnonymously,
   }) => {
     const { deleteComment } = useComments();
     const [editing, setEditing] = useState(false);
@@ -129,6 +131,7 @@ const Comment: React.FC<CommentProps> = React.memo(
             socketId={socketId}
             anonymous={comment.anonymous}
             isDefaultText={isDefaultText}
+            postAnonymously={postAnonymously}
           />
         )}
       </Flex>

--- a/frontend/src/components/Board/Comment/Comments.tsx
+++ b/frontend/src/components/Board/Comment/Comments.tsx
@@ -22,6 +22,7 @@ interface CommentsListProps {
   isDefaultText: boolean;
   hasAdminRole: boolean;
   isMainboard: boolean;
+  postAnonymously: boolean;
 }
 
 const Comments = React.memo(
@@ -38,6 +39,7 @@ const Comments = React.memo(
     isDefaultText,
     hasAdminRole,
     isMainboard,
+    postAnonymously,
   }: CommentsListProps) => {
     const [isCreateCommentOpened, setCreateComment] = useState(false);
 
@@ -67,6 +69,7 @@ const Comments = React.memo(
               isDefaultText={isDefaultText}
               hasAdminRole={hasAdminRole}
               isMainboard={isMainboard}
+              postAnonymously={postAnonymously}
               cardItemId={
                 cardItems.find((item) => {
                   if (item && item.comments)
@@ -91,6 +94,7 @@ const Comments = React.memo(
               socketId={socketId}
               anonymous={false}
               isDefaultText={isDefaultText}
+              postAnonymously={postAnonymously}
             />
           </Flex>
         )}

--- a/frontend/src/components/Board/DragDropArea/index.tsx
+++ b/frontend/src/components/Board/DragDropArea/index.tsx
@@ -140,6 +140,7 @@ const DragDropArea: React.FC<Props> = ({
             isRegularBoard={isRegularBoard}
             hasAdminRole={hasAdminRole}
             addCards={board.addCards}
+            postAnonymously={board.postAnonymously}
           />
         ))}
       </DragDropContext>

--- a/frontend/src/components/Board/Settings/index.tsx
+++ b/frontend/src/components/Board/Settings/index.tsx
@@ -73,6 +73,7 @@ const BoardSettings = ({
       isPublic,
       columns,
       addCards,
+      postAnonymously,
     },
   } = useRecoilValue(boardInfoState);
 
@@ -90,6 +91,7 @@ const BoardSettings = ({
     isPublic,
     columns: isRegularBoard ? editColumns : columns,
     addCards,
+    postAnonymously,
   };
 
   const [data, setData] = useState<UpdateBoardType>(initialData);
@@ -106,6 +108,7 @@ const BoardSettings = ({
     hideVotes: boolean;
     isPublic: boolean;
     addCards: boolean;
+    postAnonymously: boolean;
   }>({
     maxVotes: false,
     responsible: false,
@@ -113,6 +116,7 @@ const BoardSettings = ({
     hideVotes: false,
     isPublic: false,
     addCards: false,
+    postAnonymously: false,
   });
 
   // User Board Hook
@@ -161,6 +165,7 @@ const BoardSettings = ({
       hideVotes,
       isPublic,
       addCards,
+      postAnonymously,
     }));
     methods.setValue('title', boardTitle);
     methods.setValue('maxVotes', boardMaxVotes ?? null);
@@ -178,6 +183,7 @@ const BoardSettings = ({
       maxVotes: !isEmpty(boardMaxVotes),
       isPublic,
       addCards,
+      postAnonymously,
     }));
   }, [
     boardMaxVotes,
@@ -190,6 +196,7 @@ const BoardSettings = ({
     editColumns,
     addCards,
     isRegularBoard,
+    postAnonymously,
   ]);
 
   const handleHideCardsChange = () => {
@@ -259,6 +266,17 @@ const BoardSettings = ({
     }));
   };
 
+  const handlePostAnonymouslyChange = () => {
+    setData((prev) => ({
+      ...prev,
+      postAnonymously: !prev.postAnonymously,
+    }));
+    setSwitchesState((prev) => ({
+      ...prev,
+      postAnonymously: !prev.postAnonymously,
+    }));
+  };
+
   const updateBoard = (
     title: string,
     maxVotes?: number | null,
@@ -283,6 +301,7 @@ const BoardSettings = ({
             responsible: false,
             isPublic: false,
             addCards: false,
+            postAnonymously: false,
           });
         },
       },
@@ -416,8 +435,14 @@ const BoardSettings = ({
                     <ConfigurationSwitchSettings
                       handleCheckedChange={handleAddCardsChange}
                       isChecked={switchesState.addCards}
-                      text="Allow users to add cards"
+                      text="Allow users to add cards."
                       title="Add cards"
+                    />
+                    <ConfigurationSwitchSettings
+                      handleCheckedChange={handlePostAnonymouslyChange}
+                      isChecked={switchesState.postAnonymously}
+                      text=" The option to post anonymously is checked by default."
+                      title="Post anonymously"
                     />
 
                     {!isSubBoard && (

--- a/frontend/src/components/CreateBoard/Configurations/BoardConfigurations.tsx
+++ b/frontend/src/components/CreateBoard/Configurations/BoardConfigurations.tsx
@@ -40,6 +40,16 @@ const BoardConfigurations = ({ isRegularBoard }: BoardConfigurationsProps) => {
     }));
   };
 
+  const handlePostAnonymouslyChange = (checked: boolean) => {
+    setCreateBoardData((prev) => ({
+      ...prev,
+      board: {
+        ...prev.board,
+        postAnonymously: checked,
+      },
+    }));
+  };
+
   const handleLimitVotesChange = (checked: boolean) => {
     setCreateBoardData((prev) => ({
       ...prev,
@@ -94,6 +104,17 @@ const BoardConfigurations = ({ isRegularBoard }: BoardConfigurationsProps) => {
             </Text>
             <Text color="primary500" size="sm">
               Participants can not see the votes from other participants of this retrospective.
+            </Text>
+          </Flex>
+        </Flex>
+        <Flex gap="16">
+          <Switch checked={board.postAnonymously} onCheckedChange={handlePostAnonymouslyChange} />
+          <Flex direction="column">
+            <Text size="md" fontWeight="medium">
+              Post anonymously
+            </Text>
+            <Text color="primary500" size="sm">
+              The option to post anonymously is checked by default.
             </Text>
           </Flex>
         </Flex>

--- a/frontend/src/components/Primitives/Checkbox.tsx
+++ b/frontend/src/components/Primitives/Checkbox.tsx
@@ -100,6 +100,10 @@ const Checkbox: React.FC<{
   );
 
   useEffect(() => {
+    setCurrentCheckValue(checked);
+  }, [checked]);
+
+  useEffect(() => {
     if (id === 'slackEnable' && formContext) {
       setCurrentCheckValue(formContext.getValues(id));
     }

--- a/frontend/src/helper/board/blurFilter.ts
+++ b/frontend/src/helper/board/blurFilter.ts
@@ -4,7 +4,9 @@ import CommentType from '@/types/comment/comment';
 import { User } from '@/types/user/user';
 
 export function cardBlur(hideCards: boolean, card: CardType, userId: string) {
-  return hideCards && card.createdBy?._id !== userId ? 'blur($sizes$6)' : 'none';
+  return hideCards && (card.createdBy?._id !== userId || card.createdByTeam)
+    ? 'blur($sizes$6)'
+    : 'none';
 }
 
 export function cardFooterBlur(hideCards: boolean, createdBy?: User, userId?: string) {

--- a/frontend/src/hooks/useCreateBoard.tsx
+++ b/frontend/src/hooks/useCreateBoard.tsx
@@ -39,6 +39,7 @@ const useCreateBoard = (team?: Team) => {
       hideCards: false,
       hideVotes: false,
       addCards: true,
+      postAnonymously: true,
     }),
     [],
   );

--- a/frontend/src/pages/boards/newRegularBoard.tsx
+++ b/frontend/src/pages/boards/newRegularBoard.tsx
@@ -66,6 +66,7 @@ const defaultBoard = {
     hideVotes: false,
     slackEnable: false,
     addCards: true,
+    postAnonymously: false,
   },
 };
 

--- a/frontend/src/pages/boards/newSplitBoard.tsx
+++ b/frontend/src/pages/boards/newSplitBoard.tsx
@@ -67,6 +67,7 @@ const defaultBoard = {
     hideVotes: false,
     slackEnable: false,
     addCards: true,
+    postAnonymously: false,
   },
 };
 

--- a/frontend/src/store/createBoard/atoms/create-board.atom.tsx
+++ b/frontend/src/store/createBoard/atoms/create-board.atom.tsx
@@ -55,6 +55,7 @@ export const createBoardDataState = atom<CreateBoardData>({
       hideVotes: false,
       slackEnable: false,
       addCards: true,
+      postAnonymously: false,
     },
   },
 });

--- a/frontend/src/types/board/board.ts
+++ b/frontend/src/types/board/board.ts
@@ -43,6 +43,7 @@ export default interface BoardType {
   slackEnable?: boolean;
   responsibles?: string[];
   addCards: boolean;
+  postAnonymously: boolean;
 }
 
 export interface BoardInfoType {
@@ -88,4 +89,5 @@ export type UpdateBoardType = {
   columns?: (ColumnType | CreateColumn)[];
   addCards: boolean;
   responsible?: BoardUser;
+  postAnonymously: boolean;
 };

--- a/frontend/src/types/column.ts
+++ b/frontend/src/types/column.ts
@@ -48,6 +48,7 @@ export interface ColumnInnerList {
   cardText?: string;
   isDefaultText?: boolean;
   hasAdminRole: boolean;
+  postAnonymously: boolean;
 }
 
 export type ColumnDragItem = {


### PR DESCRIPTION
<!--
#1021
-->

Fixes #1021
Fixes #989 

## Proposed Changes

  - Add translate3D to force the hardware acceleration when using blur
  - Add option to post anonymously by default
  - Refactor the replace text method
  - Setting hide cards in a sub-board by default
  - Fix selecting the text in the text area of a card with firefox

<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #1021 and closes #989 