### PR TITLE
fix: endpoint returns paginated boards to sAdmin

### DIFF
--- a/backend/src/modules/boards/services/get.board.service.ts
+++ b/backend/src/modules/boards/services/get.board.service.ts
@@ -72,7 +72,7 @@ export default class GetBoardServiceImpl implements GetBoardServiceInterface {
 			$and: [{ isSubBoard: false }, { $or: [{ _id: { $in: boardIds } }, { team: { $ne: null } }] }]
 		};
 
-		return this.getBoards(true, query, page, size);
+		return this.getBoards(false, query, page, size);
 	}
 
 	async getUsersBoards(userId: string, page: number, size?: number) {


### PR DESCRIPTION
Fixes #1152 

## Proposed Changes

  - Get all boards as a super admin returns boards with pagination.


This pull request closes #1152 