### PR TITLE
feat: regular board no team edit responsible

### DIFF
--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantCard.tsx/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantCard.tsx/index.tsx
@@ -50,32 +50,15 @@ const ParticipantCard = React.memo<CardBodyProps>(
     };
 
     const updateIsResponsibleStatus = (checked: boolean) => {
-      // if (member.team) {
-      //   const updateTeamUser: TeamUserUpdate = {
-      //     team: member.team,
-      //     user: member.user._id,
-      //     role: member.role,
-      //     isNewJoiner: checked,
-      //   };
-
-      //   mutate(updateTeamUser);
-      // }
       const participantsList = [...boardParticipants];
       const idxParticipantToUpdate = participantsList.findIndex(
         (boardUser) => boardUser._id === member._id,
       );
       participantsList.splice(idxParticipantToUpdate, 1);
-      if (checked) {
-        participantsList.splice(idxParticipantToUpdate, 0, {
-          ...member,
-          role: BoardUserRoles.RESPONSIBLE,
-        });
-      } else {
-        participantsList.splice(idxParticipantToUpdate, 0, {
-          ...member,
-          role: BoardUserRoles.MEMBER,
-        });
-      }
+      participantsList.splice(idxParticipantToUpdate, 0, {
+        ...member,
+        role: checked ? BoardUserRoles.RESPONSIBLE : BoardUserRoles.MEMBER,
+      });
       setBoardParticipants(participantsList);
     };
 

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantCard.tsx/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantCard.tsx/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import Flex from '@/components/Primitives/Flex';
+import Text from '@/components/Primitives/Text';
 import Icon from '@/components/icons/Icon';
 import {
   IconButton,
@@ -11,91 +12,156 @@ import { BoardUser, BoardUserAddAndRemove } from '@/types/board/board.user';
 import Tooltip from '@/components/Primitives/Tooltip';
 import useParticipants from '@/hooks/useParticipants';
 import { useRouter } from 'next/router';
+import { ConfigurationSwitchSettings } from '@/components/Board/Settings/partials/ConfigurationSettings/ConfigurationSwitch';
+import { BoardUserRoles } from '@/utils/enums/board.user.roles';
+import { useRecoilState } from 'recoil';
+import { boardParticipantsState } from '@/store/board/atoms/board.atom';
 
 type CardBodyProps = {
   member: BoardUser;
-  isBoardCreator?: boolean;
+  isCurrentUserResponsible: boolean;
+  isCurrentUserSAdmin: boolean;
+  isMemberCurrentUser: boolean;
   isOpen?: boolean;
 };
 
-const ParticipantCard = React.memo<CardBodyProps>(({ member, isBoardCreator, isOpen }) => {
-  const {
-    addAndRemoveBoardParticipants: { mutate },
-  } = useParticipants();
+const ParticipantCard = React.memo<CardBodyProps>(
+  ({ member, isCurrentUserResponsible, isCurrentUserSAdmin, isMemberCurrentUser, isOpen }) => {
+    const {
+      addAndRemoveBoardParticipants: { mutate },
+    } = useParticipants();
 
-  const router = useRouter();
-  const boardId = router.query.boardId as string;
+    const router = useRouter();
+    const boardId = router.query.boardId as string;
+    const [boardParticipants, setBoardParticipants] = useRecoilState(boardParticipantsState);
 
-  const handleRemove = () => {
-    if (!member._id) return;
+    const isMemberResponsible = member.role === BoardUserRoles.RESPONSIBLE;
 
-    const boardUsersToUpdate: BoardUserAddAndRemove = {
-      addBoardUsers: [],
-      removeBoardUsers: [member._id],
-      boardId,
+    const handleRemove = () => {
+      if (!member._id) return;
+
+      const boardUsersToUpdate: BoardUserAddAndRemove = {
+        addBoardUsers: [],
+        removeBoardUsers: [member._id],
+        boardId,
+      };
+
+      mutate(boardUsersToUpdate);
     };
 
-    mutate(boardUsersToUpdate);
-  };
-  return (
-    <Flex css={{ flex: '1 1 1' }} direction="column">
-      <Flex>
-        <InnerContainer
-          align="center"
-          elevation="1"
-          justify="between"
-          css={{
-            position: 'relative',
-            flex: '1 1 0',
-            py: '$22',
-            maxHeight: '$76',
-            ml: 0,
-          }}
-        >
-          <Flex align="center" css={{ width: '100%' }} gap="8">
-            <Icon
-              name="blob-personal"
-              css={{
-                width: '32px',
-                height: '$32',
-                zIndex: 1,
-                opacity: isOpen ? 0.2 : 1,
-              }}
-            />
-            <Flex align="center" gap="8" justify="start" css={{ width: '50%' }}>
-              <StyledMemberTitle>
-                {`${member.user.firstName} ${member.user.lastName}`}
-              </StyledMemberTitle>
-            </Flex>
-            {!isBoardCreator && (
-              <Flex align="center" css={{ width: '50%' }} justify="end">
-                <Tooltip content="Remove participant">
-                  <Flex justify="end">
-                    <IconButton
-                      onClick={handleRemove}
-                      css={{
-                        '&:hover': {
-                          cursor: 'pointer',
-                        },
-                      }}
-                    >
-                      <Icon
-                        name="trash-alt"
-                        css={{
-                          color: '$primary400',
-                          size: '$20',
-                        }}
-                      />
-                    </IconButton>
-                  </Flex>
-                </Tooltip>
+    const updateIsResponsibleStatus = (checked: boolean) => {
+      // if (member.team) {
+      //   const updateTeamUser: TeamUserUpdate = {
+      //     team: member.team,
+      //     user: member.user._id,
+      //     role: member.role,
+      //     isNewJoiner: checked,
+      //   };
+
+      //   mutate(updateTeamUser);
+      // }
+      const participantsList = [...boardParticipants];
+      const idxParticipantToUpdate = participantsList.findIndex(
+        (boardUser) => boardUser._id === member._id,
+      );
+      participantsList.splice(idxParticipantToUpdate, 1);
+      if (checked) {
+        participantsList.splice(idxParticipantToUpdate, 0, {
+          ...member,
+          role: BoardUserRoles.RESPONSIBLE,
+        });
+      } else {
+        participantsList.splice(idxParticipantToUpdate, 0, {
+          ...member,
+          role: BoardUserRoles.MEMBER,
+        });
+      }
+      setBoardParticipants(participantsList);
+    };
+
+    const handleSelectFunction = (checked: boolean) => updateIsResponsibleStatus(checked);
+
+    return (
+      <Flex css={{ flex: '1 1 1' }} direction="column">
+        <Flex>
+          <InnerContainer
+            align="center"
+            elevation="1"
+            justify="between"
+            css={{
+              position: 'relative',
+              flex: '1 1 0',
+              py: '$22',
+              maxHeight: '$76',
+              ml: 0,
+            }}
+          >
+            <Flex align="center" css={{ width: '100%' }} gap="8">
+              <Icon
+                name="blob-personal"
+                css={{
+                  width: '32px',
+                  height: '$32',
+                  zIndex: 1,
+                  opacity: isOpen ? 0.2 : 1,
+                }}
+              />
+              <Flex align="center" gap="8" justify="start" css={{ width: '50%' }}>
+                <StyledMemberTitle>
+                  {`${member.user.firstName} ${member.user.lastName}`}
+                </StyledMemberTitle>
               </Flex>
-            )}
-          </Flex>
-        </InnerContainer>
+
+              <Flex css={{ width: '50%' }} justify="between">
+                {(isCurrentUserSAdmin || isCurrentUserResponsible) && (
+                  <Flex align="center" gap="8" justify="start">
+                    <ConfigurationSwitchSettings
+                      handleCheckedChange={handleSelectFunction}
+                      isChecked={isMemberResponsible}
+                      text=""
+                      title="Responsible"
+                    />
+                  </Flex>
+                )}
+                {(isCurrentUserSAdmin || (isCurrentUserResponsible && !isMemberCurrentUser)) && (
+                  <Flex align="center" justify="end">
+                    <Tooltip content="Remove participant">
+                      <Flex justify="end">
+                        <IconButton
+                          onClick={handleRemove}
+                          css={{
+                            '&:hover': {
+                              cursor: 'pointer',
+                            },
+                          }}
+                        >
+                          <Icon
+                            name="trash-alt"
+                            css={{
+                              color: '$primary400',
+                              size: '$20',
+                            }}
+                          />
+                        </IconButton>
+                      </Flex>
+                    </Tooltip>
+                  </Flex>
+                )}
+
+                {isMemberResponsible && !isCurrentUserResponsible && !isCurrentUserSAdmin && (
+                  <Flex align="center" css={{ width: '100%' }} gap="8" justify="end">
+                    <Text size="sm" fontWeight="medium">
+                      Responsible
+                    </Text>
+                  </Flex>
+                )}
+              </Flex>
+            </Flex>
+          </InnerContainer>
+        </Flex>
       </Flex>
-    </Flex>
-  );
-});
+    );
+  },
+);
 
 export default ParticipantCard;

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantsLayout.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantsLayout.tsx
@@ -11,10 +11,15 @@ import { BoardUserAddAndRemove, BoardUserToAdd } from '@/types/board/board.user'
 import { UserList } from '@/types/team/userList';
 import { BoardUserRoles } from '@/utils/enums/board.user.roles';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 import { useRecoilValue } from 'recoil';
 
-const ParticipantsLayout: React.FC = ({ children }) => {
+interface Props {
+  children: ReactNode;
+  hasPermissionsToEdit: boolean;
+}
+
+const ParticipantsLayout = ({ children, hasPermissionsToEdit }: Props) => {
   const {
     addAndRemoveBoardParticipants: { mutate },
   } = useParticipants();
@@ -75,10 +80,12 @@ const ParticipantsLayout: React.FC = ({ children }) => {
       >
         <Flex justify="between">
           <Text heading="1">Participants</Text>
-          <Button size="md" onClick={handleOpen}>
-            <Icon css={{ color: 'white' }} name="plus" />
-            Add/remove participants
-          </Button>
+          {hasPermissionsToEdit && (
+            <Button size="md" onClick={handleOpen}>
+              <Icon css={{ color: 'white' }} name="plus" />
+              Add/remove participants
+            </Button>
+          )}
         </Flex>
         {children}
       </Flex>

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
@@ -1,19 +1,25 @@
 import React from 'react';
-import { useSession } from 'next-auth/react';
 import { useRecoilValue } from 'recoil';
 import Flex from '@/components/Primitives/Flex';
 import { ScrollableContent } from '@/components/Boards/MyBoards/styles';
 import { boardParticipantsState } from '@/store/board/atoms/board.atom';
-import ParticipantCard from './ParticipantCard.tsx';
+import { BoardUserRoles } from '@/utils/enums/board.user.roles';
+import { useSession } from 'next-auth/react';
 import ParticipantsLayout from './ParticipantsLayout';
+import ParticipantCard from './ParticipantCard.tsx';
 
 const ParticipantsList = () => {
+  const boardParticipants = useRecoilValue(boardParticipantsState);
   const { data: session } = useSession({ required: true });
 
-  const boardParticipants = useRecoilValue(boardParticipantsState);
+  const isResponsible = !!boardParticipants.find(
+    (boardUser) =>
+      boardUser.user._id === session?.user.id && boardUser.role === BoardUserRoles.RESPONSIBLE,
+  );
+  const isSAdmin = !!session?.user.isSAdmin;
 
   return (
-    <ParticipantsLayout>
+    <ParticipantsLayout hasPermissionsToEdit={isResponsible || isSAdmin}>
       <Flex direction="column">
         <ScrollableContent
           direction="column"
@@ -24,8 +30,10 @@ const ParticipantsList = () => {
           {boardParticipants?.map((member) => (
             <ParticipantCard
               key={member.user._id}
-              isBoardCreator={member.user._id === session?.user.id}
               member={member}
+              isMemberCurrentUser={member.user._id === session?.user.id}
+              isCurrentUserResponsible={isResponsible}
+              isCurrentUserSAdmin={isSAdmin}
             />
           ))}
         </ScrollableContent>

--- a/frontend/src/components/Board/RegularBoard/ReagularHeader/HeaderParticipants.tsx
+++ b/frontend/src/components/Board/RegularBoard/ReagularHeader/HeaderParticipants.tsx
@@ -1,0 +1,61 @@
+import { useSession } from 'next-auth/react';
+import { useRecoilValue } from 'recoil';
+
+import Flex from '@/components/Primitives/Flex';
+import Separator from '@/components/Primitives/Separator';
+import Text from '@/components/Primitives/Text';
+import { boardInfoState } from '@/store/board/atoms/board.atom';
+import { StyledBoardTitle } from '@/components/CardBoard/CardBody/CardTitle/partials/Title/styles';
+import AvatarGroup from '@/components/Primitives/Avatar/AvatarGroup';
+
+interface Props {
+  isParticipantsPage?: boolean;
+}
+
+const HeaderParticipants = ({ isParticipantsPage }: Props) => {
+  const { data: session } = useSession({ required: true });
+
+  // Atoms
+  const boardData = useRecoilValue(boardInfoState);
+
+  // Get Board Users
+  const { users } = boardData.board;
+
+  return (
+    <Flex gap="24">
+      <Flex align="center" gap="10">
+        {isParticipantsPage ? (
+          <Text size="sm">Participants</Text>
+        ) : (
+          <StyledBoardTitle>
+            <Text size="sm">Participants</Text>
+          </StyledBoardTitle>
+        )}
+        <AvatarGroup
+          isBoardsPage
+          responsible={false}
+          listUsers={users}
+          teamAdmins={false}
+          userId={session!.user.id}
+        />
+      </Flex>
+      <Flex align="center">
+        <Separator orientation="vertical" size="lg" />
+      </Flex>
+      <Flex align="center" gap="10">
+        <Text color="primary300" size="sm">
+          Board Creator
+        </Text>
+        <AvatarGroup
+          isBoardsPage
+          responsible
+          listUsers={users}
+          teamAdmins={false}
+          userId={session!.user.id}
+        />
+      </Flex>
+    </Flex>
+  );
+};
+
+export default HeaderParticipants;

--- a/frontend/src/components/Board/RegularBoard/ReagularHeader/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ReagularHeader/index.tsx
@@ -23,6 +23,7 @@ import {
   StyledLogo,
   TitleSection,
 } from '../../SplitBoard/Header/styles';
+import HeaderParticipants from './HeaderParticipants';
 
 interface Props {
   isParticipantsPage?: boolean;
@@ -174,40 +175,16 @@ const RegularBoardHeader = ({ isParticipantsPage }: Props) => {
           )}
 
           {isRegularBoardWithNoTeam && (
-            <Flex gap="24">
-              <Flex align="center" gap="10">
-                {isParticipantsPage ? (
-                  <Text size="sm">Participants</Text>
-                ) : (
-                  <Link href={`/boards/${_id}/participants`}>
-                    <StyledBoardTitle>
-                      <Text size="sm">Participants</Text>
-                    </StyledBoardTitle>
-                  </Link>
-                )}
-                <AvatarGroup
-                  isBoardsPage
-                  responsible={false}
-                  listUsers={users}
-                  teamAdmins={false}
-                  userId={session!.user.id}
-                />
-              </Flex>
-              <Flex align="center">
-                <Separator orientation="vertical" size="lg" />
-              </Flex>
-              <Flex align="center" gap="10">
-                <Text color="primary300" size="sm">
-                  Board Creator
-                </Text>
-                <AvatarGroup
-                  isBoardsPage
-                  responsible
-                  listUsers={users}
-                  teamAdmins={false}
-                  userId={session!.user.id}
-                />
-              </Flex>
+            <Flex>
+              {isParticipantsPage ? (
+                <HeaderParticipants isParticipantsPage />
+              ) : (
+                <Link href={`/boards/${_id}/participants`}>
+                  <Flex>
+                    <HeaderParticipants />
+                  </Flex>
+                </Link>
+              )}
             </Flex>
           )}
         </Flex>

--- a/frontend/src/components/Board/RegularBoard/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from 'react';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue } from 'recoil';
 
 import { Container } from '@/styles/pages/boards/board.styles';
 
@@ -10,11 +10,7 @@ import Icon from '@/components/icons/Icon';
 import LoadingPage from '@/components/loadings/LoadingPage';
 import Button from '@/components/Primitives/Button';
 import Flex from '@/components/Primitives/Flex';
-import {
-  boardInfoState,
-  deletedColumnsState,
-  editColumnsState,
-} from '@/store/board/atoms/board.atom';
+import { boardInfoState } from '@/store/board/atoms/board.atom';
 import EmitEvent from '@/types/events/emit-event.type';
 import ListenEvent from '@/types/events/listen-event.type';
 import { BoardUserRoles } from '@/utils/enums/board.user.roles';
@@ -34,15 +30,6 @@ const RegularBoard = ({ socketId, emitEvent, listenEvent }: RegularBoardProps) =
 
   // Recoil States
   const { board } = useRecoilValue(boardInfoState);
-  const setEditColumns = useSetRecoilState(editColumnsState);
-  const setDeletedColumns = useSetRecoilState(deletedColumnsState);
-
-  useMemo(() => {
-    if (!isOpen) {
-      setEditColumns(board.columns);
-      setDeletedColumns([]);
-    }
-  }, [board.columns, isOpen, setDeletedColumns, setEditColumns]);
 
   // Session Details
   const { data: session } = useSession({ required: true });


### PR DESCRIPTION
Relates to #1038 
Fixes #1031 

## Screenshots (if visual changes)
- Board Responsible view
![image](https://user-images.githubusercontent.com/116013814/218438745-d00cc875-9753-44b3-bac9-a5defa0cbb2f.png)
- Super admin view
![image](https://user-images.githubusercontent.com/116013814/218438951-94eb66e5-94af-466d-bfaa-28444a309ff6.png)
- Regular Board Participant
![image](https://user-images.githubusercontent.com/116013814/218439212-cdd31cfb-bf9f-4c16-97da-3d7386baf922.png)


## Proposed Changes

  - Add toggle to edit responsibles of a Regular board.
  - Show ad/remove participants and responsible toggle when user has permissions.


This pull request closes #1031 