### PR TITLE
fix: tsconfig paths

### DIFF
--- a/frontend/.eslintrc.cjs
+++ b/frontend/.eslintrc.cjs
@@ -1,23 +1,21 @@
 const fs = require('fs');
 
-
 const folders = fs
-  .readdirSync('src', {withFileTypes: true})
-  .filter(dirent => dirent.isDirectory())
-  .map(dirent => !['styles'].includes(dirent.name) && dirent.name);
-
+  .readdirSync('src', { withFileTypes: true })
+  .filter((dirent) => dirent.isDirectory())
+  .map((dirent) => !['styles'].includes(dirent.name) && dirent.name);
 
 const tsconfigPaths = [
   '@components',
   '@helper',
   '@hooks',
   '@pages',
-  '@schemas',
+  '@schema',
   '@styles',
   '@utils',
   '@api',
   '@animations',
-  '@'
+  '@',
 ];
 
 module.exports = {
@@ -25,7 +23,7 @@ module.exports = {
   extends: ['next/core-web-vitals', 'prettier', 'plugin:storybook/recommended'],
   plugins: ['prettier'],
   rules: {
-    'prettier/prettier': ['error', {usePrettierrc: true}],
+    'prettier/prettier': ['error', { usePrettierrc: true }],
   },
   overrides: [
     {
@@ -41,12 +39,7 @@ module.exports = {
         extraFileExtensions: ['.css'],
         project: './tsconfig.json',
       },
-      plugins: [
-        '@typescript-eslint',
-        'simple-import-sort',
-        'import',
-        'unused-imports',
-      ],
+      plugins: ['@typescript-eslint', 'simple-import-sort', 'import', 'unused-imports'],
       rules: {
         '@typescript-eslint/ban-types': 'warn',
         '@typescript-eslint/no-empty-function': 'warn',
@@ -108,7 +101,7 @@ module.exports = {
         'react/prop-types': 'off',
         'react/react-in-jsx-scope': 'off',
         'react/display-name': 'off',
-        'react/jsx-curly-brace-presence': ['error', {props: 'never'}],
+        'react/jsx-curly-brace-presence': ['error', { props: 'never' }],
         'react/jsx-boolean-value': ['error', 'never'],
         'react/jsx-sort-props': [
           'error',

--- a/frontend/.storybook/main.js
+++ b/frontend/.storybook/main.js
@@ -22,7 +22,7 @@ module.exports = {
       '@helper': path.resolve(__dirname, '../src/helper'),
       '@hooks': path.resolve(__dirname, '../src/hooks'),
       '@pages': path.resolve(__dirname, '../src/pages'),
-      '@schemas': path.resolve(__dirname, '../src/schemas'),
+      '@schema': path.resolve(__dirname, '../src/schema'),
       '@styles': path.resolve(__dirname, '../src/styles'),
       '@utils': path.resolve(__dirname, '../src/utils'),
       '@api': path.resolve(__dirname, '../src/api'),

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -18,14 +18,14 @@
     "baseUrl": ".",
     "paths": {
       "@components/*": ["./src/components/*"],
-      "@helper": ["./src/helper/*"],
-      "@hooks": ["./src/hooks/*"],
-      "@pages": ["./src/pages/*"],
-      "@schemas": ["./src/schemas/*"],
-      "@styles": ["./src/styles/*"],
-      "@utils": ["./src/utils/*"],
-      "@api": ["./src/api/*"],
-      "@animations": ["./src/animations/*"],
+      "@helper/*": ["./src/helper/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@pages/*": ["./src/pages/*"],
+      "@schema/*": ["./src/schema/*"],
+      "@styles/*": ["./src/styles/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@api/*": ["./src/api/*"],
+      "@animations/*": ["./src/animations/*"],
       "@/*": ["./src/*"],
       "@/public/*": ["./public/*"]
     }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -17,7 +17,7 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@components": ["./src/components/*"],
+      "@components/*": ["./src/components/*"],
       "@helper": ["./src/helper/*"],
       "@hooks": ["./src/hooks/*"],
       "@pages": ["./src/pages/*"],


### PR DESCRIPTION
## Screenshots
| Old                                                                                                                                        | New                                                                                                                                        |
|--------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="1173" alt="image" src="https://user-images.githubusercontent.com/61988699/232013373-27f3b704-e9fc-495a-a848-b732ddb3e1e9.png"> | <img width="1173" alt="image" src="https://user-images.githubusercontent.com/61988699/232021496-ee54da12-0074-4bb3-aaa4-b6c6ddd6eea1.png"> |


## Proposed Changes
  - Add `/*` to the paths in `tsconfig`, so that it can import folders inside it. This wasn't working because the main folders didn't have an index file.
  - Fix `schema` typo.
