### PR TITLE
fix: add comment on own cards if they are hidden

### DIFF
--- a/frontend/src/components/Board/Card/CardFooter.tsx
+++ b/frontend/src/components/Board/Card/CardFooter.tsx
@@ -238,7 +238,7 @@ const CardFooter = ({
               variant="light"
               size="sm"
               css={{ color: '$primary500' }}
-              disabled={hideCards}
+              disabled={hideCards && card.createdBy?._id !== userId}
               onClick={setOpenComments}
             >
               <Icon name={isCommentsOpened ? 'comment-filled' : 'comment'} />


### PR DESCRIPTION
<!--
#1102 
-->

Fixes #1102

## Proposed Changes

  - Disable comments button only if the cards are hidden and the cards don't belong to the logged user

<!--
Mention people who discussed this issue previously
@someone
-->

This pull request closes #1102 