### PR TITLE
fix: hide timer after sub board is merged

### DIFF
--- a/frontend/src/components/Board/RegularBoard/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/index.tsx
@@ -93,15 +93,16 @@ const RegularBoard = ({ socketId, emitEvent, listenEvent }: RegularBoardProps) =
       <Container direction="column">
         <Flex gap={40} align="center" css={{ py: '$32', width: '100%' }} justify="end">
           <Flex css={{ flex: 1 }} />
-          <Flex css={{ flex: 1 }}>
-            <Timer
-              boardId={board._id}
-              isAdmin={hasAdminRole}
-              emitEvent={emitEvent}
-              listenEvent={listenEvent}
-            />
-          </Flex>
-
+          {!board?.submitedAt && (
+            <Flex css={{ flex: 1 }}>
+              <Timer
+                boardId={board._id}
+                isAdmin={hasAdminRole}
+                emitEvent={emitEvent}
+                listenEvent={listenEvent}
+              />
+            </Flex>
+          )}
           {hasAdminRole && !board?.submitedAt && (
             <>
               <Button onClick={handleOpen} variant="primaryOutline">

--- a/frontend/src/pages/boards/[boardId].tsx
+++ b/frontend/src/pages/boards/[boardId].tsx
@@ -30,10 +30,10 @@ import {
   newBoardState,
 } from '@/store/board/atoms/board.atom';
 import { GetBoardResponse } from '@/types/board/board';
+import { BoardUser } from '@/types/board/board.user';
 import { BoardUserRoles } from '@/utils/enums/board.user.roles';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 import isEmpty from '@/utils/isEmpty';
-import { BoardUser } from '@/types/board/board.user';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const boardId = String(context.query.boardId);
@@ -244,14 +244,16 @@ const Board: NextPage<Props> = ({ boardId, mainBoardId }) => {
             </Flex>
           )}
 
-          <Flex css={{ flex: 1 }}>
-            <Timer
-              boardId={boardId}
-              isAdmin={hasAdminRole}
-              emitEvent={emitEvent}
-              listenEvent={listenEvent}
-            />
-          </Flex>
+          {!board?.submitedAt && (
+            <Flex css={{ flex: 1 }}>
+              <Timer
+                boardId={boardId}
+                isAdmin={hasAdminRole}
+                emitEvent={emitEvent}
+                listenEvent={listenEvent}
+              />
+            </Flex>
+          )}
 
           {hasAdminRole && !board?.submitedAt && (
             <>


### PR DESCRIPTION
Fixes #1062 

## Screenshots

Before
<img width="979" alt="Screenshot 2023-02-09 at 18 00 35" src="https://user-images.githubusercontent.com/33127565/217899016-d45e283f-dd81-4497-b8d1-d321c2c26955.png">


After
<img width="979" alt="Screenshot 2023-02-09 at 18 00 50" src="https://user-images.githubusercontent.com/33127565/217899043-d177c47b-5c30-467a-ae8e-af8b5db9f103.png">


## Proposed Changes

  - Hide the timer after a sub-board is merged

This pull request closes #1062 