### PR TITLE
fix: textarea validation state

### DIFF
--- a/frontend/src/components/Board/AddCardOrComment.tsx
+++ b/frontend/src/components/Board/AddCardOrComment.tsx
@@ -118,13 +118,6 @@ const AddCard = React.memo<AddCardProps>(
         ? '$primary300'
         : '$primaryBase';
 
-    const state =
-      watchCardTextInput.text !== CARD_TEXT_DEFAULT &&
-      watchCardTextInput.text === placeholder &&
-      methods.formState.touchedFields
-        ? 'default'
-        : undefined;
-
     const disabledButton =
       watchCardTextInput.text?.trim().length === 0 || watchCardTextInput.text === placeholder;
 
@@ -263,12 +256,7 @@ const AddCard = React.memo<AddCardProps>(
         })}
       >
         <FormProvider {...methods}>
-          <TextArea
-            id="text"
-            placeholder={placeholderToDisplay}
-            textColor={placeholderColor}
-            state={state}
-          />
+          <TextArea id="text" placeholder={placeholderToDisplay} textColor={placeholderColor} />
           <Flex css={{ width: '100%' }} justify="end">
             {!isCard && (isOwner || !commentId) && (
               // This is when you are editing a card / comment

--- a/frontend/src/components/Primitives/TextArea.tsx
+++ b/frontend/src/components/Primitives/TextArea.tsx
@@ -59,16 +59,16 @@ const StyledTextArea = styled('textarea', {
       default: {
         '&:focus': {
           borderColor: '$primary400',
-          boxShadow: '0px 0px 0px 2px $colors$primaryLightest)',
+          boxShadow: '0px 0px 0px 2px $colors$primaryLightest',
         },
       },
       valid: {
         borderColor: '$success700',
-        boxShadow: '0px 0px 0px 2px $colors$successLightest)',
+        boxShadow: '0px 0px 0px 2px $colors$successLightest',
       },
       error: {
         borderColor: '$danger700',
-        boxShadow: '0px 0px 0px 2px $colors$dangerLightest)',
+        boxShadow: '0px 0px 0px 2px $colors$dangerLightest',
       },
     },
   },
@@ -78,20 +78,12 @@ interface ResizableTextAreaProps {
   id: string;
   placeholder: string;
   disabled?: boolean;
-  state?: 'valid' | 'default' | 'error';
   textColor?: '$primaryBase' | '$primary300';
 }
 
-const TextArea: React.FC<ResizableTextAreaProps> = ({
-  id,
-  placeholder,
-  disabled,
-  state,
-  textColor,
-}) => {
+const TextArea: React.FC<ResizableTextAreaProps> = ({ id, placeholder, disabled, textColor }) => {
   TextArea.defaultProps = {
     disabled: false,
-    state: undefined,
     textColor: '$primaryBase',
   };
 
@@ -106,25 +98,20 @@ const TextArea: React.FC<ResizableTextAreaProps> = ({
   const {
     register,
     getValues,
-    formState: { errors, touchedFields },
+    formState: { errors, dirtyFields },
   } = useFormContext();
   const { ref, ...rest } = register(id);
 
-  const message = errors[id]?.message;
   const value = getValues()[id];
   const isValueEmpty = isEmpty(value);
 
-  const autoState = useMemo(() => {
-    if (message) return 'error';
-    if (isValueEmpty || (value && !touchedFields.text)) return 'default';
-    return 'valid';
-  }, [message, isValueEmpty, value, touchedFields.text]);
+  const getCurrentState = useMemo(() => {
+    if (errors[id]) return 'error';
+    if (!dirtyFields[id]) return 'default';
+    if (!isValueEmpty) return 'valid';
 
-  const currentState = useMemo(() => {
-    if (disabled && !touchedFields[id]) return 'default';
-    if (state) return state;
-    return autoState;
-  }, [autoState, disabled, id, state, touchedFields]);
+    return 'default';
+  }, [errors[id], dirtyFields[id], isValueEmpty]);
 
   useEffect(() => {
     textAreaAdjust(textareaRef.current);
@@ -143,7 +130,7 @@ const TextArea: React.FC<ResizableTextAreaProps> = ({
       disabled={disabled}
       id={id}
       placeholder={placeholder}
-      variant={currentState}
+      variant={getCurrentState}
       ref={(e) => {
         if (ref) ref(e);
         textareaRef.current = e;


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #1096
Fixes #1096 

## Proposed Changes

  - Let the textarea primitive component decide for itself whether it has a state of error, valid or default based on the information provided by its form.

<!--
Mention people who discussed this issue previously
@StereoPT 
-->


This pull request closes #1096 