### PR TITLE
fix: renamed keys of atoms

### DIFF
--- a/frontend/src/store/operations/atom/operations-queue.atom.ts
+++ b/frontend/src/store/operations/atom/operations-queue.atom.ts
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 
 export const operationsQueueAtom = atom<Boolean>({
-  key: 'usersWithTeams',
+  key: 'operationsQueueAtom',
   default: true,
 });

--- a/frontend/src/store/vote/atoms/vote.atom.tsx
+++ b/frontend/src/store/vote/atoms/vote.atom.tsx
@@ -1,6 +1,6 @@
 import { atom } from 'recoil';
 
 export const maxVotesReachedAtom = atom<{ maxVotesReached: boolean; noVotes: boolean }>({
-  key: 'usersWithTeams',
+  key: 'maxVotesReachedAtom',
   default: { maxVotesReached: false, noVotes: false },
 });


### PR DESCRIPTION
Fixes #1079 

## Screenshots (if visual changes)

## Proposed Changes

  - Fix duplicated key name of atoms ('usersWithTeams') used on 3 atoms.


This pull request closes #1079 