### PR TITLE
fix: board not found redirect

### DIFF
--- a/frontend/src/pages/boards/[boardId]/index.tsx
+++ b/frontend/src/pages/boards/[boardId]/index.tsx
@@ -44,11 +44,6 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
 
   const session = await getSession(context);
 
-  if (boardId.includes('.map'))
-    return {
-      props: {},
-    };
-
   try {
     const boardIsPublic = await getPublicStatusRequest(boardId, context);
 

--- a/frontend/src/pages/boards/[boardId]/index.tsx
+++ b/frontend/src/pages/boards/[boardId]/index.tsx
@@ -49,24 +49,27 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
       props: {},
     };
 
-  const boardIsPublic = await getPublicStatusRequest(boardId, context);
-
-  // if board is public and user has no session
-  if (boardIsPublic && !session) {
-    // check if there are guest user cookies
-    const cookiesGuestUser: GuestUser | { user: string } = getGuestUserCookies({ req, res }, true);
-    // if there isn´t cookies, the guest user is not registered
-    if (!cookiesGuestUser) {
-      return {
-        redirect: {
-          permanent: false,
-          destination: `/login-guest-user/${boardId}`,
-        },
-      };
-    }
-  }
-
   try {
+    const boardIsPublic = await getPublicStatusRequest(boardId, context);
+
+    // if board is public and user has no session
+    if (boardIsPublic && !session) {
+      // check if there are guest user cookies
+      const cookiesGuestUser: GuestUser | { user: string } = getGuestUserCookies(
+        { req, res },
+        true,
+      );
+      // if there isn´t cookies, the guest user is not registered
+      if (!cookiesGuestUser) {
+        return {
+          redirect: {
+            permanent: false,
+            destination: `/login-guest-user/${boardId}`,
+          },
+        };
+      }
+    }
+
     await queryClient.fetchQuery(['board', { id: boardId }], () =>
       getBoardRequest(boardId, context),
     );

--- a/frontend/src/pages/boards/[boardId]/index.tsx
+++ b/frontend/src/pages/boards/[boardId]/index.tsx
@@ -29,7 +29,7 @@ import { BoardUserRoles } from '@/utils/enums/board.user.roles';
 import { TeamUserRoles } from '@/utils/enums/team.user.roles';
 import isEmpty from '@/utils/isEmpty';
 import { GuestUser } from '@/types/user/user';
-import { DASHBOARD_ROUTE } from '@/utils/routes';
+import { BOARDS_ROUTE } from '@/utils/routes';
 import { getGuestUserCookies } from '@/utils/getGuestUserCookies';
 import { BoardPhases } from '@/utils/enums/board.phases';
 import ConfirmationDialog from '@/components/Primitives/Alerts/ConfirmationDialog/ConfirmationDialog';
@@ -72,7 +72,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
     return {
       redirect: {
         permanent: false,
-        destination: DASHBOARD_ROUTE,
+        destination: BOARDS_ROUTE,
       },
     };
   }


### PR DESCRIPTION
Fixes:
- #1317

## Proposed Changes
  - Wrap `getPublicStatusRequest` inside the existing try-catch, as it will redirect the user to the proper page based on the session.

This pull request closes #1317
