### PR TITLE
Fix: regular retro column name

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -45,6 +45,7 @@
         "react-dom": "^17.0.2",
         "react-error-boundary": "^3.1.4",
         "react-hook-form": "^7.29.0",
+        "react-resize-detector": "^8.0.4",
         "react-select": "^5.7.0",
         "recoil": "^0.7.6",
         "socket.io-client": "^4.4.1",
@@ -24476,8 +24477,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -27582,6 +27582,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-resize-detector": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.0.4.tgz",
+      "integrity": "sha512-ln9pMAob8y8mc9UI4aZuuWFiyMqBjnTs/sxe9Vs9dPXUjwCTeKK1FP8I75ufnb/2mEEZXG6wOo/fjMcBRRuAXw==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-select": {
@@ -51274,8 +51286,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.debounce": {
       "version": "4.0.8",
@@ -53653,6 +53664,14 @@
       "requires": {
         "react-style-singleton": "^2.2.1",
         "tslib": "^2.0.0"
+      }
+    },
+    "react-resize-detector": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-8.0.4.tgz",
+      "integrity": "sha512-ln9pMAob8y8mc9UI4aZuuWFiyMqBjnTs/sxe9Vs9dPXUjwCTeKK1FP8I75ufnb/2mEEZXG6wOo/fjMcBRRuAXw==",
+      "requires": {
+        "lodash": "^4.17.21"
       }
     },
     "react-select": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -54,6 +54,7 @@
     "react-dom": "^17.0.2",
     "react-error-boundary": "^3.1.4",
     "react-hook-form": "^7.29.0",
+    "react-resize-detector": "^8.0.4",
     "react-select": "^5.7.0",
     "recoil": "^0.7.6",
     "socket.io-client": "^4.4.1",

--- a/frontend/src/components/Board/AddCardOrComment.tsx
+++ b/frontend/src/components/Board/AddCardOrComment.tsx
@@ -119,7 +119,8 @@ const AddCard = React.memo<AddCardProps>(
         : '$primaryBase';
 
     const disabledButton =
-      watchCardTextInput.text?.trim().length === 0 || watchCardTextInput.text === placeholder;
+      watchCardTextInput.text?.trim().length === 0 ||
+      watchCardTextInput.text.trim() === placeholder;
 
     const handleClear = () => {
       if ((isUpdate || !isCard) && cancelUpdate) {

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -10,6 +10,7 @@ import { filteredColumnsState } from '@/store/board/atoms/filterColumns';
 import { countColumnCards } from '@/helper/board/countCards';
 import Icon from '@/components/Primitives/Icon';
 import Tooltip from '@/components/Primitives/Tooltip';
+import { useResizeDetector } from 'react-resize-detector';
 import AddCardOrComment from '../AddCardOrComment';
 import CardsList from './CardsList';
 import SortMenu from './partials/SortMenu';
@@ -64,6 +65,8 @@ const Column = React.memo<ColumMemoProps>(
       deleteCards: false,
     });
     const [dialogType, setDialogType] = useState('ColumnName');
+    const [showTooltip, setShowTooltip] = useState(false);
+    const { width, ref } = useResizeDetector({ handleWidth: true });
 
     const handleDialogNameChange = (open: boolean, type: string) => {
       setOpenDialog({ columnName: open, deleteColumn: false, deleteCards: false });
@@ -119,6 +122,14 @@ const Column = React.memo<ColumMemoProps>(
       }
     }, [columnId, filter, setFilteredColumns]);
 
+    useEffect(() => {
+      setShowTooltip(false);
+
+      if (ref.current && ref.current.offsetWidth < ref.current?.scrollWidth) {
+        setShowTooltip(true);
+      }
+    }, [ref, width]);
+
     return (
       <>
         <Draggable
@@ -144,9 +155,17 @@ const Column = React.memo<ColumMemoProps>(
                             width: hasMoreThanThreeColumns ? '$130' : '$237',
                           }}
                         >
-                          <Tooltip content={title}>
-                            <Title heading="4">{title}</Title>
-                          </Tooltip>
+                          {showTooltip ? (
+                            <Tooltip content={title}>
+                              <Title heading="4" ref={ref}>
+                                {title}
+                              </Title>
+                            </Tooltip>
+                          ) : (
+                            <Title heading="4" ref={ref}>
+                              {title}
+                            </Title>
+                          )}
                         </TitleContainer>
                         <Text
                           color="primary400"

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -9,10 +9,11 @@ import { useSetRecoilState } from 'recoil';
 import { filteredColumnsState } from '@/store/board/atoms/filterColumns';
 import { countColumnCards } from '@/helper/board/countCards';
 import Icon from '@/components/Primitives/Icon';
+import Tooltip from '@/components/Primitives/Tooltip';
 import AddCardOrComment from '../AddCardOrComment';
 import CardsList from './CardsList';
 import SortMenu from './partials/SortMenu';
-import { CardsContainer, Container, OuterContainer, Title } from './styles';
+import { CardsContainer, Container, OuterContainer, Title, TitleContainer } from './styles';
 import OptionsMenu from './partials/OptionsMenu';
 import UpdateColumnDialog from './partials/UpdateColumnDialog';
 import AlertDeleteColumn from './partials/AlertDeleteColumn';
@@ -138,14 +139,15 @@ const Column = React.memo<ColumMemoProps>(
                             <Icon name="arrange" size={24} />
                           </Flex>
                         )}
-                        <Flex
+                        <TitleContainer
                           css={{
-                            width: hasMoreThanThreeColumns ? '$130' : '70%',
-                            '@media (min-width: 1750px)': { width: 'fit-content' },
+                            width: hasMoreThanThreeColumns ? '$130' : '$237',
                           }}
                         >
-                          <Title heading="4">{title}</Title>
-                        </Flex>
+                          <Tooltip content={title}>
+                            <Title heading="4">{title}</Title>
+                          </Tooltip>
+                        </TitleContainer>
                         <Text
                           color="primary400"
                           size="xs"

--- a/frontend/src/components/Board/Column/Column.tsx
+++ b/frontend/src/components/Board/Column/Column.tsx
@@ -26,6 +26,7 @@ type ColumMemoProps = {
   columnIndex: number;
   isSubBoard?: boolean;
   phase?: string;
+  hasMoreThanThreeColumns: boolean;
 } & ColumnBoardType;
 
 const Column = React.memo<ColumMemoProps>(
@@ -52,6 +53,7 @@ const Column = React.memo<ColumMemoProps>(
     columnIndex,
     isSubBoard,
     phase,
+    hasMoreThanThreeColumns,
   }) => {
     const [filter, setFilter] = useState<'asc' | 'desc' | undefined>();
     const setFilteredColumns = useSetRecoilState(filteredColumnsState);
@@ -130,13 +132,20 @@ const Column = React.memo<ColumMemoProps>(
                 {(provided) => (
                   <Container direction="column" elevation="2">
                     <Flex css={{ pt: '$20', px: '$20', pb: '$16' }} justify="between">
-                      <Flex>
+                      <Flex css={{ width: '100%' }}>
                         {hasAdminRole && isRegularBoard && (
                           <Flex {...providedColumn.dragHandleProps}>
                             <Icon name="arrange" size={24} />
                           </Flex>
                         )}
-                        <Title heading="4">{title}</Title>
+                        <Flex
+                          css={{
+                            width: hasMoreThanThreeColumns ? '$130' : '70%',
+                            '@media (min-width: 1750px)': { width: 'fit-content' },
+                          }}
+                        >
+                          <Title heading="4">{title}</Title>
+                        </Flex>
                         <Text
                           color="primary400"
                           size="xs"
@@ -145,6 +154,7 @@ const Column = React.memo<ColumMemoProps>(
                             border: '1px solid $colors$primary100',
                             px: '$8',
                             py: '$2',
+                            ml: '$10',
                           }}
                         >
                           {countColumnCards(cards)} cards

--- a/frontend/src/components/Board/Column/partials/UpdateColumnDialog/index.tsx
+++ b/frontend/src/components/Board/Column/partials/UpdateColumnDialog/index.tsx
@@ -54,7 +54,11 @@ const UpdateColumnDialog: React.FC<UpdateColumnNameProps> = ({
     mode: 'onChange',
     reValidateMode: 'onChange',
     defaultValues: {
-      title: columnTitle || '',
+      title: columnTitle,
+      text: cardText || 'Write your comment here...',
+    },
+    values: {
+      title: columnTitle,
       text: cardText || 'Write your comment here...',
     },
     resolver: joiResolver(SchemaChangeColumnName),

--- a/frontend/src/components/Board/Column/styles.tsx
+++ b/frontend/src/components/Board/Column/styles.tsx
@@ -44,8 +44,8 @@ const OuterContainer = styled(Flex, {
 });
 
 const TitleContainer = styled(Flex, {
-  '@media (min-width: 1750px)': { width: 'fit-content' },
-  '@media (max-width: 1300px)': { width: '$150' },
+  '@media (min-width: 1750px)': { width: 'fit-content !important' },
+  '@media (max-width: 1300px)': { width: '$150 !important' },
 });
 
 const Title = styled(Text, {
@@ -53,6 +53,9 @@ const Title = styled(Text, {
   whiteSpace: 'nowrap',
   textOverflow: 'ellipsis',
   overflow: 'hidden',
+  '@hover': {
+    cursor: 'default',
+  },
 });
 
 export { CardsContainer, Container, OuterContainer, TitleContainer, Title };

--- a/frontend/src/components/Board/Column/styles.tsx
+++ b/frontend/src/components/Board/Column/styles.tsx
@@ -43,6 +43,11 @@ const OuterContainer = styled(Flex, {
   width: '100%',
 });
 
+const TitleContainer = styled(Flex, {
+  '@media (min-width: 1750px)': { width: 'fit-content' },
+  '@media (max-width: 1300px)': { width: '$150' },
+});
+
 const Title = styled(Text, {
   px: '$8',
   whiteSpace: 'nowrap',
@@ -50,4 +55,4 @@ const Title = styled(Text, {
   overflow: 'hidden',
 });
 
-export { CardsContainer, Container, OuterContainer, Title };
+export { CardsContainer, Container, OuterContainer, TitleContainer, Title };

--- a/frontend/src/components/Board/Column/styles.tsx
+++ b/frontend/src/components/Board/Column/styles.tsx
@@ -45,6 +45,9 @@ const OuterContainer = styled(Flex, {
 
 const Title = styled(Text, {
   px: '$8',
+  whiteSpace: 'nowrap',
+  textOverflow: 'ellipsis',
+  overflow: 'hidden',
 });
 
 export { CardsContainer, Container, OuterContainer, Title };

--- a/frontend/src/components/Board/DragDropArea/index.tsx
+++ b/frontend/src/components/Board/DragDropArea/index.tsx
@@ -18,7 +18,10 @@ import { boardInfoState } from '@/store/board/atoms/board.atom';
 import { BoardUserRoles } from '@/utils/enums/board.user.roles';
 import ColumnType from '@/types/column';
 
-const Container = styled(Flex, { width: '100%', display: 'inline-flex', mb: '$32' });
+const Container = styled(Flex, {
+  display: 'inline-flex',
+  mb: '$32',
+});
 
 type Props = {
   userId: string;
@@ -181,6 +184,7 @@ const DragDropArea: React.FC<Props> = ({
   };
 
   const isMainboard = !board.isSubBoard && board.dividedBoards.length > 0;
+  const hasMoreThanThreeColumns = !!(board.columns.length > 3);
 
   const ColumnnContainer = (
     <Droppable
@@ -190,10 +194,18 @@ const DragDropArea: React.FC<Props> = ({
       isDropDisabled={isMainboard || !hasAdminRole}
     >
       {(provided) => (
-        <Container css={{ gap: '$24' }} ref={provided.innerRef} {...provided.droppableProps}>
+        <Container
+          css={{
+            gap: '$24',
+            width: '100%',
+          }}
+          ref={provided.innerRef}
+          {...provided.droppableProps}
+        >
           {board.columns.map((column, index) => (
             <Column
               key={column._id}
+              hasMoreThanThreeColumns={hasMoreThanThreeColumns}
               boardId={board._id}
               cards={column.cards}
               color={column.color}

--- a/frontend/src/components/Board/DragDropArea/index.tsx
+++ b/frontend/src/components/Board/DragDropArea/index.tsx
@@ -19,8 +19,18 @@ import { BoardUserRoles } from '@/utils/enums/board.user.roles';
 import ColumnType from '@/types/column';
 
 const Container = styled(Flex, {
-  display: 'inline-flex',
-  mb: '$32',
+  boxSizing: 'border-box',
+  marginBottom: '$32',
+  overflowY: 'scroll',
+  width: '100%',
+  position: 'relative',
+  '@media (max-width: 1350px)': {
+    overflowY: 'auto',
+    minHeight: '62vh',
+  },
+  '@media (min-height: 800px)': {
+    minHeight: '75vh',
+  },
 });
 
 type Props = {
@@ -197,7 +207,6 @@ const DragDropArea: React.FC<Props> = ({
         <Container
           css={{
             gap: '$24',
-            width: '100%',
           }}
           ref={provided.innerRef}
           {...provided.droppableProps}

--- a/frontend/src/components/Board/RegularBoard/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/index.tsx
@@ -119,14 +119,26 @@ const RegularBoard = ({
             </>
           )}
         </Flex>
-
-        <DragDropArea
-          board={board}
-          socketId={socketId}
-          userId={userId}
-          isRegularBoard
-          hasAdminRole={hasAdminRole}
-        />
+        <Flex
+          css={{
+            width: '100%',
+            '@media (max-width: 1200px)': {
+              overflowY: 'auto',
+              minHeight: '60vh',
+            },
+            '@media (min-height: 800px)': {
+              minHeight: '75vh',
+            },
+          }}
+        >
+          <DragDropArea
+            board={board}
+            socketId={socketId}
+            userId={userId}
+            isRegularBoard
+            hasAdminRole={hasAdminRole}
+          />
+        </Flex>
       </Container>
     </>
   ) : (

--- a/frontend/src/components/Board/RegularBoard/index.tsx
+++ b/frontend/src/components/Board/RegularBoard/index.tsx
@@ -119,26 +119,13 @@ const RegularBoard = ({
             </>
           )}
         </Flex>
-        <Flex
-          css={{
-            width: '100%',
-            '@media (max-width: 1200px)': {
-              overflowY: 'auto',
-              minHeight: '60vh',
-            },
-            '@media (min-height: 800px)': {
-              minHeight: '75vh',
-            },
-          }}
-        >
-          <DragDropArea
-            board={board}
-            socketId={socketId}
-            userId={userId}
-            isRegularBoard
-            hasAdminRole={hasAdminRole}
-          />
-        </Flex>
+        <DragDropArea
+          board={board}
+          socketId={socketId}
+          userId={userId}
+          isRegularBoard
+          hasAdminRole={hasAdminRole}
+        />
       </Container>
     </>
   ) : (

--- a/frontend/src/components/Board/Settings/partials/Columns/ColumnBoxAndDelete.tsx
+++ b/frontend/src/components/Board/Settings/partials/Columns/ColumnBoxAndDelete.tsx
@@ -13,7 +13,7 @@ const ColumnBoxAndDelete = ({ remove, title, index, disableDeleteColumn }: Props
   <Flex gap="20">
     <Input
       id={`formColumns.${index}.title`}
-      maxChars="30"
+      maxChars="15"
       placeholder={`Column ${index + 1}`}
       showCount
       type="text"

--- a/frontend/src/components/Primitives/TextArea.tsx
+++ b/frontend/src/components/Primitives/TextArea.tsx
@@ -110,6 +110,7 @@ const TextArea: React.FC<ResizableTextAreaProps> = ({ id, placeholder, disabled,
     if (!isValueEmpty) return 'valid';
 
     return 'default';
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dirtyFields[id], errors[id], id, isValueEmpty]);
 
   useEffect(() => {

--- a/frontend/src/schema/schemaUpdateBoardForm.ts
+++ b/frontend/src/schema/schemaUpdateBoardForm.ts
@@ -16,10 +16,10 @@ const SchemaUpdateBoard = Joi.object({
     .items(
       Joi.object()
         .keys({
-          title: Joi.string().required().trim().max(30).messages({
+          title: Joi.string().required().trim().max(15).messages({
             'any.required': 'Please enter the Column name',
             'string.empty': 'Please enter the Column name',
-            'string.max': 'Maximum of 30 characters',
+            'string.max': 'Maximum of 15 characters',
           }),
         })
         .unknown(true),

--- a/frontend/src/styles/pages/boards/board.styles.tsx
+++ b/frontend/src/styles/pages/boards/board.styles.tsx
@@ -3,9 +3,7 @@ import { styled } from '@/styles/stitches/stitches.config';
 import Flex from '@/components/Primitives/Flex';
 
 const Container = styled(Flex, {
-  // remove 108px from header to the 100vh
   overflow: 'hidden',
-
   alignItems: 'flex-start',
   justifyContent: 'center',
   px: '$36',


### PR DESCRIPTION

Fixes #1150 

## Proposed Changes

  - Fix maximum of column title chars to 15 letters
  - Fix input value when column name is changed (settings and column options)
  - Add overflow-text: ellipsis property for when column name is too long
  - Add tooltip to when is not possible to display all the column name
  - Add horizontal scroll on columns container for when it is not possible to display all of them on the screen 
  


This pull request closes #1150 