### PR TITLE
fix: popover border in main board

### DIFF
--- a/frontend/src/components/Board/SplitBoard/Header/index.tsx
+++ b/frontend/src/components/Board/SplitBoard/Header/index.tsx
@@ -276,7 +276,7 @@ const BoardHeader = () => {
             </BoardCounter>
           </PopoverTrigger>
           <PopoverPortal>
-            <StyledPopoverContent>
+            <StyledPopoverContent onOpenAutoFocus={(e) => e.preventDefault()}>
               <Flex direction="column">
                 {dividedBoards.map((board: BoardType) => (
                   <StyledPopoverItem key={board.title.toLowerCase().split(' ').join('-')}>


### PR DESCRIPTION


Relates to:
- #1323

Fixes:
- #1323

## Screenshots (if visual changes)
![image](https://user-images.githubusercontent.com/58892791/235942120-4433e77d-dd9d-4d5b-81d0-4182fc8675d9.png)

## Proposed Changes

  - adding the `eventPreventDefault` on the `onOpenAutoFocus` prop
  


This pull request closes #1323
