### PR TITLE
fix: board settings save button and create regular board cards

### DIFF
--- a/frontend/src/components/Primitives/Dialogs/Dialog/DialogFooter.tsx
+++ b/frontend/src/components/Primitives/Dialogs/Dialog/DialogFooter.tsx
@@ -31,7 +31,7 @@ const Footer = (props: FooterProps) => {
       <Button variant="primaryOutline" onClick={handleClose} type="button">
         Cancel
       </Button>
-      {handleAffirmative && affirmativeLabel && (
+      {affirmativeLabel && (
         <Button onClick={handleAffirmative} ref={buttonRef} data-testid="dialogFooterSubmit">
           {affirmativeLabel}
         </Button>

--- a/frontend/src/pages/boards/newRegularBoard.tsx
+++ b/frontend/src/pages/boards/newRegularBoard.tsx
@@ -298,7 +298,7 @@ const NewRegularBoard: NextPage = () => {
               />
             </>
           ) : (
-            <Flex align="center" justify="center">
+            <Flex align="center" justify="center" css={{ height: '100%' }}>
               <Flex gap={16} direction="column">
                 <BoxRowContainer
                   iconName="blob-arrow-right"


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to:
- #1243 

Fixes:
- #1243 

## Proposed Changes

- The save button of the board settings dialog is not appearing
- The cards of the create regular board page are not vertically aligned

<!--
Mention people who discussed this issue previously
@StereoPT 
-->


This pull request closes:
- #1243
