### PR TITLE
feat: alert box primitive story

### DIFF
--- a/frontend/src/components/Board/Column/styles.tsx
+++ b/frontend/src/components/Board/Column/styles.tsx
@@ -41,7 +41,6 @@ const OuterContainer = styled(Flex, {
   flexGrow: 1,
   flexShrink: 0,
   width: '100%',
-  mx: '$12',
 });
 
 const Title = styled(Text, {

--- a/frontend/src/components/Board/DragDropArea/index.tsx
+++ b/frontend/src/components/Board/DragDropArea/index.tsx
@@ -190,7 +190,7 @@ const DragDropArea: React.FC<Props> = ({
       isDropDisabled={isMainboard || !hasAdminRole}
     >
       {(provided) => (
-        <Container ref={provided.innerRef} {...provided.droppableProps}>
+        <Container css={{ gap: '$24' }} ref={provided.innerRef} {...provided.droppableProps}>
           {board.columns.map((column, index) => (
             <Column
               key={column._id}

--- a/frontend/src/components/Primitives/AlertBox/index.tsx
+++ b/frontend/src/components/Primitives/AlertBox/index.tsx
@@ -17,7 +17,7 @@ const AlertBox: FC<AlertBoxProps> = ({ type, title, text, children, css }) => (
   <AlertStyle align="center" css={css} justify="between" type={type}>
     <Flex align="center">
       <AlertIconStyle>
-        <Icon name={['warning', 'error'].includes(type) ? 'blob-error' : 'blob-info'} />
+        <Icon name={`blob-${type}`} />
       </AlertIconStyle>
       <AlertText direction="column">
         {!!title && <Text heading="5">{title}</Text>}

--- a/frontend/src/components/Primitives/AlertBox/styles.tsx
+++ b/frontend/src/components/Primitives/AlertBox/styles.tsx
@@ -6,8 +6,8 @@ const AlertStyle = styled(Flex, {
   variants: {
     type: {
       warning: {
-        backgroundColor: '$infoLightest',
-        border: '1px solid $colors$infoBase',
+        backgroundColor: '$warningLightest',
+        border: '1px solid $colors$warningBase',
       },
       error: {
         backgroundColor: '$dangerLightest',

--- a/frontend/src/stories/AlertBox.stories.tsx
+++ b/frontend/src/stories/AlertBox.stories.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { ComponentStory } from '@storybook/react';
+
+import dedent from 'ts-dedent';
+
+import AlertBox from '@/components/Primitives/AlertBox';
+
+export default {
+  title: 'Primitives/AlertBox',
+  component: AlertBox,
+  parameters: {
+    docs: {
+      description: {
+        component: dedent`
+        An alert box that is displayed on the screen to inform or warn the user of something.
+
+        **File Path:**
+        \`@/components/Primitives/AlertBox/index.tsx\` and \`@/components/Primitives/AlertBox/styles.tsx\`
+        `,
+      },
+    },
+  },
+  args: {
+    type: 'info',
+  },
+  argTypes: {
+    title: {
+      control: false,
+      description: 'Content of the title of the alert box.',
+    },
+    text: {
+      control: false,
+      description: 'Content of the body of the alert box.',
+    },
+    type: {
+      description: 'Type of the component.',
+    },
+  },
+};
+
+const Template: ComponentStory<typeof AlertBox> = ({ type }) => (
+  <AlertBox
+    title="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    text="Aut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."
+    type={type}
+  />
+);
+
+export const Default = Template.bind({});
+Default.storyName = 'Basic Usage';


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #1112 
Fixes #1112

## Proposed Changes

  - Add a gap between board columns so the alert box is aligned on the left side. How it was before:

![image](https://user-images.githubusercontent.com/24455614/219708410-a6db882b-c64c-4884-bd39-5a3ea08bad12.png)

Now:

![image](https://user-images.githubusercontent.com/24455614/219708626-0160ee4f-958c-4d68-919e-8c780a12feab.png)

  - Add the AlertBox primitive to Storybook

<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #1112