### PR TITLE
feat: issue 945 soft delete users

### DIFF
--- a/backend/src/infrastructure/database/mongoose.module.ts
+++ b/backend/src/infrastructure/database/mongoose.module.ts
@@ -8,6 +8,7 @@ import Schedules, { SchedulesSchema } from 'src/modules/schedules/entities/sched
 import TeamUser, { TeamUserSchema } from 'src/modules/teamUsers/entities/team.user.schema';
 import Team, { TeamSchema } from 'src/modules/teams/entities/team.schema';
 import User, { UserSchema } from 'src/modules/users/entities/user.schema';
+import { SoftDeletePlugin } from './plugins/soft-delete.plugin';
 
 export const mongooseBoardModule = MongooseModule.forFeature([
 	{ name: Board.name, schema: BoardSchema }
@@ -17,8 +18,16 @@ export const mongooseBoardUserModule = MongooseModule.forFeature([
 	{ name: BoardUser.name, schema: BoardUserSchema }
 ]);
 
-export const mongooseUserModule = MongooseModule.forFeature([
-	{ name: User.name, schema: UserSchema }
+export const mongooseUserModule = MongooseModule.forFeatureAsync([
+	{
+		name: User.name,
+		useFactory: () => {
+			const schema = UserSchema;
+			schema.plugin(SoftDeletePlugin);
+
+			return schema;
+		}
+	}
 ]);
 
 export const mongooseResetModule = MongooseModule.forFeature([

--- a/backend/src/infrastructure/database/plugins/soft-delete-not-mocked.plugin.spec.ignore.ts
+++ b/backend/src/infrastructure/database/plugins/soft-delete-not-mocked.plugin.spec.ignore.ts
@@ -1,0 +1,432 @@
+import { randomBytes } from 'node:crypto';
+import mongoose, { Document, Schema, model } from 'mongoose';
+import { SoftDeleteModel, SoftDeletePlugin } from './soft-delete.plugin';
+
+/**
+ * To run this tests please remove '.ignore' from the name of the file,
+ * these tests are ignored because they're intendend to be tested with a database
+ * available at mongodb://127.0.0.1:27017/(generated automatically)
+ * The database will be created (with a random name) at the beggining of the tests and dropped after they run
+ */
+
+describe('SoftDeletePlugin', () => {
+	interface IPost extends Document {
+		_id: string;
+		name: string;
+	}
+
+	const PostSchema = new Schema({ name: String });
+	PostSchema.plugin(SoftDeletePlugin);
+
+	const PostModel = model<IPost, SoftDeleteModel<IPost>>('Post', PostSchema);
+
+	const dbName = randomBytes(10).toString('hex');
+	beforeAll(async () => {
+		mongoose.set('strictQuery', false);
+		await mongoose.connect(`mongodb://127.0.0.1:27017/${dbName}`);
+	});
+	afterAll(async () => {
+		await mongoose.connection.db.dropDatabase();
+		await mongoose.disconnect();
+	});
+
+	it("should 'forceDelete' rows", async () => {
+		await PostModel.create({ name: 'forceDeleteMany' });
+		await PostModel.create({ name: 'forceDeleteMany' });
+		expect(await PostModel.count().exec()).toBe(2);
+		const resultFD = await PostModel.forceDelete({ name: 'forceDeleteMany' });
+		expect(resultFD.deletedCount).toBe(2);
+		expect(await PostModel.count().exec()).toBe(0);
+	});
+	it("should 'softDelete' row", async () => {
+		const row = await PostModel.create({ name: 'softDelete' });
+		expect(await PostModel.count().exec()).toBe(1);
+		await PostModel.softDelete({ _id: row._id.toString() });
+		expect(await PostModel.count().exec()).toBe(0);
+		expect(await PostModel.findDeleted()).toHaveLength(1);
+		await PostModel.forceDelete({ _id: row._id.toString() });
+		expect(await PostModel.count().exec()).toBe(0);
+		expect(await PostModel.findDeleted()).toHaveLength(0);
+	});
+	it("should 'findDeleted' row", async () => {
+		const row = await PostModel.create({ name: 'findDeleted' });
+		expect(await PostModel.count().exec()).toBe(1);
+		await PostModel.deleteOne({ _id: row._id.toString() }).exec();
+		expect(await PostModel.count().exec()).toBe(0);
+		expect(await PostModel.findDeleted()).toHaveLength(1);
+		await PostModel.forceDelete({ _id: row._id.toString() });
+		expect(await PostModel.count().exec()).toBe(0);
+		expect(await PostModel.findDeleted()).toHaveLength(0);
+	});
+	it("should 'countDeleted' row", async () => {
+		const row = await PostModel.create({ name: 'countDeleted' });
+		expect(await PostModel.count().exec()).toBe(1);
+		await PostModel.deleteOne({ _id: row._id.toString() }).exec();
+		expect(await PostModel.count().exec()).toBe(0);
+		expect(await PostModel.countDeleted()).toBe(1);
+		await PostModel.forceDelete({ _id: row._id.toString() });
+		expect(await PostModel.count().exec()).toBe(0);
+		expect(await PostModel.countDeleted()).toBe(0);
+	});
+	it("should 'restore' row", async () => {
+		const row = await PostModel.create({ name: 'restore' });
+		expect(await PostModel.count().exec()).toBe(1);
+		await PostModel.deleteOne({ _id: row._id.toString() }).exec();
+		expect(await PostModel.count().exec()).toBe(0);
+		expect(await PostModel.findDeleted()).toHaveLength(1);
+		await PostModel.restore({ _id: row._id.toString() });
+		expect(await PostModel.count().exec()).toBe(1);
+		expect(await PostModel.findDeleted()).toHaveLength(0);
+		await PostModel.forceDelete({ _id: row._id.toString() });
+		expect(await PostModel.count().exec()).toBe(0);
+		expect(await PostModel.findDeleted()).toHaveLength(0);
+	});
+	it("should 'restoreMany' rows", async () => {
+		await PostModel.create({ name: 'restoreMany' });
+		await PostModel.create({ name: 'restoreMany' });
+		expect(await PostModel.count().exec()).toBe(2);
+		await PostModel.deleteMany({ name: 'restoreMany' }).exec();
+		expect(await PostModel.count().exec()).toBe(0);
+		expect(await PostModel.findDeleted()).toHaveLength(2);
+		await PostModel.restore({ name: 'restoreMany' });
+		expect(await PostModel.count().exec()).toBe(2);
+		expect(await PostModel.findDeleted()).toHaveLength(0);
+		await PostModel.forceDelete({ name: 'restoreMany' });
+		expect(await PostModel.count().exec()).toBe(0);
+		expect(await PostModel.findDeleted()).toHaveLength(0);
+	});
+	describe('mongoose middleware functions - query', () => {
+		afterEach(async () => {
+			expect(await PostModel.count().exec()).toBe(0);
+			expect(await PostModel.countDeleted()).toBe(0);
+		});
+		it("should not 'find' deleted rows", async () => {
+			await PostModel.create({ name: 'find' });
+			await PostModel.create({
+				name: 'find',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			expect(await PostModel.find().exec()).toHaveLength(1);
+			expect(await PostModel.findDeleted()).toHaveLength(1);
+			await PostModel.forceDelete({ name: 'find' });
+		});
+		it("should not 'count' deleted rows", async () => {
+			await PostModel.create({ name: 'find' });
+			await PostModel.create({
+				name: 'find',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.findDeleted()).toHaveLength(1);
+			await PostModel.forceDelete({ name: 'find' });
+		});
+		it("should not 'countDocuments' deleted rows", async () => {
+			await PostModel.create({ name: 'find' });
+			await PostModel.create({
+				name: 'find',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			expect(await PostModel.countDocuments().exec()).toBe(1);
+			expect(await PostModel.findDeleted()).toHaveLength(1);
+			await PostModel.forceDelete({ name: 'find' });
+		});
+		it("should not 'findOne' deleted rows", async () => {
+			await PostModel.create({ name: 'find' });
+			const row = await PostModel.create({
+				name: 'find',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			expect(await PostModel.findOne({ _id: row._id.toString() })).toBe(null);
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({ name: 'find' });
+		});
+		it("should not 'findOneAndUpdate' deleted rows", async () => {
+			const row = await PostModel.create({ name: 'findOneAndUpdate' });
+			const rowDeleted = await PostModel.create({
+				name: 'findOneAndUpdate',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			await PostModel.findOneAndUpdate(
+				{ _id: row._id.toString() },
+				{ $set: { name: 'updated' } }
+			).exec();
+			await PostModel.findOneAndUpdate(
+				{ _id: rowDeleted._id.toString() },
+				{ $set: { name: 'updated' } }
+			).exec();
+			expect(await PostModel.findOne({ _id: row._id.toString() })).toHaveProperty(
+				'name',
+				'updated'
+			);
+			expect((await PostModel.findDeleted({ _id: rowDeleted._id.toString() }))[0]).toHaveProperty(
+				'name',
+				'findOneAndUpdate'
+			);
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: { $in: [row._id.toString(), rowDeleted._id.toString()] }
+			});
+		});
+		it("should not 'updateOne' deleted rows", async () => {
+			const row = await PostModel.create({ name: 'updateOne' });
+			const rowDeleted = await PostModel.create({
+				name: 'updateOne',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			await PostModel.updateOne({ _id: row._id.toString() }, { $set: { name: 'updated' } }).exec();
+			await PostModel.updateOne(
+				{ _id: rowDeleted._id.toString() },
+				{ $set: { name: 'updated' } }
+			).exec();
+			expect(await PostModel.findOne({ _id: row._id.toString() })).toHaveProperty(
+				'name',
+				'updated'
+			);
+			expect((await PostModel.findDeleted({ _id: rowDeleted._id.toString() }))[0]).toHaveProperty(
+				'name',
+				'updateOne'
+			);
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: { $in: [row._id.toString(), rowDeleted._id.toString()] }
+			});
+		});
+		it("should not 'updateMany' deleted rows", async () => {
+			const row = await PostModel.create({ name: 'updateMany' });
+			const rowDeleted = await PostModel.create({
+				name: 'updateMany',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			await PostModel.updateMany({ name: 'updateMany' }, { $set: { name: 'updated' } }).exec();
+			expect(await PostModel.findOne({ _id: row._id.toString() })).toHaveProperty(
+				'name',
+				'updated'
+			);
+			expect((await PostModel.findDeleted({ _id: rowDeleted._id.toString() }))[0]).toHaveProperty(
+				'name',
+				'updateMany'
+			);
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: { $in: [row._id.toString(), rowDeleted._id.toString()] }
+			});
+		});
+		it("should not 'findOneAndReplace' deleted rows", async () => {
+			const row = await PostModel.create({ name: 'findOneAndReplace' });
+			const rowDeleted = await PostModel.create({
+				name: 'findOneAndReplace',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			await PostModel.findOneAndReplace({ _id: row._id.toString() }, { name: 'updated' }).exec();
+			await PostModel.findOneAndReplace(
+				{ _id: rowDeleted._id.toString() },
+				{ name: 'updated' }
+			).exec();
+			expect(await PostModel.findOne({ _id: row._id.toString() })).toHaveProperty(
+				'name',
+				'updated'
+			);
+			expect((await PostModel.findDeleted({ _id: rowDeleted._id.toString() }))[0]).toHaveProperty(
+				'name',
+				'findOneAndReplace'
+			);
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: { $in: [row._id.toString(), rowDeleted._id.toString()] }
+			});
+		});
+		it("should not 'replaceOne' deleted rows", async () => {
+			const row = await PostModel.create({ name: 'replaceOne' });
+			const rowDeleted = await PostModel.create({
+				name: 'replaceOne',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			await PostModel.replaceOne({ _id: row._id.toString() }, { name: 'updated' }).exec();
+			await PostModel.replaceOne({ _id: rowDeleted._id.toString() }, { name: 'updated' }).exec();
+			expect(await PostModel.findOne({ _id: row._id.toString() })).toHaveProperty(
+				'name',
+				'updated'
+			);
+			expect((await PostModel.findDeleted({ _id: rowDeleted._id.toString() }))[0]).toHaveProperty(
+				'name',
+				'replaceOne'
+			);
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: { $in: [row._id.toString(), rowDeleted._id.toString()] }
+			});
+		});
+		it("set state isDeleted with 'deleteOne'", async () => {
+			const row = await PostModel.create({ name: 'deleteOne' });
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(0);
+			const result = await PostModel.deleteOne({ _id: row._id.toString() });
+			expect(result.deletedCount).toBe(1);
+			expect(await PostModel.count().exec()).toBe(0);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: row._id.toString()
+			});
+		});
+		it("set state isDeleted with 'deleteMany'", async () => {
+			await PostModel.create({ name: 'deleteMany' });
+			await PostModel.create({ name: 'deleteMany' });
+			expect(await PostModel.count().exec()).toBe(2);
+			expect(await PostModel.countDeleted()).toBe(0);
+			const result = await PostModel.deleteMany({ name: 'deleteMany' }).exec();
+			expect(result.deletedCount).toBe(2);
+			expect(await PostModel.count().exec()).toBe(0);
+			expect(await PostModel.countDeleted()).toBe(2);
+			await PostModel.forceDelete({
+				name: 'deleteMany'
+			});
+		});
+		it("set state isDeleted with 'findOneAndDelete'", async () => {
+			const row = await PostModel.create({ name: 'findOneAndDelete' });
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(0);
+			const result = await PostModel.findByIdAndDelete({ _id: row._id.toString() });
+			expect(result._id.toString()).toBe(row._id.toString());
+			expect(await PostModel.count().exec()).toBe(0);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: row._id.toString()
+			});
+		});
+		it("set state isDeleted with 'findOneAndRemove'", async () => {
+			const row = await PostModel.create({ name: 'findOneAndRemove' });
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(0);
+			const result = await PostModel.findOneAndRemove({ _id: row._id.toString() });
+			expect(result._id.toString()).toBe(row._id.toString());
+			expect(await PostModel.count().exec()).toBe(0);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: row._id.toString()
+			});
+		});
+	});
+	describe('mongoose middleware functions - document', () => {
+		afterEach(async () => {
+			expect(await PostModel.count().exec()).toBe(0);
+			expect(await PostModel.countDeleted()).toBe(0);
+		});
+		it("should not 'update' deleted rows", async () => {
+			const row = await PostModel.create({ name: 'update' });
+			const rowDeleted = await PostModel.create({
+				name: 'update',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			await row.update({ $set: { name: 'updated' } }).exec();
+			await rowDeleted.update({ $set: { name: 'updated' } }).exec();
+			expect(await PostModel.findOne({ _id: row._id.toString() })).toHaveProperty(
+				'name',
+				'updated'
+			);
+			expect((await PostModel.findDeleted({ _id: rowDeleted._id.toString() }))[0]).toHaveProperty(
+				'name',
+				'update'
+			);
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: { $in: [row._id.toString(), rowDeleted._id.toString()] }
+			});
+		});
+		it("should not 'updateOne' deleted rows", async () => {
+			const row = await PostModel.create({ name: 'updateOne' });
+			const rowDeleted = await PostModel.create({
+				name: 'updateOne',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			await row.updateOne({ $set: { name: 'updated' } }).exec();
+			await rowDeleted.updateOne({ $set: { name: 'updated' } }).exec();
+			expect(await PostModel.findOne({ _id: row._id.toString() })).toHaveProperty(
+				'name',
+				'updated'
+			);
+			expect((await PostModel.findDeleted({ _id: rowDeleted._id.toString() }))[0]).toHaveProperty(
+				'name',
+				'updateOne'
+			);
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: { $in: [row._id.toString(), rowDeleted._id.toString()] }
+			});
+		});
+		it("should not 'replaceOne' deleted rows", async () => {
+			const row = await PostModel.create({ name: 'replaceOne' });
+			const rowDeleted = await PostModel.create({
+				name: 'replaceOne',
+				isDeleted: true,
+				deletedAt: new Date()
+			});
+			await row.replaceOne({ name: 'updated' }).exec();
+			await rowDeleted.replaceOne({ name: 'updated' }).exec();
+			expect(await PostModel.findOne({ _id: row._id.toString() })).toHaveProperty(
+				'name',
+				'updated'
+			);
+			expect((await PostModel.findDeleted({ _id: rowDeleted._id.toString() }))[0]).toHaveProperty(
+				'name',
+				'replaceOne'
+			);
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: { $in: [row._id.toString(), rowDeleted._id.toString()] }
+			});
+		});
+		it("set state isDeleted with 'deleteOne'", async () => {
+			const row = await PostModel.create({ name: 'deleteOne' });
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(0);
+			await row.deleteOne();
+			expect(await PostModel.count().exec()).toBe(0);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: row._id.toString()
+			});
+		});
+		it("set state isDeleted with 'delete'", async () => {
+			const row = await PostModel.create({ name: 'delete' });
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(0);
+			await row.delete();
+			expect(await PostModel.count().exec()).toBe(0);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: row._id.toString()
+			});
+		});
+		it("set state isDeleted with 'remove'", async () => {
+			const row = await PostModel.create({ name: 'remove' });
+			expect(await PostModel.count().exec()).toBe(1);
+			expect(await PostModel.countDeleted()).toBe(0);
+			await row.remove();
+			expect(await PostModel.count().exec()).toBe(0);
+			expect(await PostModel.countDeleted()).toBe(1);
+			await PostModel.forceDelete({
+				_id: row._id.toString()
+			});
+		});
+	});
+});

--- a/backend/src/infrastructure/database/plugins/soft-delete.plugin.ts
+++ b/backend/src/infrastructure/database/plugins/soft-delete.plugin.ts
@@ -1,0 +1,247 @@
+import { DeleteResult } from 'mongodb';
+import mongoose, {
+	Document,
+	FilterQuery,
+	Model,
+	MongooseDocumentMiddleware,
+	MongooseQueryMiddleware,
+	Query,
+	QueryOptions,
+	Schema
+} from 'mongoose';
+
+export type TSoftDelete<T> = T & {
+	isDeleted: boolean;
+	deletedAt?: Date | null;
+};
+
+export interface SoftDeleteModel<T> extends Model<TSoftDelete<T>> {
+	countDeleted(query?: FilterQuery<T>): Promise<number>;
+	findDeleted(query?: FilterQuery<T>): Promise<Array<TSoftDelete<T>>>;
+	forceDelete(query: FilterQuery<T>, options?: QueryOptions<any>): Promise<DeleteResult>;
+	restore(query: FilterQuery<T>): Promise<Array<T>>;
+	softDelete(query: FilterQuery<T>, options?: QueryOptions<T>): Promise<Array<T>>;
+}
+
+type TSoftDeleteDocument = TSoftDelete<Document>;
+
+//Used to inject data into the query object to count deleted documents to be used in post hook to return that value
+type SoftDeleteQuery = Query<any, any> & {
+	deletedCount: number;
+	isForceDelete: boolean;
+};
+
+//Find hooks for pre
+const findTypesQueryMiddleware = [
+	'count',
+	'countDocuments',
+	'delete',
+	'deleteOne',
+	'deleteMany',
+	'find',
+	'findOne',
+	'findOneAndDelete',
+	'findOneAndRemove',
+	'findOneAndReplace',
+	'findOneAndUpdate',
+	'remove',
+	'replaceOne',
+	'update',
+	'updateOne',
+	'updateMany'
+];
+
+//Delete hooks for pre "query"
+const deleteTypesQueryMiddleware = [
+	'delete',
+	'deleteMany',
+	'deleteOne',
+	'findOneAndDelete',
+	'findOneAndRemove',
+	'remove'
+];
+
+//Delete hooks for pre "document"
+const deleteTypesDocumentMiddleware = ['delete', 'deleteOne', 'remove'];
+
+export function SoftDeletePlugin(schema: Schema) {
+	schema.add({
+		isDeleted: {
+			type: Boolean,
+			required: true,
+			default: false
+		},
+		deletedAt: {
+			type: Date,
+			default: null
+		}
+	});
+
+	//Add isDeleted field to query if it doesn't exist
+	schema.pre(
+		findTypesQueryMiddleware as Array<MongooseQueryMiddleware>,
+		async function softDeleteFind() {
+			if (this instanceof Query && !('isDeleted' in this.getFilter())) {
+				this.setQuery({ ...this.getFilter(), isDeleted: { $ne: true } });
+			}
+		}
+	);
+
+	schema.pre('aggregate', async function softDeleteAggregate() {
+		this.pipeline().unshift({ $match: { isDeleted: { $ne: true } } });
+	});
+
+	//Soft-delete documents
+	schema.pre(
+		deleteTypesQueryMiddleware as Array<MongooseQueryMiddleware>,
+		{ query: true, document: false },
+		async function softDelete(this: SoftDeleteQuery) {
+			this.deletedCount = 0;
+			this.isForceDelete = false;
+
+			if (this instanceof Query && !('isDeleted' in this.getFilter())) {
+				this.setQuery({ ...this.getFilter(), isDeleted: { $ne: true } });
+			}
+
+			if (!('forceDelete' in this.getFilter())) {
+				const docs: Array<TSoftDeleteDocument> = await this.find(
+					this.getQuery(),
+					undefined,
+					this.getOptions()
+				)
+					.clone()
+					.exec();
+
+				for (const doc of docs) {
+					doc.isDeleted = true;
+					doc.deletedAt = new Date();
+					doc.$isDeleted(true);
+
+					await doc.save({ session: this.getOptions().session });
+
+					this.deletedCount++;
+				}
+			} else {
+				this.isForceDelete = true;
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				const { forceDelete, isDeleted, ...rest } = this.getFilter();
+				this.setQuery({ ...rest });
+			}
+		}
+	);
+
+	schema.pre(
+		deleteTypesDocumentMiddleware as Array<MongooseDocumentMiddleware>,
+		{ document: true, query: false },
+		async function softDelete() {
+			const doc = this as TSoftDeleteDocument;
+			doc.isDeleted = true;
+			doc.deletedAt = new Date();
+			doc.$isDeleted(true);
+			await doc.save();
+		}
+	);
+
+	schema.post(
+		['deleteOne', 'deleteMany', 'remove'] as Array<MongooseQueryMiddleware>,
+		{ query: true, document: false },
+		async function (this: SoftDeleteQuery): Promise<DeleteResult> {
+			if (!this.isForceDelete) {
+				// eslint-disable-next-line @typescript-eslint/no-unused-vars
+				const { isDeleted, ...query } = this.getFilter();
+				this.setQuery({ ...query, isDeleted: true });
+
+				return (mongoose as any).overwriteMiddlewareResult({
+					acknowledged: true,
+					deletedCount: this.deletedCount
+				});
+			}
+		}
+	);
+	schema.post(
+		['findOneAndRemove', 'findOneAndDelete'] as Array<MongooseQueryMiddleware>,
+		{ query: true, document: false },
+		async function (): Promise<TSoftDeleteDocument> {
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { isDeleted, ...query } = this.getFilter();
+			this.setQuery({ ...query, isDeleted: true });
+			const doc = await this.findOne(this.getQuery()).clone().exec();
+
+			return (mongoose as any).overwriteMiddlewareResult(doc);
+		}
+	);
+
+	//Helper to find deleted documents
+	schema.static(
+		'findDeleted',
+		async function (query?: FilterQuery<TSoftDelete<any>>): Promise<number> {
+			if (!query) {
+				query = {};
+			}
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { isDeleted, ...rest } = query;
+			query = { ...rest, isDeleted: true };
+
+			return this.find(query).clone().exec();
+		}
+	);
+
+	schema.static(
+		'countDeleted',
+		async function (query?: FilterQuery<TSoftDelete<any>>): Promise<number> {
+			if (!query) {
+				query = {};
+			}
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			const { isDeleted, ...rest } = query;
+			query = { ...rest, isDeleted: true };
+
+			return this.count(query).clone().exec();
+		}
+	);
+
+	//Helper to restore documents
+	schema.static('restore', async function (query: FilterQuery<TSoftDelete<any>>): Promise<
+		Array<TSoftDelete<Document & any>>
+	> {
+		// eslint-disable-next-line @typescript-eslint/no-unused-vars
+		const { isDeleted, ...rest } = query;
+		query = { ...rest, isDeleted: true };
+
+		return this.updateMany(query, {
+			$set: {
+				isDeleted: false,
+				deletedAt: null
+			}
+		});
+	});
+
+	//Helper to force delete documents
+	schema.static(
+		'forceDelete',
+		async function (query: FilterQuery<any>, options?: QueryOptions<any>): Promise<DeleteResult> {
+			if (!('forceDelete' in query)) {
+				query = { ...query, forceDelete: true };
+			}
+
+			return this.deleteMany(query, options);
+		}
+	);
+
+	//Helper to soft delete documents
+	schema.static('softDelete', async function <
+		T
+	>(query: FilterQuery<T>, options?: QueryOptions<T>): Promise<Array<TSoftDelete<Document & T>>> {
+		const docs: Array<TSoftDelete<Document & T>> = await this.find(query, null, options)
+			.clone()
+			.exec();
+		for (const doc of docs) {
+			doc.isDeleted = true;
+			doc.deletedAt = new Date();
+			doc.$isDeleted(true);
+			await doc.save(options);
+		}
+
+		return docs;
+	});
+}

--- a/backend/src/modules/boardUsers/interfaces/repositories/board-user.repository.interface.ts
+++ b/backend/src/modules/boardUsers/interfaces/repositories/board-user.repository.interface.ts
@@ -8,6 +8,7 @@ import { BulkWriteResult, DeleteResult } from 'mongodb';
 export interface BoardUserRepositoryInterface extends BaseInterfaceRepository<BoardUser> {
 	getAllBoardsIdsOfUser(userId: string): Promise<BoardUser[]>;
 	getAllBoardUsersOfBoard(boardId: string): Promise<BoardUser[]>;
+	getAllOpenBoardsIdsOfUser(userId: string);
 	getBoardResponsible(boardId: string): Promise<BoardUser>;
 	getVotesCount(boardId: string): Promise<BoardUser[]>;
 	getBoardUser(board: string, user: string): Promise<BoardUser>;
@@ -27,7 +28,7 @@ export interface BoardUserRepositoryInterface extends BaseInterfaceRepository<Bo
 		boardId: ObjectId | string
 	): Promise<number>;
 	deleteSimpleBoardUsers(boardId: ObjectId | string, withSession: boolean): Promise<number>;
-	deleteBoardUsers(boardUsers: string[]): Promise<number>;
+	deleteBoardUsers(boardUsers: string[], withSession?: boolean): Promise<number>;
 	deleteBoardUsersByBoardList(
 		teamBoardsIds: string[],
 		withSession?: boolean

--- a/backend/src/modules/boardUsers/interfaces/services/delete.board.user.service.interface.ts
+++ b/backend/src/modules/boardUsers/interfaces/services/delete.board.user.service.interface.ts
@@ -15,4 +15,9 @@ export interface DeleteBoardUserServiceInterface extends SessionInterface {
 		teamBoardsIds: string[],
 		withSession?: boolean
 	): Promise<DeleteResult>;
+	deleteBoardUserFromOpenBoards(userId: string, withSession?: boolean);
+	startTransaction(): Promise<void>;
+	commitTransaction(): Promise<void>;
+	abortTransaction(): Promise<void>;
+	endSession(): Promise<void>;
 }

--- a/backend/src/modules/boardUsers/interfaces/services/get.board.user.service.interface.ts
+++ b/backend/src/modules/boardUsers/interfaces/services/get.board.user.service.interface.ts
@@ -5,6 +5,8 @@ export interface GetBoardUserServiceInterface {
 
 	getAllBoardUsersOfBoard(boardId: string): Promise<BoardUser[]>;
 
+	getAllOpenBoardsOfUser(userId: string): Promise<BoardUser[]>;
+
 	getBoardResponsible(boardId: string): Promise<BoardUser>;
 
 	getVotesCount(boardId: string): Promise<BoardUser[]>;

--- a/backend/src/modules/boardUsers/repositories/board-user.repository.ts
+++ b/backend/src/modules/boardUsers/repositories/board-user.repository.ts
@@ -23,6 +23,16 @@ export class BoardUserRepository
 		return this.findAllWithQuery({ user: userId }, null, 'board');
 	}
 
+	async getAllOpenBoardsIdsOfUser(userId: string) {
+		const boards = await this.findAllWithQuery({ user: userId }, null, 'board', {
+			path: 'board',
+			select: '_id',
+			match: { submitedAt: { $eq: null } }
+		});
+
+		return boards.filter((b) => b.board !== null).map((b) => b._id);
+	}
+
 	getAllBoardUsersOfBoard(boardId: string) {
 		return this.findAllWithQuery({ board: boardId });
 	}
@@ -108,10 +118,13 @@ export class BoardUserRepository
 		);
 	}
 
-	deleteBoardUsers(boardUsers: string[]) {
-		return this.deleteMany({
-			_id: { $in: boardUsers }
-		});
+	deleteBoardUsers(boardUsers: string[], withSession?: boolean) {
+		return this.deleteMany(
+			{
+				_id: { $in: boardUsers }
+			},
+			withSession
+		);
 	}
 
 	deleteBoardUsersByBoardList(teamBoardsIds: string[], withSession?: boolean) {

--- a/backend/src/modules/boardUsers/services/delete.board.user.service.ts
+++ b/backend/src/modules/boardUsers/services/delete.board.user.service.ts
@@ -40,6 +40,12 @@ export default class DeleteBoardUserService implements DeleteBoardUserServiceInt
 		return this.boardUserRepository.deleteBoardUsers(boardUsers);
 	}
 
+	async deleteBoardUserFromOpenBoards(userId: string, withSession?: boolean) {
+		const boardUsers = await this.boardUserRepository.getAllOpenBoardsIdsOfUser(userId);
+
+		return this.boardUserRepository.deleteBoardUsers(boardUsers, withSession);
+	}
+
 	startTransaction(): Promise<void> {
 		return this.boardUserRepository.startTransaction();
 	}

--- a/backend/src/modules/boardUsers/services/get.board.user.service.ts
+++ b/backend/src/modules/boardUsers/services/get.board.user.service.ts
@@ -20,6 +20,10 @@ export default class GetBoardUserService implements GetBoardUserServiceInterface
 		return this.boardUserRepository.getAllBoardUsersOfBoard(boardId);
 	}
 
+	getAllOpenBoardsOfUser(userId: string): Promise<BoardUser[]> {
+		return this.boardUserRepository.getAllOpenBoardsIdsOfUser(userId);
+	}
+
 	getBoardResponsible(boardId: string): Promise<BoardUser> {
 		return this.boardUserRepository.getBoardResponsible(boardId);
 	}

--- a/backend/src/modules/boards/repositories/board.repository.ts
+++ b/backend/src/modules/boards/repositories/board.repository.ts
@@ -84,7 +84,11 @@ export class BoardRepository
 		const selectDividedBoards =
 			'-__v -createdAt -slackEnable -slackChannelId -submitedByUser -submitedAt -columns.id -columns._id -columns.cards.text -columns.cards.createdBy -columns.cards.items.text -columns.cards.items.createdBy -columns.cards.createdAt -columns.cards.items.createdAt -columns.cards._id -columns.cards.id -columns.cards.items._id -columns.cards.items.id -columns.cards.createdByTeam -columns.cards.items.createdByTeam -columns.cards.items.votes -columns.cards.items.comments -columns.cards.votes -columns.cards.comments';
 		const boardDataToPopulate: PopulateOptions[] = [
-			{ path: 'createdBy', select: 'firstName lastName' },
+			{
+				path: 'createdBy',
+				select: 'firstName lastName isDeleted',
+				match: { isDeleted: { $in: [true, false] } }
+			},
 			{
 				path: 'team',
 				select: 'name users _id',
@@ -93,7 +97,8 @@ export class BoardRepository
 					select: 'user role',
 					populate: {
 						path: 'user',
-						select: '_id firstName lastName joinedAt'
+						select: '_id firstName lastName joinedAt isDeleted',
+						match: { isDeleted: { $in: [true, false] } }
 					}
 				}
 			},
@@ -107,7 +112,8 @@ export class BoardRepository
 						populate: {
 							path: 'user',
 							model: 'User',
-							select: 'firstName email lastName'
+							select: 'firstName email lastName isDeleted',
+							match: { isDeleted: { $in: [true, false] } }
 						}
 					}
 				]
@@ -117,7 +123,8 @@ export class BoardRepository
 				select: 'user role -board',
 				populate: {
 					path: 'user',
-					select: '_id firstName email lastName isAnonymous'
+					select: '_id firstName email lastName isAnonymous isDeleted',
+					match: { isDeleted: { $in: [true, false] } }
 				}
 			}
 		];

--- a/backend/src/modules/boards/utils/populate-board.ts
+++ b/backend/src/modules/boards/utils/populate-board.ts
@@ -49,7 +49,11 @@ export const GetBoardDataPopulate: PopulateOptions[] = [
 	{
 		path: 'users',
 		select: 'user role -board votesCount',
-		populate: { path: 'user', select: 'firstName email lastName _id isAnonymous' }
+		populate: {
+			path: 'user',
+			select: 'firstName email lastName _id isAnonymous isDeleted',
+			match: { isDeleted: { $in: [true, false] } }
+		}
 	},
 	{
 		path: 'team',
@@ -57,50 +61,64 @@ export const GetBoardDataPopulate: PopulateOptions[] = [
 		populate: {
 			path: 'users',
 			select: 'user role -_id',
-			populate: { path: 'user', select: 'firstName lastName email' }
+			populate: {
+				path: 'user',
+				select: 'firstName lastName email isDeleted',
+				match: { isDeleted: { $in: [true, false] } }
+			}
 		}
 	},
 	{
 		path: 'columns.cards.createdBy',
-		select: '_id firstName lastName'
+		select: '_id firstName lastName isDeleted',
+		match: { isDeleted: { $in: [true, false] } }
 	},
 	{
 		path: 'columns.cards.comments.createdBy',
-		select: '_id  firstName lastName'
+		select: '_id  firstName lastName isDeleted',
+		match: { isDeleted: { $in: [true, false] } }
 	},
 	{
 		path: 'columns.cards.items.createdBy',
-		select: '_id firstName lastName'
+		select: '_id firstName lastName isDeleted',
+		match: { isDeleted: { $in: [true, false] } }
 	},
 	{
 		path: 'columns.cards.items.comments.createdBy',
-		select: '_id firstName lastName'
+		select: '_id firstName lastName isDeleted',
+		match: { isDeleted: { $in: [true, false] } }
 	},
 	{
 		path: 'createdBy',
-		select: '_id firstName lastName'
+		select: '_id firstName lastName isDeleted',
+		match: { isDeleted: { $in: [true, false] } }
 	},
 	{
 		path: 'dividedBoards',
-		select: 'title _id submitedAt'
+		select: 'title _id submitedAt isDeleted',
+		match: { isDeleted: { $in: [true, false] } }
 	}
 ];
 
 export const GetCardFromBoardPopulate: PopulateOptions[] = [
 	{
 		path: 'columns.cards.createdBy',
-		select: '_id firstName lastName'
+		select: '_id firstName lastName isDeleted',
+		match: { isDeleted: { $in: [true, false] } }
 	},
 	{
 		path: 'columns.cards.comments.createdBy',
-		select: '_id  firstName lastName'
+		select: '_id  firstName lastName isDeleted',
+		match: { isDeleted: { $in: [true, false] } }
 	},
 	{
 		path: 'columns.cards.items.createdBy',
-		select: '_id firstName lastName'
+		select: '_id firstName lastName isDeleted',
+		match: { isDeleted: { $in: [true, false] } }
 	},
 	{
 		path: 'columns.cards.items.comments.createdBy',
-		select: '_id firstName lastName'
+		select: '_id firstName lastName isDeleted',
+		match: { isDeleted: { $in: [true, false] } }
 	}
 ];

--- a/backend/src/modules/users/applications/delete-user.use-case.spec.ts
+++ b/backend/src/modules/users/applications/delete-user.use-case.spec.ts
@@ -10,6 +10,8 @@ import { DeleteFailedException } from 'src/libs/exceptions/deleteFailedBadReques
 import { DELETE_TEAM_USER_SERVICE, GET_TEAM_USER_SERVICE } from 'src/modules/teamUsers/constants';
 import { USER_REPOSITORY } from 'src/modules/users/constants';
 import { DeleteUserUseCase } from 'src/modules/users/applications/delete-user.use-case';
+import { DELETE_BOARD_USER_SERVICE } from 'src/modules/boardUsers/constants';
+import { DeleteBoardUserServiceInterface } from 'src/modules/boardUsers/interfaces/services/delete.board.user.service.interface';
 
 const userId = faker.datatype.uuid();
 const userDeleted = UserFactory.create({ _id: userId });
@@ -36,6 +38,10 @@ describe('DeleteUserUseCase', () => {
 				{
 					provide: GET_TEAM_USER_SERVICE,
 					useValue: createMock<GetTeamUserServiceInterface>()
+				},
+				{
+					provide: DELETE_BOARD_USER_SERVICE,
+					useValue: createMock<DeleteBoardUserServiceInterface>()
 				}
 			]
 		}).compile();

--- a/backend/src/modules/users/applications/soft-delete-user.use-case.spec.ts
+++ b/backend/src/modules/users/applications/soft-delete-user.use-case.spec.ts
@@ -1,0 +1,299 @@
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { UseCase } from 'src/libs/interfaces/use-case.interface';
+import { UserRepositoryInterface } from '../repository/user.repository.interface';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeleteTeamUserServiceInterface } from 'src/modules/teamUsers/interfaces/services/delete.team.user.service.interface';
+import { GetTeamUserServiceInterface } from 'src/modules/teamUsers/interfaces/services/get.team.user.service.interface';
+import faker from '@faker-js/faker';
+import { DELETE_TEAM_USER_SERVICE, GET_TEAM_USER_SERVICE } from 'src/modules/teamUsers/constants';
+import { USER_REPOSITORY } from 'src/modules/users/constants';
+import { DeleteUserUseCase } from 'src/modules/users/applications/delete-user.use-case';
+import { userRepository as userRepositoryProvider } from '../users.providers';
+import CreateUserService from '../services/create.user.service';
+import { CreateUserServiceInterface } from '../interfaces/services/create.user.service.interface';
+import User, { UserSchema } from '../entities/user.schema';
+import * as mongoose from 'mongoose';
+import { SoftDeletePlugin } from 'src/infrastructure/database/plugins/soft-delete.plugin';
+import { getModelToken } from '@nestjs/mongoose';
+import { DELETE_BOARD_USER_SERVICE } from 'src/modules/boardUsers/constants';
+import { UserFactory } from 'src/libs/test-utils/mocks/factories/user-factory';
+import { DeleteBoardUserServiceInterface } from 'src/modules/boardUsers/interfaces/services/delete.board.user.service.interface';
+import { DeleteFailedException } from 'src/libs/exceptions/deleteFailedBadRequestException';
+
+jest.mock('mongoose', () => {
+	const actual = jest.requireActual('mongoose');
+
+	const newObj = {
+		...actual,
+		connect: () => newObj
+	};
+
+	return newObj;
+});
+
+const userId = faker.datatype.uuid();
+const userDeleted = UserFactory.create({ _id: userId });
+const teamsOfUser = faker.datatype.number();
+
+class UsersFindResult extends Array {
+	toArray(cb: CallableFunction) {
+		return cb(null, this);
+	}
+}
+
+class UsersRepositoryHelper {
+	private _users = new Map<string, User>();
+	create(user: User) {
+		this._users.set(user._id.toString(), user);
+	}
+	remove(id: string) {
+		this._users.delete(id);
+	}
+	usersArray() {
+		return Array.from(this._users.values());
+	}
+	delete(filter) {
+		const { _id } = filter;
+
+		this._users.delete(_id.toString());
+	}
+	find(filter) {
+		let users = UsersFindResult.from(this._users.values());
+
+		if ('isDeleted' in filter) {
+			users = users.filter(
+				(u) => (filter.isDeleted.$ne && !u.isDeleted) || (!filter.isDeleted.$ne && u.isDeleted)
+			);
+		}
+
+		if ('_id' in filter) {
+			if ('$in' in filter._id) {
+				const filterStringIds = filter._id.$in.map((s) => s.toString());
+				users = users.filter((u) => filterStringIds.includes(u._id.toString()));
+			} else {
+				users = users.filter((u) => u._id.toString() === filter._id.toString());
+			}
+		}
+
+		return users;
+	}
+	updateOne(filter, updates) {
+		const user = this.find(filter)[0];
+		for (const [key, value] of Object.entries(updates.$set)) {
+			if (key in user) {
+				Reflect.set(user, key, value);
+			}
+		}
+
+		return user;
+	}
+	updateMany(filter, updates) {
+		const users = this.find(filter);
+		for (const user of users) {
+			for (const [key, value] of Object.entries(updates.$set)) {
+				if (key in user) {
+					Reflect.set(user, key, value);
+				}
+			}
+		}
+
+		return users;
+	}
+	deleteOne(filter) {
+		const user = this.find(filter)[0];
+
+		if (user) {
+			this._users.delete(user._id);
+		}
+	}
+	deleteMany(filter) {
+		const users = this.find(filter);
+		for (const user of users) {
+			this._users.delete(user._id.toString());
+		}
+	}
+}
+
+const usersRepositoryHelper = new UsersRepositoryHelper();
+describe('DeleteUserUseCase', () => {
+	const collectionNative = (mongoose as any).__driver.Collection;
+	const collectionProto = collectionNative.prototype;
+
+	let createUserService: CreateUserServiceInterface;
+	let userRepository: UserRepositoryInterface;
+	let deleteUser: UseCase<string, boolean>;
+	let getTeamUserServiceMock: DeepMocked<GetTeamUserServiceInterface>;
+	let deleteTeamUserServiceMock: DeepMocked<DeleteTeamUserServiceInterface>;
+	let deleteBoardUserServiceMock: DeepMocked<DeleteBoardUserServiceInterface>;
+
+	beforeAll(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				{
+					provide: 'DATABASE_CONNECTION',
+					useFactory: async (): Promise<typeof mongoose> => await mongoose.connect('')
+				},
+				{
+					provide: getModelToken(User.name),
+					useFactory: (connection: mongoose.Connection) => {
+						const schema = UserSchema;
+						schema.plugin(SoftDeletePlugin);
+
+						return connection.model('User', schema);
+					},
+					inject: ['DATABASE_CONNECTION']
+				},
+				DeleteUserUseCase,
+				CreateUserService,
+				userRepositoryProvider,
+				{
+					provide: DELETE_TEAM_USER_SERVICE,
+					useValue: createMock<DeleteTeamUserServiceInterface>()
+				},
+				{
+					provide: GET_TEAM_USER_SERVICE,
+					useValue: createMock<GetTeamUserServiceInterface>()
+				},
+				{
+					provide: DELETE_BOARD_USER_SERVICE,
+					useValue: createMock<DeleteBoardUserServiceInterface>()
+				}
+			]
+		}).compile();
+
+		createUserService = module.get(CreateUserService);
+		deleteUser = module.get(DeleteUserUseCase);
+		userRepository = module.get(USER_REPOSITORY);
+		getTeamUserServiceMock = module.get(GET_TEAM_USER_SERVICE);
+		deleteTeamUserServiceMock = module.get(DELETE_TEAM_USER_SERVICE);
+		deleteBoardUserServiceMock = module.get(DELETE_BOARD_USER_SERVICE);
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.resetAllMocks();
+	});
+
+	it('should be defined', () => {
+		expect(deleteUser).toBeDefined();
+	});
+
+	describe('execute', () => {
+		beforeAll(() => {
+			userRepository.startTransaction = jest.fn();
+			userRepository.commitTransaction = jest.fn();
+			userRepository.endSession = jest.fn();
+			userRepository.abortTransaction = jest.fn();
+		});
+
+		it('should return true', async () => {
+			const spyDelete = jest.spyOn(userRepository, 'deleteUser').mockResolvedValueOnce(userDeleted);
+			getTeamUserServiceMock.countTeamsOfUser.mockResolvedValue(teamsOfUser);
+			deleteTeamUserServiceMock.deleteTeamUsersOfUser.mockResolvedValue(teamsOfUser);
+			deleteBoardUserServiceMock.deleteBoardUserFromOpenBoards.mockResolvedValueOnce({});
+			await expect(deleteUser.execute(userId)).resolves.toEqual(true);
+			spyDelete.mockRestore();
+		});
+
+		it('should throw error when user is not deleted', async () => {
+			await expect(deleteUser.execute(userId)).rejects.toThrowError(DeleteFailedException);
+		});
+
+		it('should throw error when commitTransaction fails', async () => {
+			getTeamUserServiceMock.countTeamsOfUser.mockResolvedValue(teamsOfUser);
+			deleteTeamUserServiceMock.deleteTeamUsersOfUser.mockResolvedValue(teamsOfUser);
+			const spyDelete = jest.spyOn(userRepository, 'deleteUser').mockResolvedValueOnce(userDeleted);
+			userRepository.commitTransaction = jest.fn().mockRejectedValueOnce(new Error());
+			await expect(deleteUser.execute(userId)).rejects.toThrowError(DeleteFailedException);
+			spyDelete.mockRestore();
+		});
+	});
+	describe('integration', () => {
+		it('should create and soft delete the user', async () => {
+			//This will test various aspects of the softdelete plugin
+			jest
+				.spyOn(collectionProto, 'insertOne')
+				.mockImplementation((doc, _options, callback: CallableFunction) => {
+					usersRepositoryHelper.create(doc as User);
+					callback(null, doc);
+				});
+			const email = faker.internet.email();
+			const email2 = faker.internet.email();
+			const userTest = await createUserService.create({
+				email,
+				firstName: 'test',
+				lastName: 'test',
+				password: 'test',
+				providerAccountCreatedAt: new Date()
+			});
+			const userTest2 = await createUserService.create({
+				email: email2,
+				firstName: 'test2',
+				lastName: 'test2',
+				password: 'test2',
+				providerAccountCreatedAt: new Date()
+			});
+			jest
+				.spyOn(collectionProto, 'find')
+				.mockImplementation((filter, _options, callback: CallableFunction) => {
+					expect(filter).toHaveProperty('isDeleted');
+					callback(null, usersRepositoryHelper.find(filter));
+				});
+			let users: Array<User> = await userRepository.getAllSignedUpUsers();
+			expect(
+				users.filter(
+					(u) =>
+						u._id.toString() === userTest._id.toString() ||
+						u._id.toString() === userTest2._id.toString()
+				)
+			).toHaveLength(2);
+
+			jest
+				.spyOn(collectionProto, 'findOneAndDelete')
+				.mockImplementationOnce((filter, _options, callback: CallableFunction) => {
+					usersRepositoryHelper.deleteOne(filter);
+					callback(null);
+				});
+			jest
+				.spyOn(collectionProto, 'updateOne')
+				.mockImplementation((filter, update, _options, callback: CallableFunction) => {
+					const u = usersRepositoryHelper.updateOne(filter, update);
+					callback(null, u);
+				});
+			jest
+				.spyOn(collectionProto, 'findOne')
+				.mockImplementation((filter, _options, callback: CallableFunction) => {
+					const u = usersRepositoryHelper.find(filter);
+					callback(null, u[0]);
+				});
+			await userRepository.deleteUser(userTest._id.toString(), true);
+			users = await userRepository.getAllSignedUpUsers();
+			expect(users.find((u) => u._id.toString() === userTest._id.toString())).toBeUndefined();
+			expect(users.find((u) => u._id.toString() === userTest2._id.toString())).toBeDefined();
+
+			users = await userRepository.findDeleted();
+			expect(users).toHaveLength(1);
+			jest
+				.spyOn(collectionProto, 'updateMany')
+				.mockImplementation((filter, update, _options, callback: CallableFunction) => {
+					const users = usersRepositoryHelper.updateMany(filter, update);
+					callback(null, { modifiedCount: users.length });
+				});
+			expect(await userRepository.restore({ _id: userTest._id.toString() })).toHaveProperty(
+				'modifiedCount',
+				1
+			);
+			expect(await userRepository.findAll()).toHaveLength(2);
+			jest
+				.spyOn(collectionProto, 'deleteMany')
+				.mockImplementation((filter, options, callback: CallableFunction) => {
+					usersRepositoryHelper.deleteMany(filter);
+					callback(null);
+				});
+			await userRepository.forceDelete({
+				_id: { $in: [userTest._id.toString(), userTest2._id.toString()] }
+			});
+			expect(await userRepository.findAll()).toHaveLength(0);
+		});
+	});
+});

--- a/backend/src/modules/users/repository/user.repository.interface.ts
+++ b/backend/src/modules/users/repository/user.repository.interface.ts
@@ -1,5 +1,8 @@
 import { BaseInterfaceRepository } from 'src/libs/repositories/interfaces/base.repository.interface';
 import User from '../entities/user.schema';
+import { TSoftDelete } from 'src/infrastructure/database/plugins/soft-delete.plugin';
+import { FilterQuery, QueryOptions } from 'mongoose';
+import { DeleteResult } from 'mongodb';
 
 export interface UserRepositoryInterface extends BaseInterfaceRepository<User> {
 	getById(userId: string): Promise<User>;
@@ -12,4 +15,8 @@ export interface UserRepositoryInterface extends BaseInterfaceRepository<User> {
 	getAllSignedUpUsers(): Promise<User[]>;
 	getSignedUpUsersCount(): Promise<number>;
 	updateUserUpdatedAt(user: string): Promise<User>;
+	findDeleted(): Promise<Array<TSoftDelete<User>>>;
+	forceDelete(query: FilterQuery<User>, options?: QueryOptions<User>): Promise<DeleteResult>;
+	restore(query: FilterQuery<User>): Promise<Array<User>>;
+	softDelete(query: FilterQuery<User>, options?: QueryOptions<User>): Promise<Array<User>>;
 }

--- a/backend/src/modules/users/repository/user.repository.ts
+++ b/backend/src/modules/users/repository/user.repository.ts
@@ -1,16 +1,18 @@
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { FilterQuery, Model } from 'mongoose';
+import { FilterQuery, QueryOptions } from 'mongoose';
 import { MongoGenericRepository } from 'src/libs/repositories/mongo/mongo-generic.repository';
 import User from 'src/modules/users/entities/user.schema';
 import { UserRepositoryInterface } from './user.repository.interface';
+import { SoftDeleteModel } from 'src/infrastructure/database/plugins/soft-delete.plugin';
+import { DeleteResult } from 'mongodb';
 
 @Injectable()
 export class UserRepository
 	extends MongoGenericRepository<User>
 	implements UserRepositoryInterface
 {
-	constructor(@InjectModel(User.name) private readonly model: Model<User>) {
+	constructor(@InjectModel(User.name) private readonly model: SoftDeleteModel<User>) {
 		super(model);
 	}
 
@@ -99,5 +101,20 @@ export class UserRepository
 
 	updateUserUpdatedAt(user: string) {
 		return this.findOneByFieldAndUpdate({ _id: user }, { $set: { updatedAt: new Date() } });
+	}
+
+	findDeleted() {
+		return this.model.findDeleted();
+	}
+
+	forceDelete(query: FilterQuery<User>, options?: QueryOptions<User>): Promise<DeleteResult> {
+		return this.model.forceDelete(query, options);
+	}
+	restore(query: FilterQuery<User>): Promise<Array<User>> {
+		return this.model.restore(query);
+	}
+
+	softDelete(query: FilterQuery<User>, options?: QueryOptions<User>): Promise<Array<User>> {
+		return this.model.softDelete(query, options);
 	}
 }

--- a/backend/src/modules/users/users.module.ts
+++ b/backend/src/modules/users/users.module.ts
@@ -19,12 +19,14 @@ import {
 	userRepository
 } from './users.providers';
 import TeamUsersModule from '../teamUsers/teamusers.module';
+import BoardUsersModule from '../boardUsers/boardusers.module';
 
 @Module({
 	imports: [
 		mongooseUserModule,
 		TeamsModule,
 		TeamUsersModule,
+		BoardUsersModule,
 		mongooseResetModule,
 		mongooseTeamUserModule,
 		forwardRef(() => AuthModule)


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to:
- #945 


## Proposed Changes

  - Add Soft-delete mongoose plugin (can be used for other schemas)
  - Add soft-delete plugin to User Schema
  - Remove user from not submitted boards only, to maintain history
  - All the query's consider `isDeleted` field to not present data when it's `true`, unless the query specifies their presentation
  - Delete-user-case now also deletes the user from the open boards
  

<!--
Mention people who discussed this issue previously
@someone
-->

@nunocaseiro 

This pull request closes #945
