### PR TITLE
fix: submitted action points format

### DIFF
--- a/backend/src/modules/boards/services/update.board.service.ts
+++ b/backend/src/modules/boards/services/update.board.service.ts
@@ -486,7 +486,7 @@ export default class UpdateBoardService implements UpdateBoardServiceInterface {
 
 			//Extracts the action points to a string
 			cards.map((card) => {
-				actionPoints += ` \u2022 ${card.text} \n`;
+				actionPoints += ` \u2022 ${card.text.replace(/\n{2,}/g, '\n\t')} \n`;
 			});
 
 			return (


### PR DESCRIPTION
Relates to:
- #1288 

Fixes:
-  The cards that have the "\n" doesn't stay aligned as points of a list
-  The cards with multiple "\n" have multiple new lines in the slack message

## Screenshots (if visual changes)

<img width="350" alt="image" src="https://user-images.githubusercontent.com/58892791/226909268-1c195ae8-1ee7-4f8a-b86f-68cb1a59820f.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/58892791/226909303-14221d25-2ce9-4d37-8752-8b0577008616.png">


## Proposed Changes

  - Multiple \n are replaced with only one \n
  - After a \n it is introduced a \t for spacing and alignment 
  


This pull request closes #1288
