### PR TITLE
refactor: team participants page

### DIFF
--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -1,5 +1,4 @@
 import { userRepository } from 'src/modules/users/users.providers';
-import { UserRepository } from './../users/repository/user.repository';
 import { mongooseBoardUserModule } from './../../infrastructure/database/mongoose.module';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';

--- a/backend/src/modules/auth/services/register.auth.service.ts
+++ b/backend/src/modules/auth/services/register.auth.service.ts
@@ -1,5 +1,4 @@
 import { UserRepositoryInterface } from './../../users/repository/user.repository.interface';
-import { userRepository } from 'src/modules/users/users.providers';
 import { GetTokenAuthService } from 'src/modules/auth/interfaces/services/get-token.auth.service.interface';
 import { BOARD_USER_NOT_FOUND, INSERT_FAILED } from 'src/libs/exceptions/messages';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';

--- a/backend/src/modules/auth/services/register.auth.service.ts
+++ b/backend/src/modules/auth/services/register.auth.service.ts
@@ -54,7 +54,7 @@ export default class RegisterAuthServiceImpl implements RegisterAuthService {
 			throw new BadRequestException(BOARD_USER_NOT_FOUND);
 		}
 
-		const { _id, firstName, lastName } = userFound.user as User;
+		const { _id, firstName, lastName, isAnonymous } = userFound.user as User;
 
 		return {
 			role: userFound.role,
@@ -63,7 +63,8 @@ export default class RegisterAuthServiceImpl implements RegisterAuthService {
 			user: {
 				_id: String(_id),
 				firstName,
-				lastName
+				lastName,
+				isAnonymous
 			}
 		};
 	}

--- a/backend/src/modules/boards/services/get.board.service.ts
+++ b/backend/src/modules/boards/services/get.board.service.ts
@@ -152,7 +152,7 @@ export default class GetBoardServiceImpl implements GetBoardServiceInterface {
 					select: 'user role -board',
 					populate: {
 						path: 'user',
-						select: '_id firstName email lastName'
+						select: '_id firstName email lastName isAnonymous'
 					}
 				})
 				.lean({ virtuals: true })

--- a/backend/src/modules/boards/utils/populate-board.ts
+++ b/backend/src/modules/boards/utils/populate-board.ts
@@ -4,7 +4,7 @@ export const BoardDataPopulate: PopulateOptions[] = [
 	{
 		path: 'users',
 		select: 'user role -board votesCount',
-		populate: { path: 'user', select: 'firstName email lastName _id' }
+		populate: { path: 'user', select: 'firstName email lastName _id isAnonymous' }
 	},
 	{
 		path: 'team',
@@ -49,7 +49,7 @@ export const GetBoardDataPopulate: PopulateOptions[] = [
 	{
 		path: 'users',
 		select: 'user role -board votesCount',
-		populate: { path: 'user', select: 'firstName email lastName _id' }
+		populate: { path: 'user', select: 'firstName email lastName _id isAnonymous' }
 	},
 	{
 		path: 'team',

--- a/backend/src/modules/users/dto/guest.user.dto.ts
+++ b/backend/src/modules/users/dto/guest.user.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsMongoId, IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { IsBoolean, IsMongoId, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 
 export default class GuestUserDto {
 	@ApiProperty()
@@ -18,4 +18,8 @@ export default class GuestUserDto {
 	@IsOptional()
 	@IsString()
 	lastName?: string;
+
+	@IsOptional()
+	@IsBoolean()
+	isAnonymous?: boolean;
 }

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantCard.tsx/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantCard.tsx/index.tsx
@@ -20,7 +20,7 @@ type CardBodyProps = {
   isCurrentUserResponsible: boolean;
   isCurrentUserSAdmin: boolean;
   isMemberCurrentUser: boolean;
-  responibleToggleDisabled: boolean;
+  haveInvalidNumberOfResponsibles: boolean;
   isOpen?: boolean;
 };
 
@@ -31,7 +31,7 @@ const ParticipantCard = React.memo<CardBodyProps>(
     isCurrentUserSAdmin,
     isMemberCurrentUser,
     isOpen,
-    responibleToggleDisabled,
+    haveInvalidNumberOfResponsibles,
   }) => {
     const {
       addAndRemoveBoardParticipants: { mutate },
@@ -108,9 +108,8 @@ const ParticipantCard = React.memo<CardBodyProps>(
                       isChecked={isMemberResponsible}
                       text=""
                       title="Responsible"
-                      disabled={
-                        responibleToggleDisabled && isMemberCurrentUser && !isCurrentUserSAdmin
-                      }
+                      disabledInfo="Select another responsible for the board"
+                      disabled={haveInvalidNumberOfResponsibles && isMemberResponsible}
                     />
                   </Flex>
                 )}

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantCard.tsx/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantCard.tsx/index.tsx
@@ -20,11 +20,19 @@ type CardBodyProps = {
   isCurrentUserResponsible: boolean;
   isCurrentUserSAdmin: boolean;
   isMemberCurrentUser: boolean;
+  responibleToggleDisabled: boolean;
   isOpen?: boolean;
 };
 
 const ParticipantCard = React.memo<CardBodyProps>(
-  ({ member, isCurrentUserResponsible, isCurrentUserSAdmin, isMemberCurrentUser, isOpen }) => {
+  ({
+    member,
+    isCurrentUserResponsible,
+    isCurrentUserSAdmin,
+    isMemberCurrentUser,
+    isOpen,
+    responibleToggleDisabled,
+  }) => {
     const {
       addAndRemoveBoardParticipants: { mutate },
     } = useParticipants();
@@ -100,6 +108,9 @@ const ParticipantCard = React.memo<CardBodyProps>(
                       isChecked={isMemberResponsible}
                       text=""
                       title="Responsible"
+                      disabled={
+                        responibleToggleDisabled && isMemberCurrentUser && !isCurrentUserSAdmin
+                      }
                     />
                   </Flex>
                 )}

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantCard.tsx/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/ParticipantCard.tsx/index.tsx
@@ -21,6 +21,7 @@ type CardBodyProps = {
   isCurrentUserSAdmin: boolean;
   isMemberCurrentUser: boolean;
   haveInvalidNumberOfResponsibles: boolean;
+  responsibleSignedUpUsers: BoardUser[];
   isOpen?: boolean;
 };
 
@@ -32,6 +33,7 @@ const ParticipantCard = React.memo<CardBodyProps>(
     isMemberCurrentUser,
     isOpen,
     haveInvalidNumberOfResponsibles,
+    responsibleSignedUpUsers,
   }) => {
     const {
       addAndRemoveBoardParticipants: { mutate },
@@ -68,6 +70,14 @@ const ParticipantCard = React.memo<CardBodyProps>(
     };
 
     const handleSelectFunction = (checked: boolean) => updateIsResponsibleStatus(checked);
+
+    let memberOnlySignedUpResponsible: boolean = false;
+
+    if (haveInvalidNumberOfResponsibles) {
+      memberOnlySignedUpResponsible = !!responsibleSignedUpUsers.find(
+        (boardUser) => boardUser.user._id === member.user._id,
+      );
+    }
 
     return (
       <Flex css={{ flex: '1 1 1' }} direction="column">
@@ -109,7 +119,7 @@ const ParticipantCard = React.memo<CardBodyProps>(
                       text=""
                       title="Responsible"
                       disabledInfo="Select another responsible for the board"
-                      disabled={haveInvalidNumberOfResponsibles && isMemberResponsible}
+                      disabled={memberOnlySignedUpResponsible && !isCurrentUserSAdmin}
                     />
                   </Flex>
                 )}

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
@@ -5,6 +5,7 @@ import { ScrollableContent } from '@/components/Boards/MyBoards/styles';
 import { boardParticipantsState } from '@/store/board/atoms/board.atom';
 import { BoardUserRoles } from '@/utils/enums/board.user.roles';
 import { useSession } from 'next-auth/react';
+import { getGuestUserCookies } from '@/utils/getGuestUserCookies';
 import ParticipantsLayout from './ParticipantsLayout';
 import ParticipantCard from './ParticipantCard.tsx';
 
@@ -12,10 +13,12 @@ const ParticipantsList = () => {
   const boardParticipants = useRecoilValue(boardParticipantsState);
   const { data: session } = useSession();
 
+  const userId = session ? session.user.id : getGuestUserCookies().user;
+
   const isResponsible = !!boardParticipants.find(
-    (boardUser) =>
-      boardUser.user._id === session?.user.id && boardUser.role === BoardUserRoles.RESPONSIBLE,
+    (boardUser) => boardUser.user._id === userId && boardUser.role === BoardUserRoles.RESPONSIBLE,
   );
+
   const isSAdmin = !!session?.user.isSAdmin;
 
   return (
@@ -31,7 +34,7 @@ const ParticipantsList = () => {
             <ParticipantCard
               key={member.user._id}
               member={member}
-              isMemberCurrentUser={member.user._id === session?.user.id}
+              isMemberCurrentUser={member.user._id === userId}
               isCurrentUserResponsible={isResponsible}
               isCurrentUserSAdmin={isSAdmin}
             />

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
@@ -22,6 +22,21 @@ const ParticipantsList = () => {
 
   const isSAdmin = !!session?.user.isSAdmin;
 
+  const responsiblesList = boardParticipants.filter(
+    (boardUser) => boardUser.role === BoardUserRoles.RESPONSIBLE,
+  );
+
+  const responsibleGuestUsers = responsiblesList.filter((boardUser) => boardUser.user.isAnonymous);
+
+  const responsibleSignedUpUsers = responsiblesList.filter(
+    (boardUser) => !boardUser.user.isAnonymous,
+  );
+
+  const condition =
+    responsiblesList.length < 2 ||
+    responsibleGuestUsers.length === responsiblesList.length ||
+    responsibleSignedUpUsers.length < 2;
+
   return (
     <ParticipantsLayout hasPermissionsToEdit={isResponsible || isSAdmin}>
       <Flex direction="column">
@@ -38,6 +53,7 @@ const ParticipantsList = () => {
               isMemberCurrentUser={member.user._id === userId}
               isCurrentUserResponsible={isResponsible}
               isCurrentUserSAdmin={isSAdmin}
+              responibleToggleDisabled={condition}
             />
           ))}
         </ScrollableContent>

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
@@ -26,16 +26,11 @@ const ParticipantsList = () => {
     (boardUser) => boardUser.role === BoardUserRoles.RESPONSIBLE,
   );
 
-  const responsibleGuestUsers = responsiblesList.filter((boardUser) => boardUser.user.isAnonymous);
-
   const responsibleSignedUpUsers = responsiblesList.filter(
     (boardUser) => !boardUser.user.isAnonymous,
   );
 
-  const haveInvalidNumberOfResponsibles =
-    responsiblesList.length < 2 ||
-    responsibleGuestUsers.length === responsiblesList.length ||
-    responsibleSignedUpUsers.length < 2;
+  const haveInvalidNumberOfResponsibles = responsibleSignedUpUsers.length < 2;
 
   return (
     <ParticipantsLayout hasPermissionsToEdit={isResponsible || isSAdmin}>
@@ -54,6 +49,7 @@ const ParticipantsList = () => {
               isCurrentUserResponsible={isResponsible}
               isCurrentUserSAdmin={isSAdmin}
               haveInvalidNumberOfResponsibles={haveInvalidNumberOfResponsibles}
+              responsibleSignedUpUsers={responsibleSignedUpUsers}
             />
           ))}
         </ScrollableContent>

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
@@ -32,7 +32,7 @@ const ParticipantsList = () => {
     (boardUser) => !boardUser.user.isAnonymous,
   );
 
-  const condition =
+  const haveInvalidNumberOfResponsibles =
     responsiblesList.length < 2 ||
     responsibleGuestUsers.length === responsiblesList.length ||
     responsibleSignedUpUsers.length < 2;
@@ -53,7 +53,7 @@ const ParticipantsList = () => {
               isMemberCurrentUser={member.user._id === userId}
               isCurrentUserResponsible={isResponsible}
               isCurrentUserSAdmin={isSAdmin}
-              responibleToggleDisabled={condition}
+              haveInvalidNumberOfResponsibles={haveInvalidNumberOfResponsibles}
             />
           ))}
         </ScrollableContent>

--- a/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ParticipantsList/index.tsx
@@ -13,7 +13,8 @@ const ParticipantsList = () => {
   const boardParticipants = useRecoilValue(boardParticipantsState);
   const { data: session } = useSession();
 
-  const userId = session ? session.user.id : getGuestUserCookies().user;
+  // User Id
+  const userId = getGuestUserCookies() ? getGuestUserCookies().user : session?.user.id;
 
   const isResponsible = !!boardParticipants.find(
     (boardUser) => boardUser.user._id === userId && boardUser.role === BoardUserRoles.RESPONSIBLE,

--- a/frontend/src/components/Board/RegularBoard/ReagularHeader/HeaderParticipants.tsx
+++ b/frontend/src/components/Board/RegularBoard/ReagularHeader/HeaderParticipants.tsx
@@ -44,7 +44,7 @@ const HeaderParticipants = ({ isParticipantsPage }: Props) => {
       </Flex>
       <Flex align="center" gap="10">
         <Text color="primary300" size="sm">
-          Board Creator
+          Responsibles
         </Text>
         <AvatarGroup
           responsible

--- a/frontend/src/components/Board/RegularBoard/ReagularHeader/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ReagularHeader/index.tsx
@@ -30,7 +30,7 @@ interface Props {
 }
 
 const RegularBoardHeader = ({ isParticipantsPage }: Props) => {
-  const { data: session } = useSession();
+  const { data: session } = useSession({ required: false });
 
   // Atoms
   const boardData = useRecoilValue(boardInfoState);

--- a/frontend/src/components/Board/RegularBoard/ReagularHeader/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ReagularHeader/index.tsx
@@ -1,21 +1,14 @@
-import { useSession } from 'next-auth/react';
 import { useRecoilValue } from 'recoil';
 
 import Breadcrumb from '@/components/Primitives/Breadcrumb';
 import Icon from '@/components/Primitives/Icon';
 import LogoIcon from '@/components/icons/Logo';
 import Flex from '@/components/Primitives/Flex';
-import Separator from '@/components/Primitives/Separator';
 import Text from '@/components/Primitives/Text';
 import Tooltip from '@/components/Primitives/Tooltip';
 import { boardInfoState } from '@/store/board/atoms/board.atom';
 import { BreadcrumbType } from '@/types/board/Breadcrumb';
-import { TeamUser } from '@/types/team/team.user';
-import { TeamUserRoles } from '@/utils/enums/team.user.roles';
-import isEmpty from '@/utils/isEmpty';
 import Link from 'next/link';
-import { StyledBoardTitle } from '@/components/CardBoard/CardBody/CardTitle/partials/Title/styles';
-import AvatarGroup from '@/components/Primitives/Avatar/AvatarGroup';
 import {
   MergeIconContainer,
   RecurrentIconContainer,
@@ -24,28 +17,17 @@ import {
   TitleSection,
 } from '../../SplitBoard/Header/styles';
 import HeaderParticipants from './HeaderParticipants';
-import { getGuestUserCookies } from '@/utils/getGuestUserCookies';
 
 interface Props {
   isParticipantsPage?: boolean;
 }
 
 const RegularBoardHeader = ({ isParticipantsPage }: Props) => {
-  const { data: session } = useSession({ required: false });
-
   // Atoms
   const boardData = useRecoilValue(boardInfoState);
 
   // Get Board Info
-  const { title, recurrent, users, team, isSubBoard, submitedAt, _id } = boardData.board;
-
-  // Get Team users
-  const teamUsers = team?.users ? team.users : [];
-
-  const isRegularBoardWithNoTeam = !team;
-
-  // User id
-  const userId = getGuestUserCookies() ? getGuestUserCookies().user : session?.user.id;
+  const { title, recurrent, isSubBoard, submitedAt, _id } = boardData.board;
 
   // Set breadcrumbs
   const breadcrumbItems: BreadcrumbType = isParticipantsPage

--- a/frontend/src/components/Board/RegularBoard/ReagularHeader/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/ReagularHeader/index.tsx
@@ -24,6 +24,7 @@ import {
   TitleSection,
 } from '../../SplitBoard/Header/styles';
 import HeaderParticipants from './HeaderParticipants';
+import { getGuestUserCookies } from '@/utils/getGuestUserCookies';
 
 interface Props {
   isParticipantsPage?: boolean;
@@ -42,6 +43,9 @@ const RegularBoardHeader = ({ isParticipantsPage }: Props) => {
   const teamUsers = team?.users ? team.users : [];
 
   const isRegularBoardWithNoTeam = !team;
+
+  // User id
+  const userId = getGuestUserCookies() ? getGuestUserCookies().user : session?.user.id;
 
   // Set breadcrumbs
   const breadcrumbItems: BreadcrumbType = isParticipantsPage
@@ -101,92 +105,17 @@ const RegularBoardHeader = ({ isParticipantsPage }: Props) => {
           </TitleSection>
         </Flex>
         <Flex align="center" gap="24">
-          {!isEmpty(teamUsers) && (
-            <Link href={`/teams/${team.id}`}>
-              <Flex align="center" gap="24">
-                <Flex align="center" gap="10">
-                  <StyledBoardTitle>
-                    <Text
-                      color="primary800"
-                      size="sm"
-                      fontWeight="medium"
-                      css={{
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                      }}
-                    >
-                      {team?.name}
-                    </Text>
-                  </StyledBoardTitle>
-                  <AvatarGroup
-                    listUsers={isSubBoard ? users : teamUsers}
-                    responsible={false}
-                    teamAdmins={false}
-                    userId={session!.user.id}
-                    isClickable
-                  />
+          <Flex>
+            {isParticipantsPage ? (
+              <HeaderParticipants isParticipantsPage />
+            ) : (
+              <Link href={`/boards/${_id}/participants`}>
+                <Flex>
+                  <HeaderParticipants />
                 </Flex>
-                {!isEmpty(
-                  teamUsers.filter((user: TeamUser) => user.role === TeamUserRoles.ADMIN),
-                ) && (
-                  <>
-                    <Separator orientation="vertical" size="lg" />
-
-                    <Flex align="center" gap="10">
-                      <Text color="primary300" size="sm">
-                        Team admins
-                      </Text>
-                      <AvatarGroup
-                        teamAdmins
-                        listUsers={isSubBoard ? users : teamUsers}
-                        responsible={false}
-                        userId={session!.user.id}
-                        isClickable
-                      />
-                    </Flex>
-                  </>
-                )}
-                {!isEmpty(
-                  boardData.board.team?.users.filter(
-                    (user: TeamUser) => user.role === TeamUserRoles.STAKEHOLDER,
-                  ),
-                ) && (
-                  <>
-                    <Separator orientation="vertical" size="lg" />
-
-                    <Flex align="center" gap="10">
-                      <Text color="primary300" size="sm">
-                        Stakeholders
-                      </Text>
-                      <AvatarGroup
-                        stakeholders
-                        listUsers={isSubBoard ? users : teamUsers}
-                        responsible={false}
-                        teamAdmins={false}
-                        userId={session!.user.id}
-                        isClickable
-                      />
-                    </Flex>
-                  </>
-                )}
-              </Flex>
-            </Link>
-          )}
-
-          {isRegularBoardWithNoTeam && (
-            <Flex>
-              {isParticipantsPage ? (
-                <HeaderParticipants isParticipantsPage />
-              ) : (
-                <Link href={`/boards/${_id}/participants`}>
-                  <Flex>
-                    <HeaderParticipants />
-                  </Flex>
-                </Link>
-              )}
-            </Flex>
-          )}
+              </Link>
+            )}
+          </Flex>
         </Flex>
       </Flex>
     </StyledHeader>

--- a/frontend/src/components/Board/Settings/partials/ConfigurationSettings/ConfigurationSwitch.tsx
+++ b/frontend/src/components/Board/Settings/partials/ConfigurationSettings/ConfigurationSwitch.tsx
@@ -25,7 +25,7 @@ const ConfigurationSwitchSettings = ({
   disabledInfo,
 }: Props) => (
   <Flex gap={20}>
-    {disabledInfo ? (
+    {disabledInfo && disabled ? (
       <Tooltip content={disabledInfo}>
         <Flex>
           <Switch

--- a/frontend/src/components/Board/Settings/partials/ConfigurationSettings/ConfigurationSwitch.tsx
+++ b/frontend/src/components/Board/Settings/partials/ConfigurationSettings/ConfigurationSwitch.tsx
@@ -37,7 +37,12 @@ const ConfigurationSwitchSettings = ({
         </Flex>
       </Tooltip>
     ) : (
-      <Switch checked={isChecked} size="sm" onCheckedChange={handleCheckedChange} />
+      <Switch
+        checked={isChecked}
+        size="sm"
+        onCheckedChange={handleCheckedChange}
+        disabled={disabled}
+      />
     )}
     <Flex direction="column">
       <Text size="md" fontWeight="medium">

--- a/frontend/src/components/Teams/CreateTeam/ListMembersDialog/index.tsx
+++ b/frontend/src/components/Teams/CreateTeam/ListMembersDialog/index.tsx
@@ -20,7 +20,7 @@ type ListMembersDialogProps = {
 
 const ListMembersDialog = React.memo<ListMembersDialogProps>(
   ({ usersList, isOpen, setIsOpen, saveUsers, title, btnTitle }) => {
-    const { data: session } = useSession({ required: true });
+    const { data: session } = useSession({ required: false });
     const [searchMember, setSearchMember] = useState<string>('');
 
     const [usersChecked, setUsersChecked] = useState(usersList);

--- a/frontend/src/pages/boards/[boardId]/participants.tsx
+++ b/frontend/src/pages/boards/[boardId]/participants.tsx
@@ -16,7 +16,6 @@ import { BoardUserRoles } from '@/utils/enums/board.user.roles';
 import { ToastStateEnum } from '@/utils/enums/toast-types';
 import { QueryClient, dehydrate, useQuery } from '@tanstack/react-query';
 import { GetServerSideProps } from 'next';
-import { useSession } from 'next-auth/react';
 import React, { Suspense, useCallback, useEffect } from 'react';
 import { SetterOrUpdater, useRecoilState, useSetRecoilState } from 'recoil';
 
@@ -41,10 +40,9 @@ export const sortParticipantsList = (
 };
 
 const BoardParticipants = () => {
-  const { data: session } = useSession({ required: false });
   const setToastState = useSetRecoilState(toastState);
   const [boardParticipants, setBoardParticipants] = useRecoilState(boardParticipantsState);
-  const setRecoilBoard = useSetRecoilState(boardInfoState);
+  const [recoilBoard, setRecoilBoard] = useRecoilState(boardInfoState);
 
   // Hooks
   const {
@@ -93,8 +91,7 @@ const BoardParticipants = () => {
     handleMembersList();
   }, [handleMembersList]);
 
-  if (!session) return null;
-  return (
+  return recoilBoard ? (
     <Suspense fallback={<LoadingPage />}>
       <QueryError>
         <ContentSection gap="36" justify="between">
@@ -107,6 +104,8 @@ const BoardParticipants = () => {
         </ContentSection>
       </QueryError>
     </Suspense>
+  ) : (
+    <LoadingPage />
   );
 };
 

--- a/frontend/src/types/user/user.ts
+++ b/frontend/src/types/user/user.ts
@@ -17,6 +17,7 @@ export interface User {
   isSAdmin: boolean;
   joinedAt: string;
   providerAccountCreatedAt?: string;
+  isAnonymous?: boolean;
 }
 
 export interface UseUserType {


### PR DESCRIPTION
Related to #1120
Related to #742 


## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/116013814/221171144-c6ae33e1-813e-49a2-9d20-80cda8ac6142.png)
<img width="1030" alt="Screenshot 2023-02-24 at 11 35 41" src="https://user-images.githubusercontent.com/116013814/221170822-eb83c0ea-9082-41b3-abf9-bad2de698c1a.png">


## Proposed Changes

  - Regular Board with team, displays participants on the participants page.
  - Avoided removing the only board responsible.

@CatiaAntunes96 


This pull request closes #1120 
This pull request closes #742  