### PR TITLE
fix: fix board page scroll and add margin bottom

### DIFF
--- a/frontend/src/components/Board/DragDropArea/index.tsx
+++ b/frontend/src/components/Board/DragDropArea/index.tsx
@@ -18,7 +18,7 @@ import { boardInfoState } from '@/store/board/atoms/board.atom';
 import { BoardUserRoles } from '@/utils/enums/board.user.roles';
 import ColumnType from '@/types/column';
 
-const Container = styled(Flex, { maxHeight: '100vh', width: '100%', display: 'inline-flex' });
+const Container = styled(Flex, { width: '100%', display: 'inline-flex', mb: '$32' });
 
 type Props = {
   userId: string;


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #1114 
Fixes #1114 

## Proposed Changes

  - Fix board page limited scroll
  - Add margin bottom to the drag and drop area in the board page


<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #1114