### PR TITLE
fix: duplicate board without team

### DIFF
--- a/backend/src/modules/boards/applications/duplicate-board.use-case.ts
+++ b/backend/src/modules/boards/applications/duplicate-board.use-case.ts
@@ -114,7 +114,7 @@ export class DuplicateBoardUseCase implements UseCase<DuplicateBoardDto, Board> 
 			users,
 			columns,
 			title: boardTitle,
-			team: boardTeam._id,
+			team: boardTeam?._id,
 			slackEnable: false,
 			isSubBoard: false,
 			dividedBoards: []

--- a/frontend/src/components/CreateBoard/SplitBoard/SubTeamsTab/UsersBox/index.tsx
+++ b/frontend/src/components/CreateBoard/SplitBoard/SubTeamsTab/UsersBox/index.tsx
@@ -17,7 +17,6 @@ const UsersNames = ({ haveError, participants, title }: UsersBoxProps) => (
     <Text
       css={{
         textOverflow: 'ellipsis',
-        whiteSpace: 'nowrap',
         overflow: 'hidden',
         textAlign: 'start',
         height: '$64',


### PR DESCRIPTION
<!--
Add the issue number
-->

## Proposed Changes

  - Team can be optional when duplicating a board
  - Fix the size of the selected participant's box in the regular board creation page

<!--
Mention people who discussed this issue previously
@someone
-->

