### PR TITLE
test: add unity tests to util functions

### DIFF
--- a/backend/src/modules/boards/services/get.board.service.ts
+++ b/backend/src/modules/boards/services/get.board.service.ts
@@ -4,7 +4,6 @@ import {
 	BadRequestException,
 	Inject,
 	Injectable,
-	Logger,
 	NotFoundException,
 	forwardRef
 } from '@nestjs/common';
@@ -45,8 +44,6 @@ export default class GetBoardService implements GetBoardServiceInterface {
 		private readonly boardRepository: BoardRepositoryInterface,
 		private socketService: SocketGateway
 	) {}
-
-	private readonly logger = new Logger(GetBoardService.name);
 
 	async getAllBoardIdsAndTeamIdsOfUser(userId: string) {
 		const [boardIds, teamIds] = await Promise.all([

--- a/backend/src/modules/boards/utils/generate-subcolumns.spec.ts
+++ b/backend/src/modules/boards/utils/generate-subcolumns.spec.ts
@@ -1,0 +1,60 @@
+import { BoardFactory } from 'src/libs/test-utils/mocks/factories/board-factory.mock';
+import Column from 'src/modules/columns/entities/column.schema';
+import { generateNewSubColumns } from './generate-subcolumns';
+
+describe('generateNewSubColumns function', () => {
+	test('should return the columns with cards formatted', () => {
+		const subBoard = BoardFactory.create({ isSubBoard: true });
+
+		let columnsResult = [...subBoard.columns];
+
+		columnsResult = columnsResult.map((column) => {
+			const newColumn = {
+				title: column.title,
+				color: column.color,
+				cardText: column.cardText,
+				isDefaultText: column.isDefaultText,
+				cards: column.cards.map((card) => {
+					const newCard = {
+						text: card.text,
+						createdBy: card.createdBy,
+						votes: card.votes,
+						anonymous: card.anonymous,
+						createdByTeam: subBoard.title.replace('board', ''),
+						comments: card.comments.map((comment) => {
+							return {
+								text: comment.text,
+								createdBy: comment.createdBy,
+								anonymous: comment.anonymous
+							};
+						}),
+						items: card.items.map((cardItem) => {
+							return {
+								text: cardItem.text,
+								votes: cardItem.votes,
+								createdByTeam: subBoard.title.replace('board ', ''),
+								createdBy: cardItem.createdBy,
+								anonymous: cardItem.anonymous,
+								comments: cardItem.comments.map((comment) => {
+									return {
+										text: comment.text,
+										createdBy: comment.createdBy,
+										anonymous: comment.anonymous
+									};
+								}),
+								createdAt: card.createdAt
+							};
+						}),
+						createdAt: card.createdAt
+					};
+
+					return newCard;
+				})
+			};
+
+			return newColumn as Column;
+		});
+
+		expect(generateNewSubColumns(subBoard)).toEqual(columnsResult);
+	});
+});

--- a/backend/src/modules/boards/utils/merge-cards-from-subBoard.spec.ts
+++ b/backend/src/modules/boards/utils/merge-cards-from-subBoard.spec.ts
@@ -1,0 +1,22 @@
+import { BoardFactory } from 'src/libs/test-utils/mocks/factories/board-factory.mock';
+import { mergeCardsFromSubBoardColumnsIntoMainBoard } from './merge-cards-from-subboard';
+
+describe('mergeCardsFromSubboard function', () => {
+	test('should return the columns with the cards from the subBoards', () => {
+		const subBoard = BoardFactory.create({ isSubBoard: true });
+		const mainBoard = BoardFactory.create({ isSubBoard: false, dividedBoards: [subBoard] });
+
+		const mainBoardColumnsResult = [...mainBoard.columns];
+
+		for (let i = 0; i < mainBoardColumnsResult.length; i++) {
+			mainBoardColumnsResult[i].cards = [
+				...mainBoardColumnsResult[i].cards,
+				...subBoard.columns[i].cards
+			];
+		}
+
+		expect(mergeCardsFromSubBoardColumnsIntoMainBoard(mainBoard.columns, subBoard.columns)).toEqual(
+			mainBoardColumnsResult
+		);
+	});
+});


### PR DESCRIPTION

Relates to:
- #1266 


## Proposed Changes

  - Add unity tests to  the mergeCardsFromSubBoardColumnsIntoMainBoard and generateNewSubColumns functions
  - Remove unused logger variable from getBoardService
  -




This pull request closes #1266 
