### PR TITLE
fix: scroll on boards list

### DIFF
--- a/frontend/src/components/CardBoard/CardBody/CardBody.tsx
+++ b/frontend/src/components/CardBoard/CardBody/CardBody.tsx
@@ -44,9 +44,11 @@ const NewCircleIndicator = styled('div', {
     position: {
       absolute: {
         position: 'absolute',
-        left: '$12',
+        left: '$6',
         top: '50%',
         transform: 'translateY(-50%)',
+
+        '@md': { left: '$12' },
       },
     },
   },

--- a/frontend/src/components/Users/UsersList/UsersList.tsx
+++ b/frontend/src/components/Users/UsersList/UsersList.tsx
@@ -45,7 +45,7 @@ const UsersList = () => {
   }, [search]);
 
   return (
-    <Flex direction="column" gap="16">
+    <Flex css={{ overflow: 'hidden' }} direction="column" gap="16">
       <UsersSubHeader
         handleClearSearch={handleClearSearch}
         handleSearchUser={handleSearchUser}
@@ -59,7 +59,6 @@ const UsersList = () => {
         onScroll={onScroll}
         ref={scrollRef}
         css={{
-          height: '100%',
           position: 'relative',
           overflowY: 'auto',
         }}

--- a/frontend/src/components/layouts/Layout/styles.tsx
+++ b/frontend/src/components/layouts/Layout/styles.tsx
@@ -9,7 +9,7 @@ const Container = styled('main', {
 });
 
 const ContentSection = styled('section', Flex, {
-  flexGrow: 1,
+  height: '100%',
   mt: '$82',
   padding: '$64 $24 $24',
 


### PR DESCRIPTION
Fixes:
- #1454

## Screenshots (if visual changes)
| Old                                                                                                             | New                                                                                                             |
|-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------|
| ![image](https://user-images.githubusercontent.com/61988699/235931690-a6121d50-f64e-4713-af48-fde116fd401f.png) | ![image](https://user-images.githubusercontent.com/61988699/235931802-deff7a16-4f37-444e-865c-1fe88eb0c496.png) |
| ![image](https://user-images.githubusercontent.com/61988699/235931600-d6731fa1-1f9c-4a8a-af48-a383eee7e12f.png) | ![image](https://user-images.githubusercontent.com/61988699/235931455-46da6c25-6bb0-4f24-b3e5-089f51c92d1d.png) |

## Proposed Changes
  - Add `height: '100%'` instead of `flexGrow: 1` to the layout.
  - Add `overflow: 'hidden'` to the users container.
  - Fix dot positioning on smaller cards.

This pull request closes #1454
