### PR TITLE
fix: 1262 bug stop timer method is called unnecessarily

### DIFF
--- a/backend/src/modules/boards/services/start-board-timer.service.ts
+++ b/backend/src/modules/boards/services/start-board-timer.service.ts
@@ -1,6 +1,10 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { BOARD_TIMER_SERVER_STARTED, BOARD_TIMER_SYNC_INTERVAL } from 'src/libs/constants/timer';
+import {
+	BOARD_TIMER_SERVER_STARTED,
+	BOARD_TIMER_SYNC_INTERVAL,
+	ONE_HOUR
+} from 'src/libs/constants/timer';
 import BoardTimerDurationDto from 'src/libs/dto/board-timer-duration.dto';
 import BoardTimerStateDto from 'src/libs/dto/board-timer-state.dto';
 import ServerStartedTimerEvent from 'src/modules/boards/events/server-started-timer.event';
@@ -8,8 +12,7 @@ import SendBoardTimerTimeLeftServiceInterface from 'src/modules/boards/interface
 import StartBoardTimerServiceInterface from 'src/modules/boards/interfaces/services/start-board-timer.service.interface';
 import StopBoardTimerServiceInterface from 'src/modules/boards/interfaces/services/stop-board-timer.service.interface';
 import { TYPES } from 'src/modules/boards/interfaces/types';
-import { ONE_HOUR } from '../../../libs/constants/timer';
-import { BoardTimerRepositoryInterface } from '../repositories/board-timer.repository.interface';
+import { BoardTimerRepositoryInterface } from 'src/modules/boards/repositories/board-timer.repository.interface';
 
 @Injectable()
 export default class StartBoardTimerService implements StartBoardTimerServiceInterface {

--- a/backend/src/modules/boards/services/stop-board-timer.service.ts
+++ b/backend/src/modules/boards/services/stop-board-timer.service.ts
@@ -5,7 +5,7 @@ import BoardTimerDto from 'src/libs/dto/board-timer.dto';
 import ServerStoppedTimerEvent from 'src/modules/boards/events/server-stopped-timer.event';
 import StopBoardTimerServiceInterface from 'src/modules/boards/interfaces/services/stop-board-timer.service.interface';
 import { TYPES } from 'src/modules/boards/interfaces/types';
-import { BoardTimerRepositoryInterface } from '../repositories/board-timer.repository.interface';
+import { BoardTimerRepositoryInterface } from 'src/modules/boards/repositories/board-timer.repository.interface';
 
 @Injectable()
 export default class StopBoardTimerService implements StopBoardTimerServiceInterface {
@@ -22,6 +22,18 @@ export default class StopBoardTimerService implements StopBoardTimerServiceInter
 		this.logger.log(`Will stop timer. Board: "${boardTimerDto.boardId})"`);
 
 		const boardTimer = this.boardTimerRepository.findBoardTimerByBoardId(boardTimerDto.boardId);
+
+		if (!boardTimer?.timerHelper) {
+			this.logger.warn(`Timer not found for board: "${boardTimerDto.boardId}"`);
+
+			return;
+		}
+
+		if (boardTimer.timerHelper.isStopped) {
+			this.logger.warn(`Timer already stopped for board: "${boardTimerDto.boardId}"`);
+
+			return;
+		}
 
 		boardTimer.timerHelper.stop();
 

--- a/frontend/src/types/events/emit-event.type.ts
+++ b/frontend/src/types/events/emit-event.type.ts
@@ -1,3 +1,1 @@
-type EmitEvent = (eventName: string, payload: any) => void;
-
-export default EmitEvent;
+export type EmitEvent = (eventName: string, payload: any) => void;

--- a/frontend/src/types/events/listen-event.type.ts
+++ b/frontend/src/types/events/listen-event.type.ts
@@ -1,5 +1,3 @@
 import EventCallback from '@/types/events/event-callback.type';
 
-type ListenEvent = (eventName: string, callback: EventCallback) => void;
-
-export default ListenEvent;
+export type ListenEvent = (eventName: string, callback: EventCallback) => void;

--- a/frontend/src/types/timer/time.dto.ts
+++ b/frontend/src/types/timer/time.dto.ts
@@ -1,4 +1,4 @@
-export default interface TimeDto {
+export interface TimeDto {
   minutes: number;
   seconds: number;
 }

--- a/frontend/src/types/timer/timer-props.interface.tsx
+++ b/frontend/src/types/timer/timer-props.interface.tsx
@@ -1,0 +1,9 @@
+import { EmitEvent } from '@/types/events/emit-event.type';
+import { ListenEvent } from '@/types/events/listen-event.type';
+
+export interface TimerProps {
+  boardId: string;
+  isAdmin: boolean;
+  listenEvent: ListenEvent;
+  emitEvent: EmitEvent;
+}

--- a/frontend/src/types/timer/timer-state.dto.ts
+++ b/frontend/src/types/timer/timer-state.dto.ts
@@ -1,7 +1,7 @@
-import TimeDto from '@/types/timer/time.dto';
-import TimerStatus from '@/types/timer/timer-status';
+import { TimeDto } from '@/types/timer/time.dto';
+import { TimerStatus } from '@/types/timer/timer-status.enum';
 
-export default interface TimerStateDto {
+export interface TimerStateDto {
   status: TimerStatus;
   duration: TimeDto;
   timeLeft: TimeDto;

--- a/frontend/src/types/timer/timer-status.enum.ts
+++ b/frontend/src/types/timer/timer-status.enum.ts
@@ -1,7 +1,5 @@
-enum TimerStatus {
+export enum TimerStatus {
   RUNNING = 'running',
   PAUSED = 'paused',
   STOPPED = 'stopped',
 }
-
-export default TimerStatus;

--- a/frontend/src/types/timer/timer-with-total-time.type.tsx
+++ b/frontend/src/types/timer/timer-with-total-time.type.tsx
@@ -1,0 +1,5 @@
+import { TimeDto } from './time.dto';
+
+export type TimeWithTotalTime = TimeDto & {
+  total: number;
+};

--- a/frontend/src/types/utils.ts
+++ b/frontend/src/types/utils.ts
@@ -15,3 +15,6 @@ export type FixedLengthArray<T, N extends number> = N extends N
 type FixedLengthArrayRecursive<T, N extends number, R extends unknown[]> = R['length'] extends N
   ? R
   : FixedLengthArrayRecursive<T, N, [T, ...R]>;
+
+export const timeToString = (time: number) => (time <= 9 ? '0' : '') + time;
+export const inSeconds = (minutes: number) => minutes * 60;

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -36,60 +36,36 @@ export const MIN_MEMBERS = 4;
 
 export const RECOIL_DEV_TOOLS = NEXT_PUBLIC_RECOIL_DEV_TOOLS === 'true';
 
-// -------------------------------
-
 export const ONE_SECOND = 1000;
-
 export const BOARD_TIMER_USER_STARTED = 'board-timer.user.started';
-
 export const BOARD_TIMER_SERVER_STARTED = 'board-timer.server.started';
-
 export const BOARD_TIMER_USER_PAUSED = 'board-timer.user.paused';
-
 export const BOARD_TIMER_SERVER_PAUSED = 'board-timer.server.paused';
-
 export const BOARD_TIMER_USER_STOPPED = 'board-timer.user.stopped';
-
 export const BOARD_TIMER_SERVER_STOPPED = 'board-timer.server.stopped';
-
 export const BOARD_TIMER_USER_DURATION_UPDATED = 'board-timer.user.duration.updated';
-
 export const BOARD_TIMER_SERVER_DURATION_UPDATED = 'board-timer.server.duration.updated';
-
 export const BOARD_TIMER_SERVER_TIME_LEFT_UPDATED = 'board-timer.server.time-left.updated';
-
 export const BOARD_TIMER_USER_REQUESTED_TIMER_STATE = 'board-timer.user.requested.timer-state';
-
 export const BOARD_TIMER_SERVER_SENT_TIMER_STATE = 'board-timer.server.sent.timer-state';
-
-export const BOARD_PHASE_SERVER_SENT = 'board-phase.server.updated';
-
 export const BOARD_TIMER_PROGRESS_BAR_DEFAULT_WIDTH = 186;
-
 export const BOARD_TIMER_START_MINUTES = 5;
-
 export const BOARD_TIMER_START_SECONDS = 0;
-
 export const BOARD_TIMER_JUMP_SECONDS = 5;
-
 export const BOARD_TIMER_JUMP_MINUTES = 1;
-
 export const BOARD_TIMER_MIN_SECONDS = 30;
-
 export const BOARD_TIMER_MIN_MINUTES = 0;
-
 export const BOARD_TIMER_MAX_SECONDS = 60 - BOARD_TIMER_JUMP_SECONDS;
-
 export const BOARD_TIMER_MAX_MINUTES = 59;
-
 export const BOARD_TIMER_TOTAL_TIME =
   inSeconds(BOARD_TIMER_START_MINUTES) + BOARD_TIMER_START_SECONDS;
-
 export const BOARD_TIMER_START_TIME = {
   minutes: BOARD_TIMER_START_MINUTES,
   seconds: BOARD_TIMER_START_SECONDS,
   total: BOARD_TIMER_TOTAL_TIME,
 };
+
+export const BOARD_PHASE_SERVER_SENT = 'board-phase.server.updated';
 
 export const CARD_TEXT_DEFAULT = 'Write your comment here...';
 

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,3 +1,4 @@
+import { inSeconds } from '@/types/utils';
 import getConfig from 'next/config';
 
 const { publicRuntimeConfig, serverRuntimeConfig } = getConfig();
@@ -62,6 +63,33 @@ export const BOARD_TIMER_USER_REQUESTED_TIMER_STATE = 'board-timer.user.requeste
 export const BOARD_TIMER_SERVER_SENT_TIMER_STATE = 'board-timer.server.sent.timer-state';
 
 export const BOARD_PHASE_SERVER_SENT = 'board-phase.server.updated';
+
+export const BOARD_TIMER_PROGRESS_BAR_DEFAULT_WIDTH = 186;
+
+export const BOARD_TIMER_START_MINUTES = 5;
+
+export const BOARD_TIMER_START_SECONDS = 0;
+
+export const BOARD_TIMER_JUMP_SECONDS = 5;
+
+export const BOARD_TIMER_JUMP_MINUTES = 1;
+
+export const BOARD_TIMER_MIN_SECONDS = 30;
+
+export const BOARD_TIMER_MIN_MINUTES = 0;
+
+export const BOARD_TIMER_MAX_SECONDS = 60 - BOARD_TIMER_JUMP_SECONDS;
+
+export const BOARD_TIMER_MAX_MINUTES = 59;
+
+export const BOARD_TIMER_TOTAL_TIME =
+  inSeconds(BOARD_TIMER_START_MINUTES) + BOARD_TIMER_START_SECONDS;
+
+export const BOARD_TIMER_START_TIME = {
+  minutes: BOARD_TIMER_START_MINUTES,
+  seconds: BOARD_TIMER_START_SECONDS,
+  total: BOARD_TIMER_TOTAL_TIME,
+};
 
 export const CARD_TEXT_DEFAULT = 'Write your comment here...';
 


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to:
- #1262 

Fixes:
- #1262 

## Proposed Changes

  - In the `useTimer` (frontend) the `isActiveTimer` was not checking correctly the function `isTimerPause` it was missing the parenthesis then it was always returning `true` causing the execution of `timerStop()` function. This was the main fix in this PR.
  - In the `backend` when stopping the timer it was not checking if the timer was found (if it exists) and if it was already stopped, now it is checking, and logging it as a `warn` when the timer was not found or was found and was already stopped, it won't throw an error, it will just log it as a `warn`.

Other changes:
  - The `default` was removed from some types, interfaces and enum
  - The `constants` and helper functions were moved out from `useTimer`
  - It is now treating when a user is trying to change the status of the timer for the status it already was in those cases it will log a `warn` (it won't throw an error or log as error since it shouldn't break the API)
  
This pull request closes #
- #1262