### PR TITLE
feat(1398): global styles unnecesssary render

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -39,6 +39,8 @@ const QUERY_OPTIONS: QueryClientConfig = {
   },
 };
 
+globalStyles();
+
 function Root({
   Component,
   pageProps,
@@ -48,7 +50,6 @@ function Root({
   const getLayout = Component.getLayout ?? ((page) => page);
 
   const router = useRouter();
-  globalStyles();
 
   return (
     <>


### PR DESCRIPTION
Relates to:
- #1398 

## Screenshots (if visual changes)
the screenshots are just a way to demonstrate what was happening
#### Before
https://user-images.githubusercontent.com/104831678/232074880-d33bc45f-879b-48e3-b387-8019ea7f3df1.mov

#### Now
https://user-images.githubusercontent.com/104831678/232074894-70261e42-3b1f-44e0-923d-e095f4ff081a.mov

## Proposed Changes

  - the best thing is to place it outside the comp, if we put it inside what will happen is that every time we change pages everything inside “myapp/root” will be rendered again, but the global styles do not change between each page or best place is to put outside myapp



This pull request closes #1398
