### PR TITLE
fix: update board column name max char

### DIFF
--- a/frontend/src/components/Board/Column/partials/UpdateColumnDialog/index.tsx
+++ b/frontend/src/components/Board/Column/partials/UpdateColumnDialog/index.tsx
@@ -107,7 +107,7 @@ const UpdateColumnDialog: React.FC<UpdateColumnNameProps> = ({
             {type === 'ColumnName' ? (
               <Input
                 id="title"
-                maxChars="15"
+                maxChars="30"
                 placeholder="Column name"
                 type="text"
                 showCount

--- a/frontend/src/schema/schemaChangeColumnName.ts
+++ b/frontend/src/schema/schemaChangeColumnName.ts
@@ -1,10 +1,10 @@
 import Joi from 'joi';
 
 const SchemaChangeColumnName = Joi.object({
-  title: Joi.string().required().trim().max(15).messages({
+  title: Joi.string().required().trim().max(30).messages({
     'any.required': 'Please write a name',
     'string.empty': 'Please write a name',
-    'string.max': 'Maximum of 15 characters',
+    'string.max': 'Maximum of 30 characters',
   }),
   text: Joi.string().required().trim().messages({
     'any.required': 'Please write a text',


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to #1161
Fixes #1161

## Screenshots (if visual changes)

## Proposed Changes

  - Update the max character number of column name from 15 to 30 on the dialog to edit the column name

<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #1161