### PR TITLE
fix: placeholder replaces card

### DIFF
--- a/frontend/src/components/Board/Card/CardBoard.tsx
+++ b/frontend/src/components/Board/Card/CardBoard.tsx
@@ -35,6 +35,7 @@ interface CardBoardProps {
   socketId: string;
   isMainboard: boolean;
   boardUser?: BoardUser;
+  cardTextDefault?: string;
   maxVotes?: number;
   isSubmited: boolean;
   hideCards: boolean;
@@ -63,6 +64,7 @@ const CardBoard = React.memo<CardBoardProps>(
     hasAdminRole,
     postAnonymously,
     isRegularBoard,
+    cardTextDefault,
   }) => {
     const isCardGroup = card.items.length > 1;
     const comments = useMemo(
@@ -146,6 +148,7 @@ const CardBoard = React.memo<CardBoardProps>(
                   cardId={card._id}
                   cardItemId={card.items[0]._id}
                   cardText={card.text}
+                  cardTextDefault={cardTextDefault}
                   colId={colId}
                   socketId={socketId}
                   anonymous={card.anonymous}
@@ -219,6 +222,7 @@ const CardBoard = React.memo<CardBoardProps>(
                       isDefaultText={isDefaultText}
                       hasAdminRole={hasAdminRole}
                       postAnonymously={postAnonymously}
+                      cardTextDefault={cardTextDefault}
                     />
                   )}
                   <CardFooter

--- a/frontend/src/components/Board/Card/CardItem/CardItem.tsx
+++ b/frontend/src/components/Board/Card/CardItem/CardItem.tsx
@@ -28,6 +28,7 @@ interface CardItemProps {
   isDefaultText: boolean;
   hasAdminRole: boolean;
   postAnonymously: boolean;
+  cardTextDefault?: string;
 }
 
 const Container = styled(Flex, {
@@ -55,6 +56,7 @@ const CardItem: React.FC<CardItemProps> = React.memo(
     isDefaultText,
     hasAdminRole,
     postAnonymously,
+    cardTextDefault,
   }) => {
     const [editing, setEditing] = useState(false);
     const [deleting, setDeleting] = useState(false);
@@ -130,6 +132,7 @@ const CardItem: React.FC<CardItemProps> = React.memo(
             anonymous={item.anonymous}
             isDefaultText={isDefaultText}
             postAnonymously={postAnonymously}
+            cardTextDefault={cardTextDefault}
           />
         )}
         {deleting && (

--- a/frontend/src/components/Board/Card/CardItem/CardItemList.tsx
+++ b/frontend/src/components/Board/Card/CardItem/CardItemList.tsx
@@ -19,6 +19,7 @@ interface CardItemListProps {
   isDefaultText: boolean;
   hasAdminRole: boolean;
   postAnonymously: boolean;
+  cardTextDefault?: string;
 }
 
 const CardItemList: React.FC<CardItemListProps> = ({
@@ -36,6 +37,7 @@ const CardItemList: React.FC<CardItemListProps> = ({
   isDefaultText,
   hasAdminRole,
   postAnonymously,
+  cardTextDefault,
 }) => (
   <Flex direction="column">
     {items.map((item, idx) => (
@@ -69,6 +71,7 @@ const CardItemList: React.FC<CardItemListProps> = ({
           isDefaultText={isDefaultText}
           hasAdminRole={hasAdminRole}
           postAnonymously={postAnonymously}
+          cardTextDefault={cardTextDefault}
         />
       </Flex>
     ))}

--- a/frontend/src/components/Board/Column/CardsList.tsx
+++ b/frontend/src/components/Board/Column/CardsList.tsx
@@ -6,6 +6,7 @@ import CardBoard from '../Card/CardBoard';
 
 type CardListProps = {
   isRegularBoard?: boolean;
+  cardTextDefault?: string;
 } & ColumnInnerList;
 
 const CardsList = React.memo<CardListProps>(
@@ -25,6 +26,7 @@ const CardsList = React.memo<CardListProps>(
     hasAdminRole,
     postAnonymously,
     isRegularBoard,
+    cardTextDefault,
   }) => (
     <>
       {cards.map((card: CardType, idx) => (
@@ -46,6 +48,7 @@ const CardsList = React.memo<CardListProps>(
           hasAdminRole={hasAdminRole}
           postAnonymously={postAnonymously}
           isRegularBoard={isRegularBoard}
+          cardTextDefault={cardTextDefault}
         />
       ))}
     </>

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -192,9 +192,11 @@ const Column = React.memo<ColumMemoProps>(
                               isUpdate={false}
                               socketId={socketId}
                               anonymous={undefined}
-                              cardText={cardText}
+                              cardTextDefault={cardText}
                               isDefaultText={isDefaultText ?? true}
                               postAnonymously={postAnonymously}
+                              columnName={title}
+                              isRegularBoard={isRegularBoard}
                             />
                           )}
                         </Flex>
@@ -219,6 +221,7 @@ const Column = React.memo<ColumMemoProps>(
                           hasAdminRole={hasAdminRole}
                           postAnonymously={postAnonymously}
                           isRegularBoard={isRegularBoard}
+                          cardTextDefault={cardText}
                         />
                         {provided.placeholder}
                       </CardsContainer>

--- a/frontend/src/components/Board/DragDropArea/index.tsx
+++ b/frontend/src/components/Board/DragDropArea/index.tsx
@@ -106,6 +106,7 @@ const DragDropArea: React.FC<Props> = ({
 
     mutateBoard({
       ...boardState.board,
+      team: boardState.board.team ? boardState.board.team.id : undefined,
       columns: columnsArray,
       responsible: boardState.board.users?.find((user) => user.role === BoardUserRoles.RESPONSIBLE),
       socketId,

--- a/frontend/src/helper/board/defaultColumns.ts
+++ b/frontend/src/helper/board/defaultColumns.ts
@@ -1,24 +1,26 @@
+import { CARD_TEXT_DEFAULT, CARD_TEXT_TO_IMPROVE_SPLIT_COLUMN } from '@/utils/constants';
+
 export const defaultRegularColumns = [
   {
     title: 'Went well',
     color: '$highlight1Light',
     cards: [],
     isDefaultText: true,
-    cardText: 'Write your comment here...',
+    cardText: CARD_TEXT_DEFAULT,
   },
   {
     title: 'To improve',
     color: '$highlight4Light',
     cards: [],
     isDefaultText: true,
-    cardText: 'Write your comment here...',
+    cardText: CARD_TEXT_DEFAULT,
   },
   {
     title: 'Action points',
     color: '$highlight3Light',
     cards: [],
     isDefaultText: true,
-    cardText: 'Write your comment here...',
+    cardText: CARD_TEXT_DEFAULT,
   },
 ];
 
@@ -28,20 +30,20 @@ export const defaultSplitColumns = [
     color: '$highlight1Light',
     cards: [],
     isDefaultText: true,
-    cardText: 'Write your comment here...',
+    cardText: CARD_TEXT_DEFAULT,
   },
   {
     title: 'To improve',
     color: '$highlight4Light',
     cards: [],
     isDefaultText: true,
-    cardText: `Description: \n\nHow to improve:`,
+    cardText: CARD_TEXT_TO_IMPROVE_SPLIT_COLUMN,
   },
   {
     title: 'Action points',
     color: '$highlight3Light',
     cards: [],
     isDefaultText: true,
-    cardText: 'Write your comment here...',
+    cardText: CARD_TEXT_DEFAULT,
   },
 ];

--- a/frontend/src/types/board/board.ts
+++ b/frontend/src/types/board/board.ts
@@ -90,4 +90,5 @@ export type UpdateBoardType = {
   addCards: boolean;
   responsible?: BoardUser;
   postAnonymously: boolean;
+  team?: string;
 };

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -55,3 +55,7 @@ export const BOARD_TIMER_SERVER_TIME_LEFT_UPDATED = 'board-timer.server.time-lef
 export const BOARD_TIMER_USER_REQUESTED_TIMER_STATE = 'board-timer.user.requested.timer-state';
 
 export const BOARD_TIMER_SERVER_SENT_TIMER_STATE = 'board-timer.server.sent.timer-state';
+
+export const CARD_TEXT_DEFAULT = 'Write your comment here...';
+
+export const CARD_TEXT_TO_IMPROVE_SPLIT_COLUMN = `Description: \n\nHow to improve:`;


### PR DESCRIPTION

Fixes #1090 


## Proposed Changes

  - When editing a card, the textarea value is the text of the card and not the placeholder (previous behavior)
  - On a regular board, when the "default card text" is active, the placeholder also acts as value for the textarea
  - Fix toggle when user toggles the default car text button
  - Add team to UpdateBoardType's schema and pass team id field when updating a column position


This pull request closes #1090 