### PR TITLE
refactor: pass href to styled components anchor

### DIFF
--- a/frontend/src/components/Board/SplitBoard/Header/index.tsx
+++ b/frontend/src/components/Board/SplitBoard/Header/index.tsx
@@ -128,6 +128,8 @@ const BoardHeader = () => {
                       mainBoardTitle: boardData?.board.title,
                     },
                   }}
+                  passHref
+                  legacyBehavior
                 >
                   <StyledBoardLink>{getSubBoard()?.title.replace('team ', '')}</StyledBoardLink>
                 </Link>

--- a/frontend/src/components/Boards/MyBoards/ListBoardsByTeam/EmptyTeamBoards/index.tsx
+++ b/frontend/src/components/Boards/MyBoards/ListBoardsByTeam/EmptyTeamBoards/index.tsx
@@ -21,6 +21,8 @@ const EmptyTeamBoards = ({ teamId }: EmptyTeamBoardsProps) => (
           pathname: `/boards/new`,
           query: { team: teamId },
         }}
+        passHref
+        legacyBehavior
       >
         <StyledNewBoardLink underline fontWeight="medium">
           Add a new team board

--- a/frontend/src/components/Boards/MyBoards/ListPersonalBoards/EmptyPersonalBoards.tsx/index.tsx
+++ b/frontend/src/components/Boards/MyBoards/ListPersonalBoards/EmptyPersonalBoards.tsx/index.tsx
@@ -16,6 +16,8 @@ const EmptyPersonalBoards = () => (
         href={{
           pathname: `/boards/new`,
         }}
+        passHref
+        legacyBehavior
       >
         <StyledNewBoardLink underline fontWeight="medium">
           Add a new personal board

--- a/frontend/src/components/Dashboard/RecentRetros/partials/EmptyBoards/index.tsx
+++ b/frontend/src/components/Dashboard/RecentRetros/partials/EmptyBoards/index.tsx
@@ -8,7 +8,7 @@ const EmptyBoards: React.FC = () => (
     <EmptyBoardsText css={{ mt: '$24', textAlign: 'center' }} size="md">
       You have not participated in any retro yet.
       <br />
-      <Link href="/boards/new">
+      <Link href="/boards/new" passHref legacyBehavior>
         <StyledNewBoardLink underline fontWeight="medium">
           Add a new retro board
         </StyledNewBoardLink>


### PR DESCRIPTION
Fixes:
![image](https://user-images.githubusercontent.com/61988699/229489356-5ce1740a-cf37-41b4-91b6-9e1e4fa75529.png)

## Proposed Changes
  - Add `passRef` and `legacyBehaviour` as recommended by [Next.js docs](https://nextjs.org/docs/api-reference/next/link#if-the-child-is-a-custom-component-that-wraps-an-a-tag).
