### PR TITLE
feat:  automatically add users to team during synchronization

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -88,3 +88,6 @@ AZURE_STORAGE_CONNECTION_STRING="UseDevelopmentStorage=true;"
 
 # name of the team to automatically add the users during AD Synchronization
 AD_SYNCHRONIZATION_AUTO_ADD_USER_TEAM_NAME="xgeeks"
+
+# Domain to filter app users out of deletion
+AD_SYNCHRONIZATION_EMAIL_DOMAIN="xgeeks.com"

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -85,3 +85,6 @@ AZURE_TENANT_ID=
 
 #azure storage connection string
 AZURE_STORAGE_CONNECTION_STRING="UseDevelopmentStorage=true;"
+
+# name of the team to automatically add the users during AD Synchronization
+AD_SYNCHRONIZATION_AUTO_ADD_USER_TEAM_NAME="xgeeks"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3119,11 +3119,6 @@
       "integrity": "sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==",
       "dev": true
     },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w=="
-    },
     "node_modules/@types/mjml": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/@types/mjml/-/mjml-4.7.4.tgz",
@@ -10120,6 +10115,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
       "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
+      "license": "MIT",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "6.0.0"
@@ -10134,16 +10130,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/lru-memoizer": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
-      "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
-      "license": "MIT",
-      "dependencies": {
-        "lodash.clonedeep": "^4.5.0",
-        "lru-cache": "6.0.0"
       }
     },
     "node_modules/lru-memoizer/node_modules/yallist": {

--- a/backend/src/infrastructure/config/config.module.ts
+++ b/backend/src/infrastructure/config/config.module.ts
@@ -81,7 +81,8 @@ import { configuration } from './configuration';
 				REDIS_PASSWORD: Joi.string(),
 				REDIS_HOST: Joi.string().required(),
 				REDIS_PORT: Joi.number().required(),
-				AZURE_STORAGE_CONNECTION_STRING: Joi.string().required()
+				AZURE_STORAGE_CONNECTION_STRING: Joi.string().required(),
+				AD_SYNCHRONIZATION_AUTO_ADD_USER_TEAM_NAME: Joi.string().default('')
 			})
 		})
 	],

--- a/backend/src/infrastructure/config/config.module.ts
+++ b/backend/src/infrastructure/config/config.module.ts
@@ -82,7 +82,8 @@ import { configuration } from './configuration';
 				REDIS_HOST: Joi.string().required(),
 				REDIS_PORT: Joi.number().required(),
 				AZURE_STORAGE_CONNECTION_STRING: Joi.string().required(),
-				AD_SYNCHRONIZATION_AUTO_ADD_USER_TEAM_NAME: Joi.string().default('')
+				AD_SYNCHRONIZATION_AUTO_ADD_USER_TEAM_NAME: Joi.string().default(''),
+				AD_SYNCHRONIZATION_EMAIL_DOMAIN: Joi.string().default('')
 			})
 		})
 	],

--- a/backend/src/modules/azure/azure.module.ts
+++ b/backend/src/modules/azure/azure.module.ts
@@ -11,9 +11,19 @@ import {
 } from './azure.providers';
 import AzureController from './controller/azure.controller';
 import { JwtRegister } from 'src/infrastructure/config/jwt.register';
+import TeamsModule from '../teams/teams.module';
+import TeamUsersModule from '../teamUsers/teamusers.module';
 
 @Module({
-	imports: [UsersModule, AuthModule, CommunicationModule, StorageModule, JwtRegister],
+	imports: [
+		UsersModule,
+		AuthModule,
+		CommunicationModule,
+		StorageModule,
+		JwtRegister,
+		TeamsModule,
+		TeamUsersModule
+	],
 	controllers: [AzureController],
 	providers: [
 		authAzureService,

--- a/backend/src/modules/azure/schedules/synchronize-ad-users.cron.azure.use-case.spec.ts
+++ b/backend/src/modules/azure/schedules/synchronize-ad-users.cron.azure.use-case.spec.ts
@@ -83,6 +83,9 @@ describe('SynchronizeAdUsersCronUseCase', () => {
 								case 'AD_SYNCHRONIZATION_AUTO_ADD_USER_TEAM_NAME':
 									return 'xgeeks';
 
+								case 'AD_SYNCHRONIZATION_EMAIL_DOMAIN':
+									return 'xgeeks.com';
+
 								default:
 									return 'UNKNOWN';
 							}

--- a/backend/src/modules/teamUsers/teamusers.module.ts
+++ b/backend/src/modules/teamUsers/teamusers.module.ts
@@ -26,7 +26,8 @@ import TeamUsersController from './controller/teamUser.controller';
 		createTeamUsersUseCase,
 		updateTeamUserUseCase,
 		addAndRemoveTeamUsersUseCase,
-		deleteTeamUserUseCase
+		deleteTeamUserUseCase,
+		addAndRemoveTeamUsersUseCase
 	],
 	controllers: [TeamUsersController],
 	exports: [
@@ -38,7 +39,8 @@ import TeamUsersController from './controller/teamUser.controller';
 		createTeamUsersUseCase,
 		updateTeamUserUseCase,
 		addAndRemoveTeamUsersUseCase,
-		deleteTeamUserUseCase
+		deleteTeamUserUseCase,
+		addAndRemoveTeamUsersUseCase
 	]
 })
 export default class TeamUsersModule {}

--- a/backend/src/modules/teams/applications/get-team-by-name.use-case.spec.ts
+++ b/backend/src/modules/teams/applications/get-team-by-name.use-case.spec.ts
@@ -1,0 +1,45 @@
+import Team from 'src/modules/teams/entities/team.schema';
+import { Test, TestingModule } from '@nestjs/testing';
+import { DeepMocked, createMock } from '@golevelup/ts-jest';
+import { GET_TEAM_SERVICE } from 'src/modules/teams/constants';
+import { UseCase } from 'src/libs/interfaces/use-case.interface';
+import { GetTeamServiceInterface } from '../interfaces/services/get.team.service.interface';
+import { GetTeamByNameUseCase } from './get-team-by-name.use-case';
+import { teams } from './get-team-mocked-results';
+
+describe('GetTeamByNameUseCase', () => {
+	let getTeamByName: UseCase<string, Team>;
+	let getTeamService: DeepMocked<GetTeamServiceInterface>;
+
+	beforeAll(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				GetTeamByNameUseCase,
+				{
+					provide: GET_TEAM_SERVICE,
+					useValue: createMock<GetTeamServiceInterface>()
+				}
+			]
+		}).compile();
+
+		getTeamByName = module.get(GetTeamByNameUseCase);
+		getTeamService = module.get(GET_TEAM_SERVICE);
+	});
+
+	beforeEach(() => {
+		jest.restoreAllMocks();
+		jest.clearAllMocks();
+
+		getTeamService.getTeamByName.mockResolvedValue(teams[0]);
+	});
+
+	it('should be defined', () => {
+		expect(getTeamByName).toBeDefined();
+	});
+	describe('execute', () => {
+		it('should return a team', async () => {
+			const result = await getTeamByName.execute(teams[0].name);
+			expect(result).toBe(teams[0]);
+		});
+	});
+});

--- a/backend/src/modules/teams/applications/get-team-by-name.use-case.ts
+++ b/backend/src/modules/teams/applications/get-team-by-name.use-case.ts
@@ -1,0 +1,17 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { UseCase } from 'src/libs/interfaces/use-case.interface';
+import Team from '../entities/team.schema';
+import { GET_TEAM_SERVICE } from '../constants';
+import { GetTeamServiceInterface } from '../interfaces/services/get.team.service.interface';
+
+@Injectable()
+export class GetTeamByNameUseCase implements UseCase<string, Team> {
+	constructor(
+		@Inject(GET_TEAM_SERVICE)
+		private readonly getTeamService: GetTeamServiceInterface
+	) {}
+
+	execute(teamName: string) {
+		return this.getTeamService.getTeamByName(teamName);
+	}
+}

--- a/backend/src/modules/teams/constants.ts
+++ b/backend/src/modules/teams/constants.ts
@@ -16,6 +16,8 @@ export const GET_TEAM_USE_CASE = 'GetTeamUseCase';
 
 export const GET_TEAMS_OF_USER_USE_CASE = 'GetTeamsOfUserUseCase';
 
+export const GET_TEAM_BY_NAME_USE_CASE = 'GetTeamByNameUseCase';
+
 /* REPOSITORY */
 
 export const TEAM_REPOSITORY = 'TeamRepository';

--- a/backend/src/modules/teams/interfaces/repositories/team.repository.interface.ts
+++ b/backend/src/modules/teams/interfaces/repositories/team.repository.interface.ts
@@ -5,4 +5,5 @@ export interface TeamRepositoryInterface extends BaseInterfaceRepository<Team> {
 	getTeam(teamId: string): Promise<Team>;
 	getTeamsWithUsers(teamIds: string[]): Promise<Team[]>;
 	getAllTeams(): Promise<Team[]>;
+	getTeamByName(teamName: string): Promise<Team>;
 }

--- a/backend/src/modules/teams/interfaces/services/get.team.service.interface.ts
+++ b/backend/src/modules/teams/interfaces/services/get.team.service.interface.ts
@@ -5,4 +5,5 @@ export interface GetTeamServiceInterface {
 	getTeam(teamId: string, teamQueryParams?: TeamQueryParams): Promise<Team | null>;
 	getTeamsOfUser(userId: string): Promise<Team[]>;
 	countAllTeams(): Promise<number>;
+	getTeamByName(teamName: string): Promise<Team | null>;
 }

--- a/backend/src/modules/teams/providers.ts
+++ b/backend/src/modules/teams/providers.ts
@@ -1,6 +1,7 @@
 import { CreateTeamUseCase } from './applications/create-team.use-case';
 import { DeleteTeamUseCase } from './applications/delete-team.use-case';
 import { GetAllTeamsUseCase } from './applications/get-all-teams.use-case';
+import { GetTeamByNameUseCase } from './applications/get-team-by-name.use-case';
 import { GetTeamUseCase } from './applications/get-team.use-case';
 import { GetTeamsOfUserUseCase } from './applications/get-teams-of-user.use-case';
 import { GetTeamsUserIsNotMemberUseCase } from './applications/get-teams-user-is-not-member.use-case';
@@ -10,6 +11,7 @@ import {
 	GET_ALL_TEAMS_USE_CASE,
 	GET_TEAMS_OF_USER_USE_CASE,
 	GET_TEAMS_USER_IS_NOT_MEMBER_USE_CASE,
+	GET_TEAM_BY_NAME_USE_CASE,
 	GET_TEAM_SERVICE,
 	GET_TEAM_USE_CASE,
 	TEAM_REPOSITORY
@@ -54,6 +56,11 @@ export const getTeamsOfUserUseCase = {
 export const deleteTeamUseCase = {
 	provide: DELETE_TEAM_USE_CASE,
 	useClass: DeleteTeamUseCase
+};
+
+export const getTeamByNameUseCase = {
+	provide: GET_TEAM_BY_NAME_USE_CASE,
+	useClass: GetTeamByNameUseCase
 };
 
 /* REPOSITORY */

--- a/backend/src/modules/teams/repositories/team.repository.ts
+++ b/backend/src/modules/teams/repositories/team.repository.ts
@@ -54,4 +54,8 @@ export class TeamRepository
 			}
 		]);
 	}
+
+	getTeamByName(teamName: string): Promise<Team> {
+		return this.findOneByField({ name: teamName });
+	}
 }

--- a/backend/src/modules/teams/services/get.team.service.spec.ts
+++ b/backend/src/modules/teams/services/get.team.service.spec.ts
@@ -105,4 +105,18 @@ describe('GetTeamService', () => {
 			expect(result).toHaveLength(expectedResult.length);
 		});
 	});
+	describe('getTeamByName', () => {
+		it('should return team with users sorted by name', async () => {
+			teamRepositoryMock.getTeamByName.mockResolvedValue(team1);
+
+			await expect(teamService.getTeamByName(team1.name)).resolves.toEqual(team1);
+		});
+
+		it('should throw Not Found Exception when team not found', async () => {
+			teamRepositoryMock.getTeamByName.mockResolvedValue(null);
+
+			await expect(teamService.getTeamByName('')).rejects.toThrow(NotFoundException);
+			expect(teamRepositoryMock.getTeamByName).toHaveBeenCalled();
+		});
+	});
 });

--- a/backend/src/modules/teams/services/get.team.service.ts
+++ b/backend/src/modules/teams/services/get.team.service.ts
@@ -54,4 +54,14 @@ export default class GetTeamService implements GetTeamServiceInterface {
 
 		return teamsResult.sort((a, b) => (a.name < b.name ? -1 : 1));
 	}
+
+	async getTeamByName(teamName: string) {
+		const team = await this.teamRepository.getTeamByName(teamName);
+
+		if (!team) {
+			throw new NotFoundException(TEAM_NOT_FOUND);
+		}
+
+		return team;
+	}
 }

--- a/backend/src/modules/teams/teams.module.ts
+++ b/backend/src/modules/teams/teams.module.ts
@@ -6,6 +6,7 @@ import {
 	createTeamUseCase,
 	deleteTeamUseCase,
 	getAllTeamsUseCase,
+	getTeamByNameUseCase,
 	getTeamService,
 	getTeamUseCase,
 	getTeamsOfUserUseCase,
@@ -24,9 +25,10 @@ import TeamUsersModule from 'src/modules/teamUsers/teamusers.module';
 		getTeamsOfUserUseCase,
 		deleteTeamUseCase,
 		getTeamService,
-		teamRepository
+		teamRepository,
+		getTeamByNameUseCase
 	],
 	controllers: [TeamsController],
-	exports: [getTeamService]
+	exports: [getTeamService, getTeamByNameUseCase]
 })
 export default class TeamsModule {}

--- a/backend/src/modules/users/interfaces/services/create.user.service.interface.ts
+++ b/backend/src/modules/users/interfaces/services/create.user.service.interface.ts
@@ -5,5 +5,6 @@ import User from '../../entities/user.schema';
 
 export interface CreateUserServiceInterface {
 	create(user: CreateUserDto | CreateUserAzureDto): Promise<User>;
+	createMany(usersData: Array<CreateUserDto | CreateUserAzureDto>): Promise<Array<User>>;
 	createGuest(guestUserData: CreateGuestUserDto): Promise<User>;
 }

--- a/backend/src/modules/users/services/create.user.service.spec.ts
+++ b/backend/src/modules/users/services/create.user.service.spec.ts
@@ -81,4 +81,15 @@ describe('CreateUserService', () => {
 			);
 		});
 	});
+	describe('createMany', () => {
+		it('should create many users', async () => {
+			userRepositoryMock.insertMany.mockResolvedValue([createdUser]);
+			await expect(userService.createMany([createUserDto])).resolves.toEqual([createdUser]);
+		});
+
+		it('should throw error when users are not created', async () => {
+			userRepositoryMock.insertMany.mockResolvedValue(null);
+			await expect(userService.createMany([createUserDto])).rejects.toThrow(BadRequestException);
+		});
+	});
 });

--- a/backend/src/modules/users/services/create.user.service.ts
+++ b/backend/src/modules/users/services/create.user.service.ts
@@ -31,6 +31,27 @@ export default class CreateUserService implements CreateUserServiceInterface {
 		return createdUser;
 	}
 
+	async createMany(usersData: Array<CreateUserDto>): Promise<Array<User>> {
+		const now = new Date();
+		const users: Array<User> = usersData.map((user) => {
+			return {
+				...user,
+				strategy: '',
+				isSAdmin: false,
+				isDeleted: false,
+				joinedAt: now,
+				isAnonymous: false
+			};
+		});
+		const createdUsers = await this.userRepository.insertMany(users);
+
+		if (!createdUsers || createdUsers.length === 0) {
+			throw new BadRequestException(CREATE_FAILED);
+		}
+
+		return createdUsers;
+	}
+
 	async createGuest(guestUserData: CreateGuestUserDto) {
 		const { firstName, lastName } = guestUserData;
 


### PR DESCRIPTION
<!--
Add the issue number
-->

Relates to:
- #1601 


## Proposed Changes

  - Automatically add's new users to a team defined in env vars during AD-App users synchronization cron job
  - Changes insertion of users from each one to a user batch

<!--
Mention people who discussed this issue previously
@someone
-->


This pull request closes #1601
